### PR TITLE
Use authoritative IAM for the project

### DIFF
--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -128,3 +128,101 @@ resource "google_project_service" "services" {
 resource "google_compute_project_default_network_tier" "default" {
   network_tier = "STANDARD"
 }
+
+resource "google_project_iam_policy" "project" {
+  project     = var.project_id
+  policy_data = data.google_iam_policy.project.policy_data
+}
+
+# All IAM members at the project level must be given here.
+#
+# If terraform is about to remove the permissions of a default service account,
+# then that is probably because Google automatically created the account since
+# this file was last updated. In that case, add the new permissions here and
+# check the terraform plan again.
+data "google_iam_policy" "project" {
+  binding {
+    role = "roles/owner"
+    members = [
+      "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
+    ]
+  }
+
+  binding {
+    role = "roles/editor"
+    members = [
+      "serviceAccount:19513753240@cloudservices.gserviceaccount.com",
+      "serviceAccount:govuk-knowledge-graph@appspot.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/appengine.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-gae-service.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/artifactregistry.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-artifactregistry.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/cloudbuild.builds.builder"
+    members = [
+      "serviceAccount:19513753240@cloudbuild.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/cloudbuild.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-cloudbuild.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/compute.instanceAdmin.v1"
+    members = [
+      "serviceAccount:gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/compute.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@compute-system.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/containerregistry.ServiceAgent"
+    members = [
+      "serviceAccount:service-19513753240@containerregistry.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/firestore.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-firestore.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/networkmanagement.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-networkmanagement.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/pubsub.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-pubsub.iam.gserviceaccount.com",
+    ]
+  }
+}


### PR DESCRIPTION
This makes explicit the IAM roles that are granted to principles at the
project level.

Most of them are associated with default service accounts that are
managed by Google.  Those shouldn't be interfered with, and when they
change, the terraform configuration and state should be synchronised
with GCP so that `terraform apply` does not make any changes.

That can be done by using `terraform import` and `terraform show` to
obtain and view the true state of the project, and then manually editing
the file `terraform/main-gcp.tf` to describe that state.  Once
`terraform plan` no longer proposes changes, it is safe to continue.
