### PR TITLE
Use GNU parallel instead of python parallel

### DIFF
--- a/src/mongodb/js/body.js
+++ b/src/mongodb/js/body.js
@@ -72,5 +72,6 @@ db.content_items.aggregate([
     "hmrc_manual_section"
   ] } } },
   { $project: { url: true, html: "$details.body" } },
+  { $match: { "html": { "$exists": true, $ne: null } } },
   { $out: "body"}
 ])

--- a/src/mongodb/js/body_content.js
+++ b/src/mongodb/js/body_content.js
@@ -50,5 +50,6 @@ db.content_items.aggregate([
   { $project: { "url": true, "details.body.content": true } },
   { $unwind: "$details.body" },
   { $project: { url: true, html: "$details.body.content" } },
+  { $match: { "html": { "$exists": true, $ne: null } } },
   { $out: "body_content"}
 ])

--- a/src/mongodb/js/parts_content.js
+++ b/src/mongodb/js/parts_content.js
@@ -27,5 +27,6 @@ db.content_items.aggregate([
     "part_title": true,
     "html": "$body.content",
   } },
+  { $match: { "html": { "$exists": true, $ne: null } } },
   {$out: "parts_content"}
 ])

--- a/src/mongodb/js/place_content.js
+++ b/src/mongodb/js/place_content.js
@@ -56,5 +56,6 @@ db.content_items.aggregate([
       }
     }
   } },
+  { $match: { "html": { "$exists": true, $ne: null } } },
   { $out: "place_content" }
 ])

--- a/src/mongodb/js/step_by_step_content.js
+++ b/src/mongodb/js/step_by_step_content.js
@@ -72,5 +72,6 @@ db.content_items.aggregate([
       }
     }
   } },
+  { $match: { "html": { "$exists": true, $ne: null } } },
   { $out: "step_by_step_content" }
 ])

--- a/src/mongodb/js/transaction_content.js
+++ b/src/mongodb/js/transaction_content.js
@@ -44,5 +44,6 @@ db.content_items.aggregate([
       }
     }
   } },
+  { $match: { "html": { "$exists": true, $ne: null } } },
   { $out: "transaction_content" }
 ])

--- a/src/mongodb/sh/body.sh
+++ b/src/mongodb/sh/body.sh
@@ -1,5 +1,6 @@
 # body content
 query_mongo \
+  type=json \
   collection=body \
   fields=url,html \
 | extract_text_from_html \

--- a/src/mongodb/sh/body_content.sh
+++ b/src/mongodb/sh/body_content.sh
@@ -1,5 +1,6 @@
 # body_content content
 query_mongo \
+  type=json \
   collection=body_content \
   fields=url,html \
 | extract_text_from_html \

--- a/src/mongodb/sh/body_content_embedded_links.sh
+++ b/src/mongodb/sh/body_content_embedded_links.sh
@@ -1,5 +1,6 @@
 # body_content embedded hyperlinks
 query_mongo \
+  type=json \
   collection=body_content \
   fields=url,html \
 | extract_hyperlinks_from_html \

--- a/src/mongodb/sh/body_content_lines.sh
+++ b/src/mongodb/sh/body_content_lines.sh
@@ -1,5 +1,6 @@
 # body_content content; individual lines of text
 query_mongo \
+  type=json \
   collection=body_content \
   fields=url,html \
 | extract_lines_from_html \

--- a/src/mongodb/sh/body_embedded_links.sh
+++ b/src/mongodb/sh/body_embedded_links.sh
@@ -1,5 +1,6 @@
 # body embedded hyperlinks
 query_mongo \
+  type=json \
   collection=body \
   fields=url,html \
 | extract_hyperlinks_from_html \

--- a/src/mongodb/sh/body_lines.sh
+++ b/src/mongodb/sh/body_lines.sh
@@ -1,5 +1,6 @@
 # body content; individual lines of text
 query_mongo \
+  type=json \
   collection=body \
   fields=url,html \
 | extract_lines_from_html \

--- a/src/mongodb/sh/parts_content.sh
+++ b/src/mongodb/sh/parts_content.sh
@@ -1,5 +1,6 @@
 # guide_and_travel_advice_parts content
 query_mongo \
