### PR TITLE
Reinstate --keep-order in parallel

### DIFF
--- a/src/mongodb/functions.sh
+++ b/src/mongodb/functions.sh
@@ -131,6 +131,7 @@ extract_text_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_text_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
@@ -144,6 +145,7 @@ extract_lines_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_lines_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
@@ -157,6 +159,7 @@ extract_hyperlinks_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_hyperlinks_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \

--- a/src/postgres/functions.sh
+++ b/src/postgres/functions.sh
@@ -103,6 +103,7 @@ extract_text_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_text_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
@@ -116,6 +117,7 @@ extract_lines_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_lines_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
@@ -129,6 +131,7 @@ extract_hyperlinks_from_html () {
       --pipe \
       --round-robin \
       --line-buffer \
+      --keep-order \
       python3 ../../src/utils/extract_hyperlinks_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \


### PR DESCRIPTION
I forgot that the reason for it is to keep the _output_ lines from each
processor together, because a single output spans multiple lines, so we
musn't allow them to be jumbled.

I had removed it because it seemed to prevent the ruby scripts from
being parallel.
