### PR TITLE
Remove backend prefix

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -4,6 +4,5 @@
 terraform {
   backend "gcs" {
     bucket  = "govuk-knowledge-graph-tfstate" # Change this (keep the -tfstate suffix)
-    prefix  = "development"
   }
 }


### PR DESCRIPTION
There's no consensus on how to manage separate dev/prod environments
with terraform, so I'm going to stop pretending to do so.