+  type=json \
   collection=parts_content \
   fields=url,base_path,part_index,html \
 | extract_text_from_html \

--- a/src/mongodb/sh/parts_lines.sh
+++ b/src/mongodb/sh/parts_lines.sh
@@ -1,5 +1,6 @@
 # parts content; individual lines of text
 query_mongo \
+  type=json \
   collection=parts_content \
   fields=url,base_path,part_index,html \
 | extract_lines_from_html \

--- a/src/mongodb/sh/place_content.sh
+++ b/src/mongodb/sh/place_content.sh
@@ -1,5 +1,6 @@
 # place content
 query_mongo \
+  type=json \
   collection=place_content \
   fields=url,html \
 | extract_text_from_html \

--- a/src/mongodb/sh/place_embedded_links.sh
+++ b/src/mongodb/sh/place_embedded_links.sh
@@ -1,5 +1,6 @@
 # place embedded hyperlinks
 query_mongo \
+  type=json \
   collection=place_content \
   fields=url,html \
 | extract_hyperlinks_from_html \

--- a/src/mongodb/sh/place_lines.sh
+++ b/src/mongodb/sh/place_lines.sh
@@ -1,5 +1,6 @@
 # place content; individual lines of text
 query_mongo \
+  type=json \
   collection=place_content \
   fields=url,html \
 | extract_lines_from_html \

--- a/src/mongodb/sh/step_by_step_content.sh
+++ b/src/mongodb/sh/step_by_step_content.sh
@@ -1,5 +1,6 @@
 # step_by_step content
 query_mongo \
+  type=json \
   collection=step_by_step_content \
   fields=url,html \
 | extract_text_from_html \

--- a/src/mongodb/sh/step_by_step_embedded_links.sh
+++ b/src/mongodb/sh/step_by_step_embedded_links.sh
@@ -1,5 +1,6 @@
 # step_by_step embedded hyperlinks
 query_mongo \
+  type=json \
   collection=step_by_step_content \
   fields=url,html \
 | extract_hyperlinks_from_html \

--- a/src/mongodb/sh/step_by_step_lines.sh
+++ b/src/mongodb/sh/step_by_step_lines.sh
@@ -1,5 +1,6 @@
 # step_by_step content; individual lines of text
 query_mongo \
+  type=json \
   collection=step_by_step_content \
   fields=url,html \
 | extract_lines_from_html \

--- a/src/mongodb/sh/transaction_content.sh
+++ b/src/mongodb/sh/transaction_content.sh
@@ -1,5 +1,6 @@
 # transaction content
 query_mongo \
+  type=json \
   collection=transaction_content \
   fields=url,html \
 | extract_text_from_html \

--- a/src/mongodb/sh/transaction_embedded_links.sh
+++ b/src/mongodb/sh/transaction_embedded_links.sh
@@ -1,5 +1,6 @@
 # transaction embedded hyperlinks
 query_mongo \
+  type=json \
   collection=transaction_content \
   fields=url,html \
 | extract_hyperlinks_from_html \

--- a/src/mongodb/sh/transaction_lines.sh
+++ b/src/mongodb/sh/transaction_lines.sh
@@ -1,5 +1,6 @@
 # transaction content; individual lines of text
 query_mongo \
+  type=json \
   collection=transaction_content \
   fields=url,html \
 | extract_lines_from_html \

--- a/src/utils/extract_hyperlinks_from_html.py
+++ b/src/utils/extract_hyperlinks_from_html.py
@@ -4,11 +4,10 @@
 import argparse
 import sys
 import csv
+import json
 import re
 
-from multiprocessing import Pool, Semaphore, cpu_count
 from typing import NamedTuple
-from functools import partial
 from bs4 import BeautifulSoup
 
 
@@ -38,55 +37,27 @@ def complete_hyperlink(href, from_url):
     return href
 
 
