### PR TITLE
Push main branch to google source repositories

### DIFF
--- a/.github/workflows/source-repositories.yml
+++ b/.github/workflows/source-repositories.yml
@@ -1,0 +1,47 @@
+name: Source Repositories
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  push_to_gcp:
+    name: 'Push to Google Cloud Source Repositories'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        workload_identity_provider: 'projects/19513753240/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'source-repository-github@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    # Configure git to use the gcloud command-line tool as a credential helper
+    - name: Authenticate
+      run: |
+        # Set up git to authenticate
+        # via gcloud command-line tool.
+        git config --global credential.'https://source.developers.google.com'.helper gcloud.sh \
+
+    - name: Add remote
+      run: |
+        git remote add google https://source.developers.google.com/p/govuk-knowledge-graph/r/alphagov/govuk-knowledge-graph-gcp
+
+    - name: Push
+      run: |
+        git push google main:main

--- a/terraform/source-repositories.tf
+++ b/terraform/source-repositories.tf
@@ -1,0 +1,18 @@
+# For GitHub Actions to push the repository to GCP
+
+resource "google_sourcerepo_repository" "alphagov_govuk_knowledge_graph_gcp" {
+  name = "alphagov/govuk-knowledge-graph-gcp"
+}
+
+resource "google_service_account" "source_repositories_github" {
+  account_id   = "source-repositories-github"
+  display_name = "Source Repositories Service Account for GitHub"
+  description  = "Service account for pushing git repositories from GitHub Actions"
+}
+
+resource "google_sourcerepo_repository_iam_member" "member" {
+  project    = google_sourcerepo_repository.alphagov_govuk_knowledge_graph_gcp.project
+  repository = google_sourcerepo_repository.alphagov_govuk_knowledge_graph_gcp.name
+  role       = "roles/writer"
+  member     = "serviceAccount:${google_service_account.source_repositories_github.email}"
+}

--- a/terraform/workload-identity-federation.tf
+++ b/terraform/workload-identity-federation.tf
@@ -25,6 +25,7 @@ resource "google_iam_workload_identity_pool_provider" "main" {
 resource "google_service_account_iam_member" "wif-sa" {
   for_each = toset([
     google_service_account.terraform.name,
+    # google_service_account.source_repositories_github.name,
     google_service_account.artifact_registry_docker.name
   ])
   service_account_id = each.key


### PR DESCRIPTION
GitHub Action to push the main branch to Google Cloud Source Repositories on merge, using Workload Identity Federation (keyless authentication).  This makes the repository accessible to the Google Cloud Project without having to maintain keys.