### PR TITLE
Put Neo4j into a new network for Cloud Run to use

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -13,6 +13,23 @@ resource "google_dns_managed_zone" "govgraph" {
   name        = "govgraph"
   description = "DNS zone for .dev domains"
   dns_name    = "govgraph.dev."
+  dnssec_config {
+    kind          = "dns#managedZoneDnsSecConfig"
+    non_existence = "nsec3"
+    state         = "off"
+    default_key_specs {
+      algorithm  = "rsasha256"
+      key_length = 2048
+      key_type   = "keySigning"
+      kind       = "dns#dnsKeySpec"
+    }
+    default_key_specs {
+      algorithm  = "rsasha256"
+      key_length = 1024
+      key_type   = "zoneSigning"
+      kind       = "dns#dnsKeySpec"
+    }
+  }
 }
 
 resource "google_dns_record_set" "govgraph" {

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -164,7 +164,7 @@ main:
               networkInterfaces:
               - accessConfigs:
                 - networkTier: STANDARD
-                networkIP: 10.154.0.13
+                networkIP: 10.8.0.4
   - add_neo4j_to_instance_group:
       call: googleapis.compute.v1.instanceGroups.addInstances
       args:


### PR DESCRIPTION
It didn't work with Cloud Run in the default network, so put it into a
new network.
