### PR TITLE
Fix omitted titles

### DIFF
--- a/src/mongodb/js/title.js
+++ b/src/mongodb/js/title.js
@@ -3,7 +3,7 @@ db.content_items.aggregate([
   { $match: { $and: [
     { "title": { $exists: true } },
     { "title": { $ne: null } },
-    { "description.value": { $ne: "" } },
+    { "title": { $ne: "" } },
   ] } },
   { $project: { url: 1, title: { "$trim": { input: "$title" } } } },
   { $out: "title" }


### PR DESCRIPTION
A copy/paste error meant that they were only returned when
`description.value` also existed.
