### PR TITLE
Fix WAL config of postgres

### DIFF
--- a/src/postgres/postgresql.conf
+++ b/src/postgres/postgresql.conf
@@ -288,7 +288,7 @@ min_wal_size = 80MB
 
 # Set these on the master and on any standby that will send replication data.
 
-#max_wal_senders = 10		# max number of walsender processes
+max_wal_senders = 0		# max number of walsender processes
 				# (change requires restart)
 #wal_keep_size = 0		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables


### PR DESCRIPTION
The error is:

> WAL streaming (max_wal_senders > 0) requires wal_level "replica" or "logical"
