### PR TITLE
Fix rsync (part 2 of 2)

### DIFF
--- a/terraform/workload-identity-federation.tf
+++ b/terraform/workload-identity-federation.tf
@@ -26,6 +26,7 @@ resource "google_service_account_iam_member" "wif-sa" {
   for_each = toset([
     google_service_account.terraform.name,
     google_service_account.source_repositories_github.name,
+    google_service_account.storage_github.name,
     google_service_account.artifact_registry_docker.name
   ])
   service_account_id = each.key


### PR DESCRIPTION
Allow the service account to use workload identity federation.
