### PR TITLE
neo4j ram

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -215,7 +215,7 @@ resource "google_compute_instance_template" "neo4j" {
   disk {
     boot         = true
     source_image = module.neo4j-container.source_image
-    disk_size_gb = 64
+    disk_size_gb = 40
   }
 
   metadata = {


### PR DESCRIPTION
- Use a smaller machine for Neo4j
- Use smaller Neo4j disk
