### PR TITLE
Use vanilla mongodb image instead of custom

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -161,7 +161,7 @@ resource "google_compute_instance" "mongodb" {
 
   boot_disk {
     initialize_params {
-      image = module.mongodb-container.source_image
+      image = "mongo:4.2.21"
       size  = 10
     }
   }


### PR DESCRIPTION
To test a different architecture, where a vanilla instance hosts the
database, and a custom instance queries it.
