### PR TITLE
Don't run mongodb in memory

### DIFF
--- a/docker/mongodb/run.sh
+++ b/docker/mongodb/run.sh
@@ -7,7 +7,7 @@
 set -m
 
 # Start mongo and put it in the background
-mongod  --storageEngine inMemory &
+mongod &
 
 # Wait for mongo to start
 sleep 5


### PR DESCRIPTION
It's only supported in the enterprise (paid) edition.  It might hold a
lot of stuff in memory anyway.
