### PR TITLE
Create artifact registry for docker from GitHub

### DIFF
--- a/terraform/artifact-repository.tf
+++ b/terraform/artifact-repository.tf
@@ -1,0 +1,25 @@
+# Service account for docker build to be run by GitHub Actions
+# See also: ./workload-identity-fededocker build.tf
+
+resource "google_artifact_registry_repository" "docker" {
+  provider      = google-beta
+  location      = var.location
+  repository_id = "docker"
+  description   = "Docker repository"
+  format        = "DOCKER"
+}
+
+resource "google_service_account" "artifact_registry_docker" {
+  account_id   = "artifact-registry-docker"
+  display_name = "Artifact Registry Service Account for Docker"
+  description  = "Service account for pushing docker images"
+}
+
+resource "google_artifact_registry_repository_iam_member" "member" {
+  provider   = google-beta
+  project    = google_artifact_registry_repository.docker.project
+  location   = google_artifact_registry_repository.docker.location
+  repository = google_artifact_registry_repository.docker.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.artifact_registry_docker.email}"
+}

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -60,7 +60,8 @@ variable "services" {
   default = [
     # List all the services you use here
     "storage.googleapis.com",
-    "iam.googleapis.com"
+    "iam.googleapis.com",
+    "artifactregistry.googleapis.com"
   ]
 }
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,14 @@
+# Service account for terraform to be run by GitHub Actions
+# See also: ./workload-identity-federation.tf
+
+resource "google_service_account" "terraform" {
+  account_id   = "terraform"
+  display_name = "Terraform Service Account"
+  description  = "Service account for applying Terraform from a GitHub Action"
+}
+
+resource "google_project_iam_member" "terraform_iam_project" {
+  project = var.project_id
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.terraform.email}"
+}

--- a/terraform/workload-identity-federation.tf
+++ b/terraform/workload-identity-federation.tf
@@ -22,20 +22,12 @@ resource "google_iam_workload_identity_pool_provider" "main" {
   }
 }
 
-resource "google_service_account" "terraform" {
-  account_id   = "terraform"
-  display_name = "Terraform Service Account"
-  description  = "Service account for applying Terraform from a GitHub Action"
-}
-
 resource "google_service_account_iam_member" "wif-sa" {
-  service_account_id = google_service_account.terraform.name
+  for_each = toset([
+    google_service_account.terraform.name
+    # TODO: google_service_account.artifact_registry_docker.name
+  ])
+  service_account_id = each.key
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/projects/19513753240/locations/global/workloadIdentityPools/github-pool/attribute.repository/alphagov/govuk-knowledge-graph-gcp"
-}
-
-resource "google_project_iam_member" "terraform_iam_project" {
-  project = var.project_id
-  role    = "roles/owner"
-  member  = "serviceAccount:${google_service_account.terraform.email}"
 }


### PR DESCRIPTION
Create a Docker repository in Artifact Registry, for GitHub Actions to
push built images into.

This includes a service account for GitHub Actions to impersonate, but
GitHub can't be given permission to imporsonate that account yet,
because its name isn't known.  A subsequent pull request will grant that
permission, along with a workflow and dockerfile.
