### PR TITLE
Revert "Initialise instances as terminated (#57)"

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -149,8 +149,6 @@ resource "google_compute_instance" "neo4j" {
     scopes = ["cloud-platform"]
   }
 
-  desired_status = "TERMINATED"
-
   # Schedule start and stop
   # resource_policies = [google_compute_resource_policy.neo4j.self_link]
 }
@@ -184,8 +182,6 @@ resource "google_compute_instance" "mongodb" {
     email  = google_service_account.gce_mongodb.email
     scopes = ["cloud-platform"]
   }
-
-  desired_status = "TERMINATED"
 }
 
 resource "google_compute_instance_iam_member" "neo4j_instanceAdmin" {


### PR DESCRIPTION
This reverts commit d97b0e81da9cbc7849018d8d59a7028afa366495.

Subsequent calls of `terraform plan` gave the following error:

> When creating an instance, desired_status can only accept RUNNING value
