### PR TITLE
Add IAM for a default account to export terraform

### DIFF
--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -216,6 +216,14 @@ data "google_iam_policy" "project" {
     ]
   }
 
+  # For exporting everything as terraform
+  binding {
+    role = "roles/cloudasset.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-cloudasset.iam.gserviceaccount.com",
+    ]
+  }
+
   binding {
     role = "roles/cloudbuild.builds.builder"
     members = [


### PR DESCRIPTION
I exported the terraform config from the project, and Google created
this service account to do so.
