### PR TITLE
Reinstate the instance schedule

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -92,7 +92,7 @@ resource "google_compute_instance" "neo4j" {
     scopes = ["cloud-platform"]
   }
 
-  # resource_policies = [google_compute_resource_policy.neo4j.self_link]
+  resource_policies = [google_compute_resource_policy.neo4j.self_link]
 }
 
 resource "google_compute_instance_iam_member" "service_agent" {


### PR DESCRIPTION
Terraform tries to create the instance before it awards the service
account the permissions that are required.  I temporarily
removed the schedule, then awarded the permissions, and will now
reinstate the schedule.
