### PR TITLE
Use standard network tier everywhere by default

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -89,6 +89,7 @@ resource "google_compute_instance" "neo4j" {
   network_interface {
     network = "default"
     access_config {
+      network_tier = "STANDARD"
       nat_ip = google_compute_address.neo4j.address
     }
   }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -115,3 +115,8 @@ resource "google_project_service" "services" {
   disable_on_destroy         = false
 
 }
+
+# Use a cheaper network tier
+resource "google_compute_project_default_network_tier" "default" {
+  network_tier = "STANDARD"
+}


### PR DESCRIPTION
To overcome a conflict between something and something else, which were
using different tiers.