-def read_rows(semaphore, reader):
-    for row in reader:
-        # Reduce semaphore by 1 or wait if 0
-        semaphore.acquire()
-        # Now deliver an item to the caller (pool)
-        yield row
-
-
-def extract_hyperlinks(row, input_col):
-    soup = BeautifulSoup(row[input_col], "lxml")
-    links = [
-        Hyperlink(href=link.get("href"), text=link.get_text())
-        for link in soup.findAll("a", href=True)
-    ]
-    return row, links
-
-
-def write_hyperlinks(semaphore, writer, row, links, id_cols):
-    row_dict = {col_name: row[col_name] for col_name in id_cols}
-    for link in links:
-        if len(link.href) == 0:
-            url = row["url"]
-        else:
-            url = complete_hyperlink(link.href, row["url"])
-        row_dict = {col_name: row[col_name] for col_name in id_cols}
-        row_dict["link_url"] = url
-        row_dict["link_url_bare"] = url.split("?")[0].split("#")[0]
-        row_dict["link_text"] = link.text
-        writer.writerow(row_dict)
-    semaphore.release()
-
-
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
-        description="""Extract hyperlinks from an html column of a CSV file, via stdin, to stdout.
+        description="""Extract hyperlinks from an html field of single-line JSON documents, via stdin, to stdout.
 
 Example usage:
-    cat myfile.csv | \\
+    cat myfile.json | \\
+      parallel \
+        --pipe \
+        --round-robin \
+        --line-buffer \
         python src/data/extract_hyperlinks.py \\
             --input_col=col_containing_html \\
             --id_cols=base_path,slug
 
-That example will take a CSV file with headers:
+That example will take a file of one JSON document per line, with items:
   - base_path
   - slug
   - col_containing_html
 
-It will emit a CSV file with headers:
+It will emit a CSV file without headers, but columns for:
   - base_path
   - slug
   - link_url
@@ -108,7 +79,7 @@ New output columns:
         "--input_col",
         type=str,
         required=True,
