### PR TITLE
Dockerise neo4j browser

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,75 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/**'
+  pull_request:
+    paths:
+      - 'docker/**'
+
+defaults:
+  run:
+    working-directory: docker
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'neo4j-browser'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        workload_identity_provider: 'projects/19513753240/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker eu-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      if: github.event_name == 'pull_request'
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM neo4j:4.4.8-community
+
+# Serve the Neo4j browser and API on port 8080
+RUN sed -i \
+  's/^#dbms\.connector\.http\.listen_address=:7474$/dbms.connector.http.listen_address=:8080/' \
+  /var/lib/neo4j/conf/neo4j.conf
+
+RUN sed -i \
+  's/^#dbms\.connector\.http\.advertised_address=:7474$/dbms.connector.http.advertised_address=:8080/' \
+  /var/lib/neo4j/conf/neo4j.conf
+
+ARG GITHUB_SHA=missing
+ENV GITHUB_SHA=${GITHUB_SHA}
+
+ARG GITHUB_REF=missing
+ENV GITHUB_REF=${GITHUB_REF}


### PR DESCRIPTION
- Allow GitHub to imporsonate a service account that has write access to
  a docker repository in Google Artifact Registry.
- Write a Dockerfile for Neo4j, with the port changed to 8080, for
  Google AppEngine.
- Write a GitHub Actions workflow to build and push an image.
