### PR TITLE
Allow neo4j http endpoint

### DIFF
--- a/docker/neo4j/neo4j.conf
+++ b/docker/neo4j/neo4j.conf
@@ -93,9 +93,9 @@ dbms.connector.bolt.listen_address=:7687
 dbms.connector.bolt.advertised_address=:7687
 
 # HTTP Connector. There can be zero or one HTTP connectors.
-dbms.connector.http.enabled=false
-#dbms.connector.http.listen_address=:7474
-#dbms.connector.http.advertised_address=:7474
+dbms.connector.http.enabled=true
+dbms.connector.http.listen_address=:7474
+dbms.connector.http.advertised_address=:7474
 
 # HTTPS Connector. There can be zero or one HTTPS connectors.
 dbms.connector.https.enabled=true


### PR DESCRIPTION
To sit behind a load balancer that handles https/SSL