-        help="The name of the column to search for hyperlinks",
+        help="The name of the field to search for hyperlinks",
     )
 
     parser.add_argument(
@@ -138,27 +109,35 @@ New output columns:
             maxInt = int(maxInt / 10)
     csv.field_size_limit(maxInt)
 
-    reader = csv.DictReader(sys.stdin)
+    # Allow the largest field size possible.
+    # https://stackoverflow.com/a/15063941
+    maxInt = sys.maxsize
+    while True:
+        # decrease the maxInt value by factor 10
+        # as long as the OverflowError occurs.
+        try:
+            csv.field_size_limit(maxInt)
+            break
+        except OverflowError:
+            maxInt = int(maxInt / 10)
+    csv.field_size_limit(maxInt)
 
     writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
-    writer.writeheader()
 
-    # Don't bother setting chunksize.  Previously, we have set it to
-    # n_rows/n_processes, but we don't know n_rows before parsing the CSV file
-    # (can't cheaply count newlines because the body text includes them).  Also,
-    # chunksizes larger than 1 aren't necessarily faster, can be slower, and
-    # there's no good heuristic to choose one, so it would be trial and error --
-    # not worth it in this case.  See:
-    # https://stackoverflow.com/questions/53751050
-    # https://stackoverflow.com/questions/53306927
-    pool = Pool(processes=cpu_count())
-
-    # Allow a buffer of 1024 rows to build up as they are processed, written and
-    # discarded. See: https://stackoverflow.com/a/47058399
-    semaphore_1 = Semaphore(1024)
-
-    for row, hyperlinks in pool.imap_unordered(
-        partial(extract_hyperlinks, input_col=input_col),
-        read_rows(semaphore_1, reader),
-    ):
-        write_hyperlinks(semaphore_1, writer, row, hyperlinks, id_cols)
+    for line in sys.stdin:
+        row = json.loads(line.rstrip('\n'))
+        row_dict = {col_name: row[col_name] for col_name in id_cols}
+        soup = BeautifulSoup(row[input_col], "lxml")
+        links = [
+            Hyperlink(href=link.get("href"), text=link.get_text())
+            for link in soup.findAll("a", href=True)
+        ]
+        for link in links:
+            if len(link.href) == 0:
+                url = row["url"]
+            else:
+                url = complete_hyperlink(link.href, row["url"])
+            row_dict["link_url"] = url
+            row_dict["link_url_bare"] = url.split("?")[0].split("#")[0]
+            row_dict["link_text"] = link.text
+            writer.writerow(row_dict)

--- a/src/utils/extract_lines_from_html.py
+++ b/src/utils/extract_lines_from_html.py
@@ -4,56 +4,33 @@
 import argparse
 import sys
 import csv
+import json
 import re
 
-from multiprocessing import Pool, Semaphore, cpu_count
-from functools import partial
 from bs4 import BeautifulSoup
-
-
-def read_rows(semaphore, reader):
-    for row in reader:
-        # Reduce semaphore by 1 or wait if 0
-        semaphore.acquire()
-        # Now deliver an item to the caller (pool)
-        yield row
-
-
-def extract_lines(row, input_col):
-    soup = BeautifulSoup(row[input_col], "lxml")
-
-    # Replace breaks with newlines
-    for br in soup("br"):
-        br.replace_with("\n")
-
-    return (row, [s.strip() for s in soup.get_text().splitlines() if s.split()])
-
-
-def write_lines(semaphore, writer, row, lines, id_cols):
-    row_dict = {col_name: row[col_name] for col_name in id_cols}
-    for line in lines:
-        row_dict["line"] = line
-        writer.writerow(row_dict)
-    semaphore.release()
 
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
-        description="""Extract lines of text from an html column of a CSV file, via stdin, to stdout.
+        description="""Extract lines of text from an html field of single-line JSON documents, via stdin, to stdout.
 
 Example usage:
-    cat myfile.csv | \\
-        python src/data/extract_lines.py \\
-            --input_col=col_containing_html \\
-            --id_cols=base_path,slug
+    cat myfile.json | \\
+      parallel \
+        --pipe \
+        --round-robin \
+        --line-buffer \
+        python src/data/extract_lines_from_html.py \
+        --input_col=col_containing_html \\
+        --id_cols=base_path,slug
 
-That example will take a CSV file with headers:
+That example will take a file of one JSON document per line, with items:
   - base_path
   - slug
   - col_containing_html
 
-It will emit a CSV file with headers:
+It will emit a CSV file without headers, but columns for:
   - base_path
   - slug
   - line
@@ -65,7 +42,7 @@ It will emit a CSV file with headers:
         "--input_col",
         type=str,
         required=True,
-        help="The name of the column of HTML to extract lines of text from",
+        help="The name of the field of HTML to extract lines of text from",
     )
 
     parser.add_argument(
@@ -95,27 +72,16 @@ It will emit a CSV file with headers:
             maxInt = int(maxInt / 10)
     csv.field_size_limit(maxInt)
 
-    reader = csv.DictReader(sys.stdin)
-
     writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
-    writer.writeheader()
 
-    # Don't bother setting chunksize.  Previously, we have set it to
-    # n_rows/n_processes, but we don't know n_rows before parsing the CSV file
-    # (can't cheaply count newlines because the body text includes them).  Also,
-    # chunksizes larger than 1 aren't necessarily faster, can be slower, and
-    # there's no good heuristic to choose one, so it would be trial and error --
-    # not worth it in this case.  See:
-    # https://stackoverflow.com/questions/53751050
-    # https://stackoverflow.com/questions/53306927
-    pool = Pool(processes=cpu_count())
-
-    # Allow a buffer of 1024 rows to build up as they are processed, written and
-    # discarded. See: https://stackoverflow.com/a/47058399
-    semaphore_1 = Semaphore(1024)
-
-    for row, lines in pool.imap_unordered(
-        partial(extract_lines, input_col=input_col),
-        read_rows(semaphore_1, reader),
-    ):
-        write_lines(semaphore_1, writer, row, lines, id_cols)
+    for line in sys.stdin:
+        row = json.loads(line.rstrip('\n'))
+        row_dict = {col_name: row[col_name] for col_name in id_cols}
+        soup = BeautifulSoup(row[input_col], "lxml")
+        # Replace breaks with newlines
+        for br in soup("br"):
+            br.replace_with("\n")
+        lines = [l.strip() for l in soup.get_text().splitlines() if l.split()]
+        for line in lines:
+            row_dict["line"] = line
+            writer.writerow(row_dict)

--- a/src/utils/extract_text_from_html.py
+++ b/src/utils/extract_text_from_html.py
@@ -4,56 +4,34 @@
 import argparse
 import sys
 import csv
+import json
 import re
 
 from os import linesep
-from multiprocessing import Pool, Semaphore, cpu_count
-from functools import partial
 from bs4 import BeautifulSoup
-
-
-def read_rows(semaphore, reader):
-    for row in reader:
-        # Reduce semaphore by 1 or wait if 0
-        semaphore.acquire()
-        # Now deliver an item to the caller (pool)
-        yield row
-
-
-def extract_text(row, input_col):
-    text = BeautifulSoup(row[input_col], "lxml").get_text()
-    text_without_blank_lines = linesep.join(
-        [s.strip() for s in text.splitlines() if s.strip()]
-    )
-
-    return (row, text, text_without_blank_lines)
-
-
-def write_text(semaphore, writer, row, text, text_without_blank_lines, id_cols):
-    row_dict = {col_name: row[col_name] for col_name in id_cols}
-    row_dict["text"] = text
-    row_dict["text_without_blank_lines"] = text_without_blank_lines
-    writer.writerow(row_dict)
-    semaphore.release()
 
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
-        description="""Extract text from an html column of a CSV file, via stdin, to stdout.
+        description="""Extract text from an html field of single-line JSON documents, via stdin, to stdout.
 
 Example usage:
-    cat myfile.csv | \\
+    cat myfile.json | \\
+      parallel \
+        --pipe \
+        --round-robin \
+        --line-buffer \
         python src/data/extract_text.py \\
             --input_col=col_containing_html \\
             --id_cols=base_path,slug
 
-That example will take a CSV file with headers:
+That example will take a file of one JSON document per line, with items:
   - base_path
   - slug
   - col_containing_html
 
-It will emit a CSV file with headers:
+It will emit a CSV file without headers, but columns for:
   - base_path
   - slug
   - text
@@ -65,7 +43,7 @@ It will emit a CSV file with headers:
         "--input_col",
         type=str,
         required=True,
-        help="The name of the column of HTML to extract text from",
+        help="The name of the field of HTML to extract text from",
     )
 
     parser.add_argument(
@@ -95,27 +73,16 @@ It will emit a CSV file with headers:
             maxInt = int(maxInt / 10)
     csv.field_size_limit(maxInt)
 
-    reader = csv.DictReader(sys.stdin)
-
     writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
-    writer.writeheader()
 
-    # Don't bother setting chunksize.  Previously, we have set it to
-    # n_rows/n_processes, but we don't know n_rows before parsing the CSV file
-    # (can't cheaply count newlines because the body text includes them).  Also,
-    # chunksizes larger than 1 aren't necessarily faster, can be slower, and
-    # there's no good heuristic to choose one, so it would be trial and error --
-    # not worth it in this case.  See:
-    # https://stackoverflow.com/questions/53751050
-    # https://stackoverflow.com/questions/53306927
-    pool = Pool(processes=cpu_count())
-
-    # Allow a buffer of 1024 rows to build up as they are processed, written and
-    # discarded. See: https://stackoverflow.com/a/47058399
-    semaphore_1 = Semaphore(1024)
-
-    for row, text, text_without_blank_lines in pool.imap_unordered(
-        partial(extract_text, input_col=input_col),
-        read_rows(semaphore_1, reader),
-    ):
-        write_text(semaphore_1, writer, row, text, text_without_blank_lines, id_cols)
+    for line in sys.stdin:
+        row = json.loads(line.rstrip('\n'))
+        row_dict = {col_name: row[col_name] for col_name in id_cols}
+        soup = BeautifulSoup(row[input_col], "lxml")
+        text = BeautifulSoup(row[input_col], "lxml").get_text()
+        text_without_blank_lines = linesep.join(
+            [s.strip() for s in text.splitlines() if s.strip()]
+        )
+        row_dict["text"] = text
+        row_dict["text_without_blank_lines"] = text_without_blank_lines
+        writer.writerow(row_dict)


### PR DESCRIPTION
This gets around Python's Global Interpreter Lock to make the best use
of the available CPUs.

It requires JSON to be exported from MongoDB, instead of CSV, because
GNU parallel is very slow at parsing CSV files that might contain quoted
newline characters, whereas the JSON is guaranteed to be one line per
document.
