### PR TITLE
Reinstate neo4j network config

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -256,7 +256,6 @@ resource "google_compute_instance_template" "neo4j" {
     network = "default"
     access_config {
       network_tier = "STANDARD"
-      nat_ip = google_compute_address.neo4j_internal.address
     }
   }
 

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -162,7 +162,9 @@ main:
           body:
               name: neo4j
               networkInterfaces:
-              - networkIP: 10.154.0.13
+              - accessConfigs:
+                - networkTier: STANDARD
+                networkIP: 10.154.0.13
   - add_neo4j_to_instance_group:
       call: googleapis.compute.v1.instanceGroups.addInstances
       args:


### PR DESCRIPTION
The workflow resets it, of course, so it must be explicitly restated.
