### PR TITLE
Use a static external IP address for Neo4j

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -12,6 +12,12 @@ resource "google_compute_network" "default" {
   description = "Default network for the project"
 }
 
+resource "google_compute_address" "neo4j" {
+  name         = "neo4j"
+  purpose      = "GCE_ENDPOINT"
+  network_tier = "STANDARD"
+}
+
 resource "google_compute_firewall" "neo4j" {
   name    = "firewall-neo4j"
   network = google_compute_network.default.name
@@ -83,6 +89,9 @@ resource "google_compute_instance" "neo4j" {
 
   network_interface {
     network = "default"
+    access_config {
+      nat_ip = google_compute_address.neo4j.address
+    }
   }
 
   service_account {


### PR DESCRIPTION
Currently it doesn't have an external IP address.  It is, nevertheless,
possible to ssh into the instance by:

```sh
gcloud compute ssh --zone "europe-west2-a" "neo4j"  --tunnel-through-iap --project "govuk-knowledge-graph"
```

Once it has an external IP address, I can check whether it is accessible
from outside the VPN.
