### PR TITLE
Increase disk size for postgres

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -272,7 +272,7 @@ resource "google_compute_instance_template" "postgres" {
   disk {
     boot         = true
     source_image = module.postgres-container.source_image
-    disk_size_gb = 40
+    disk_size_gb = 60
   }
 
   metadata = {


### PR DESCRIPTION
It had 40G, of which 36G were available as /mnt/stateful_partition, and
that was all used before the editions table had been restored.
