### PR TITLE
Allow all procedures found

### DIFF
--- a/docker/neo4j/neo4j.conf
+++ b/docker/neo4j/neo4j.conf
@@ -266,7 +266,7 @@ dbms.security.procedures.unrestricted=gds.*
 
 # A comma separated list of procedures to be loaded by default.
 # Leaving this unconfigured will load all procedures found.
-dbms.security.procedures.allowlist=apoc.coll.*,apoc.load.*,gds.*
+# dbms.security.procedures.allowlist=apoc.coll.*,apoc.load.*,gds.*
 
 #********************************************************************
 # JVM Parameters


### PR DESCRIPTION
This returns to the default config.  The allowlist was restricting an
apoc function that we require.  I see no reason to disallow anything.
