### PR TITLE
Fix GCE network and instance schedule

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -94,3 +94,11 @@ resource "google_compute_instance" "neo4j" {
 
   resource_policies = [google_compute_resource_policy.neo4j.self_link]
 }
+
+resource "google_compute_instance_iam_member" "service_agent" {
+  instance_name = google_compute_instance.neo4j.name
+  role          = "roles/compute.instanceAdmin"
+  member        = "serviceAccount:service-${var.project_id}@compute-system.iam.gserviceaccount.com"
+  # 19513753240@cloudservices.gserviceaccount.com
+  # email   = "service-${var.project_id}@compute-system.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
- Provide the default network description
- Grant permissions to the default service agent
