### PR TITLE
Give mongodb instance a bigger disk

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -162,7 +162,7 @@ resource "google_compute_instance" "mongodb" {
   boot_disk {
     initialize_params {
       image = module.mongodb-container.source_image
-      size  = 10
+      size  = 20
     }
   }
 


### PR DESCRIPTION
It ran out while restoring the content store.
