### PR TITLE
Git push mirror to source repositories

### DIFF
--- a/.github/workflows/source-repositories.yml
+++ b/.github/workflows/source-repositories.yml
@@ -44,4 +44,4 @@ jobs:
 
     - name: Push
       run: |
-        git push google main
+        git push --mirror google


### PR DESCRIPTION
Hopefully this will work, because normal `git push` does not.
