### PR TITLE
Configure postgres instance with local SSD

### DIFF
--- a/docker/postgres/run.sh
+++ b/docker/postgres/run.sh
@@ -32,10 +32,11 @@ gcloud compute instances describe postgres \
   --format="value(metadata.items.object_name)"
 )
 OBJECT_URL="gs://$BUCKET/$OBJECT"
+FILE_PATH="data/$OBJECT"
 
 # https://stackoverflow.com/questions/6575221
 date
-gcloud storage cp "$OBJECT_URL" "$OBJECT"
+gcloud storage cp "$OBJECT_URL" "$FILE_PATH"
 date
 pg_restore \
   -U postgres \
@@ -44,10 +45,10 @@ pg_restore \
   --clean \
   --dbname=postgres \
   --no-owner \
-  --jobs=4 \
-  "$OBJECT"
+  --jobs=2 \
+  "$FILE_PATH"
 date
-rm "$OBJECT"
+rm "$FILE_PATH"
 
 # 1. Query the content store into intermediate datasets
 # 2. Download from the content store and intermediate datasets

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -83,6 +83,20 @@ variable "page_to_page_transitions_sql_file" {
   default = "page-to-page-transitions.sql"
 }
 
+variable "postgres-startup-script" {
+  type    = string
+  default = <<-EOF
+#cloud-config
+
+bootcmd:
+- mkfs.ext4 -F /dev/nvme0n1
+- mkdir -p /mnt/disks/local-ssd
+- mount -o discard,defaults,nobarrier /dev/nvme0n1 /mnt/disks/local-ssd
+- mkdir -p /mnt/disks/local-ssd/postgresql-data
+- mkdir -p /mnt/disks/local-ssd/data
+EOF
+}
+
 # Set the Terraform provider
 provider "google" {
   project = var.project_id

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -97,6 +97,8 @@ main:
                           value: $${object_bucket}
                         - key: object_name
                           value: $${object_name}
+                        - key: user-data
+                          value: ${jsonencode(var.postgres-startup-script)}
                         - key: gce-container-declaration
                           value: ${jsonencode(module.postgres-container.metadata_value)}
           - return_started_postgres:


### PR DESCRIPTION
Another attempt to speed up restoring the Publishing API database.

On my laptop (16GB memory, 2 CPUs, local SSD) it took 54 minutes to
restore the whole database, indexes and all.  What slows down the
instance seems to be the network latency between it and its disk.

Running the whole docker instance in memory nearly worked -- it ran for
over an hour, but I think had nearly finished, because it used 64GB of
disk, and it takes up 73GB on my laptop.  Unfortunately, only 64GB of
tmpfs was available, because tmpfs is half the amount of memory, and the
most that I asked for was 128GB.  Instances become quite expensive at
that point.

It's fiddly to mount a local SSD from inside a container, and the
documentation is poor.  The startup script has to be configured in a
different tag of the instance metadata, and mounting a directory is
undocumented.  In the configuration, I've linked to the clues that I
followed.

The startup script runs on the instance before the container is started.
It formats and mounts the local SSD, and creates a couple of folders
inside it.  The container mounts each of those folders, one for postgres
to use, and the other for the database backup file.  That leaves very
little for the instance to store itself, so its disk can be small.
