### PR TITLE
Allow nonlinear git history

### DIFF
--- a/terraform/main-github.tf
+++ b/terraform/main-github.tf
@@ -45,7 +45,7 @@ resource "github_branch_protection" "main" {
   pattern                 = "main"
   allows_deletions        = false
   require_signed_commits  = true
-  required_linear_history = true
+  required_linear_history = false
   required_pull_request_reviews {
     dismiss_stale_reviews           = true
     require_code_owner_reviews      = true


### PR DESCRIPTION
GitHub doesn't have a good way to merge pull requests with a
fast-forward, so the choice is between having lots of merge commits, or
lots of rebasing.  Having tried rebasing, I prefer the merge commits.
