### PR TITLE
Upgrade to mongo 4.4.16

### DIFF
--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.2.21
+FROM mongo:4.4.16
 
 # Install gsutil
 # https://cloud.google.com/sdk/docs/install#deb
@@ -24,7 +24,3 @@ ENV GITHUB_REF=${GITHUB_REF}
 CMD \
   gsutil cat gs://govuk-knowledge-graph-repository/docker/mongodb/run.sh \
   | bash
-
-# Self-destruct (shut down and delete this instance)
-# https://stackoverflow.com/a/41232669
-# CMD gcloud compute instances stop mongodb --quiet --zone=europe-west2-a


### PR DESCRIPTION
This is needed to support the queries we need, and yet still be
compatible with the dump from GOV.UK.

Also remove commented code.
