### PR TITLE
Install Neo4j APOC a different way

### DIFF
--- a/docker/neo4j/Dockerfile
+++ b/docker/neo4j/Dockerfile
@@ -27,8 +27,6 @@ RUN \
   && cd /var/lib/neo4j/certificates \
   && openssl req  -nodes -new -x509  -keyout private.key -out public.crt -subj \
     "/C=GB/ST=NRW/L=London/O=GDS/OU=DevOps/CN=www.gov.uk/emailAddress=gds-data-science@digital.cabinet-office.gov.uk" \
-  # Install the APOC core plugin
-  && mv /var/lib/neo4j/labs/apoc-4.4.0.5-core.jar /var/lib/neo4j/plugins \
   # Install the Graph Data Science plugin \
   # https://neo4j.com/docs/graph-data-science/current/installation/neo4j-server/ \
   && cd /tmp \

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -141,6 +141,12 @@ module "neo4j-container" {
     image = "europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/neo4j:latest"
     tty : true
     stdin : true
+    env = [
+      {
+        name = "NEO4JLABS_PLUGINS"
+        value = "[\"apoc\"]"
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
It can be installed by setting an environment variable for the docker
container.

https://neo4j.com/docs/operations-manual/current/docker/operations/#docker-neo4jlabs-plugins

It wasn't working when it was being installed by moving the .jar file.
It would do `apoc.load.json()`, but couldn't find
`apoc.map.sortedProperties()`.
