### PR TITLE
Create a workflow to run mongodb

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -12,6 +12,21 @@ resource "google_service_account" "gce_mongodb" {
   description  = "Service account for the MongoDB instance on GCE"
 }
 
+# Allow a workflow to start an instance
+data "google_iam_policy" "service_account-gce_mongodb" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+    members = [
+      "serviceAccount:${google_service_account.workflow.email}",
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "gce_mongodb" {
+  service_account_id = google_service_account.gce_mongodb.name
+  policy_data        = data.google_iam_policy.service_account-gce_mongodb.policy_data
+}
+
 # terraform import google_compute_network.default default
 resource "google_compute_network" "default" {
   name        = "default"

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -69,7 +69,8 @@ variable "services" {
     "artifactregistry.googleapis.com",
     "compute.googleapis.com",
     "pubsub.googleapis.com",
-    "sourcerepo.googleapis.com"
+    "sourcerepo.googleapis.com",
+    "workflows.googleapis.com",
   ]
 }
 
@@ -195,6 +196,7 @@ data "google_iam_policy" "project" {
     role = "roles/compute.instanceAdmin.v1"
     members = [
       "serviceAccount:${google_service_account.gce_mongodb.email}",
+      "serviceAccount:${google_service_account.workflow.email}",
     ]
   }
 
@@ -230,6 +232,13 @@ data "google_iam_policy" "project" {
     role = "roles/pubsub.serviceAgent"
     members = [
       "serviceAccount:service-19513753240@gcp-sa-pubsub.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/workflows.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-workflows.iam.gserviceaccount.com",
     ]
   }
 }

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -1,0 +1,28 @@
+# A workflow to create an instance from a template
+
+resource "google_service_account" "workflow" {
+  account_id   = "workflow-mongodb"
+  display_name = "Service account for the workflow"
+}
+
+resource "google_workflows_workflow" "workflow" {
+  name            = "workflow"
+  region          = var.region
+  description     = "Run MongoDB and Neo4j instances from their templates"
+  service_account = google_service_account.workflow.id
+  source_contents = <<-EOF
+  # This workflow does the following:
+  # - Creates an instance from the MongoDB template
+  # - [TBC] Creates an instance from the Neo4j template
+  # In terraform you need to escape the $$ or it will cause errors.
+
+  - start_mongodb:
+      call: googleapis.compute.v1.instances.insert
+      args:
+          project: ${var.project_id}
+          zone: ${var.zone}
+          sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/instanceTemplates/mongodb
+          body:
+              name: mongodb
+EOF
+}


### PR DESCRIPTION
Instead of doing this from a Cloud Function, which could be triggered by
EventArc, from PubSub, from a bucket.  That would work, but it can't yet
be managed by terraform.

Workflows can be triggered by EventArc, from PubSub, from a bucket, so
this should be a drop-in replacement.
