### PR TITLE
Always build image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,6 @@ jobs:
     # Build the Docker image
     - name: Docker build
       id: build
-      if: github.event_name == 'pull_request'
       run: |
         export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
         echo $TAG


### PR DESCRIPTION
It was previously configured to only build for pull requests, not for
merges.
