### PR TITLE
Add bank holidays

### DIFF
--- a/docker/neo4j/Dockerfile
+++ b/docker/neo4j/Dockerfile
@@ -27,13 +27,15 @@ RUN \
   && cd /var/lib/neo4j/certificates \
   && openssl req  -nodes -new -x509  -keyout private.key -out public.crt -subj \
     "/C=GB/ST=NRW/L=London/O=GDS/OU=DevOps/CN=www.gov.uk/emailAddress=gds-data-science@digital.cabinet-office.gov.uk" \
+  # Install the APOC core plugin
+  && mv /var/lib/neo4j/labs/apoc-4.4.0.5-core.jar /var/lib/neo4j/plugins \
   # Install the Graph Data Science plugin \
   # https://neo4j.com/docs/graph-data-science/current/installation/neo4j-server/ \
-  && cd /tmp \
   && cd /tmp \
   && curl -O https://graphdatascience.ninja/neo4j-graph-data-science-2.1.5.zip \
   && unzip neo4j-graph-data-science-2.1.5.zip neo4j-graph-data-science-2.1.5.jar \
   && mv neo4j-graph-data-science-2.1.5.jar /var/lib/neo4j/plugins \
+  && rm neo4j-graph-data-science-2.1.5.zip \
   # Clean up
   && apt-get -y purge --auto-remove \
     curl \

--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -461,3 +461,34 @@ MATCH (n:Page) WHERE left(n.url, 18) <> "https://www.gov.uk"
 SET n:ExternalPage
 REMOVE n:Page
 ;
+
+// Bank holidays
+CALL apoc.load.json("https://www.gov.uk/bank-holidays.json")
+YIELD value
+UNWIND apoc.map.sortedProperties(value) AS divisions
+WITH divisions[1] AS division
+WITH *, division.division AS id
+CREATE (div:Division {
+  url: "https://www.gov.uk/divisions/" + id,
+  name: CASE id
+    WHEN "england-and-wales" THEN "England and Wales"
+    WHEN "northern-ireland" THEN "Northern Ireland"
+    WHEN "scotland" THEN "Scotland"
+    ELSE id
+  END
+})
+WITH *
+UNWIND division.events AS event
+MERGE (holiday:BankHoliday {
+  url: "https://www.gov.uk/bank-holidays/" + event.title,
+  name: event.title
+})
+MERGE (date:Date {
+  url: "https://www.gov.uk/dates/" + event.date,
+  dateString: event.date
+})
+MERGE (holiday)-[:IS_OBSERVED_IN]->(div)
+WITH *, CASE event.notes WHEN "" THEN NULL ELSE event.notes END AS note
+MERGE (holiday)-[observance:IS_ON]->(date)
+SET observance.notes = note
+;


### PR DESCRIPTION
These are maintained in https://github.com/alphagov/frontend, but we
fetch them from the API, and parse the JSON in Neo4j cypher.

The query requires the APOC Core plugin for Neo4j, which is available in
the docker container, but isn't configured by default.  Now it is
configured, and a couple of other things are tidied up.
