### PR TITLE
Keep output of parallel jobs together

### DIFF
--- a/src/mongodb/functions.sh
+++ b/src/mongodb/functions.sh
@@ -113,9 +113,10 @@ extract_text_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_text_from_html.py \
-        --input_col=${input_col} \
-        --id_cols=${id_cols} \
+      --input_col=${input_col} \
+      --id_cols=${id_cols} \
   ;}
 }
 extract_lines_from_html () {
@@ -126,6 +127,7 @@ extract_lines_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_lines_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
@@ -139,7 +141,8 @@ extract_hyperlinks_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
-    python3 ../../src/utils/extract_hyperlinks_from_html.py \
+      --keep-order \
+      python3 ../../src/utils/extract_hyperlinks_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
   ;}


### PR DESCRIPTION
The option --line-buffer on its own causes whole lines to be emitted by
each job (partial lines won't get mixed up), but a line from one job
might be followed by a line from another job, thus jumbling multi-line
content.  The option --keep-together causes --line-buffer to apply to
only one job at a time, until it is finished.  The outputs of the other
jobs are presumably cached.
