### PR TITLE
Allow PubSub to use push authentication

### DIFF
--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -230,6 +230,13 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role = "roles/iam.serviceAccountTokenCreator"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-pubsub.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
     role = "roles/networkmanagement.serviceAgent"
     members = [
       "serviceAccount:service-19513753240@gcp-sa-networkmanagement.iam.gserviceaccount.com",


### PR DESCRIPTION
https://cloud.google.com/pubsub/docs/push?&_ga=2.54121259.-245591889.1647874680#authentication
