### PR TITLE
Sync the repo HEAD with a cloud storage bucket

### DIFF
--- a/.github/workflows/rsync.yml
+++ b/.github/workflows/rsync.yml
@@ -1,0 +1,37 @@
+name: Sync to Google Cloud Storage
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  sync_to_gcs:
+    name: 'Synchronise HEAD with a Google Cloud Storage bucket'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        workload_identity_provider: 'projects/19513753240/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'source-repositories-github@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    # Sync everything except for the .git folder, which could get large.
+    - name: Sync
+      run: |
+        gsutil -m rsync -J -r -d -C -x "\.git[$/].*" . gs://govuk-knowledge-graph-repository

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,0 +1,10 @@
+# Bucket for a copy of the current state of the git repository
+resource "google_storage_bucket" "repository" {
+  name          = "${var.project_id}-repository" # Must be globally unique
+  force_destroy = false                          # terraform won't delete the bucket unless it is empty
+  location      = var.location
+  storage_class = "STANDARD" # https://cloud.google.com/storage/docs/storage-classes
+  versioning {
+    enabled = false
+  }
+}


### PR DESCRIPTION
This makes the current state of the repo available to virtual machines,
without having to clone the whole thing.
