### PR TITLE
Delete rather than stop mongodb instance

### DIFF
--- a/docker/mongodb/run.sh
+++ b/docker/mongodb/run.sh
@@ -30,7 +30,7 @@ bash src/mongodb/extract-from-mongodb.sh
 
 # Stop this instance
 # https://stackoverflow.com/a/41232669
-gcloud compute instances stop mongodb --quiet --zone=europe-west2-a
+gcloud compute instances delete mongodb --quiet --zone=europe-west2-a
 
 # In case the instance is still running, bring the background process back into
 # the foreground and leave it there


### PR DESCRIPTION
Now that it is from a template, it won't need terraforming to reinstate
the instance.
