### PR TITLE
Use letsencrypt instead of Google Managed SSL

### DIFF
--- a/docker/neo4j/Dockerfile
+++ b/docker/neo4j/Dockerfile
@@ -22,11 +22,24 @@ RUN \
   && apt-get install -y \
     curl \
     unzip \
+    certbot \
+    python3-certbot-nginx \
   # Generate certificates needed for HTTPS/BOLT connections"
-  && mkdir -p /var/lib/neo4j/certificates \
+  # https://medium.com/neo4j/getting-certificates-for-neo4j-with-letsencrypt-a8d05c415bbd
+  && certbot certonly -n --nginx -d govgraph.dev \
+  && chgrp -R neo4j /etc/letsencrypt/*\
+  && chmod -R g+rx /etc/letsencrypt/* \
   && cd /var/lib/neo4j/certificates \
-  && openssl req  -nodes -new -x509  -keyout private.key -out public.crt -subj \
-    "/C=GB/ST=NRW/L=London/O=GDS/OU=DevOps/CN=www.gov.uk/emailAddress=gds-data-science@digital.cabinet-office.gov.uk" \
+  && mkdir bolt cluster https \
+  && export DOMAIN=govgraph.dev \
+  && for certsource in bolt cluster https ; do \
+     ln -s /etc/letsencrypt/live/$DOMAIN/fullchain.pem $certsource/neo4j.cert \
+     ln -s /etc/letsencrypt/live/$DOMAIN/privkey.pem $certsource/neo4j.key \
+     mkdir $certsource/trusted \
+     ln -s /etc/letsencrypt/live/$DOMAIN/fullchain.pem $certsource/trusted/neo4j.cert ; \
+  done \
+  && chgrp -R neo4j * \
+  && chmod -R g+rx * \
   # Install the Graph Data Science plugin \
   # https://neo4j.com/docs/graph-data-science/current/installation/neo4j-server/ \
   && cd /tmp \

--- a/docker/neo4j/neo4j.conf
+++ b/docker/neo4j/neo4j.conf
@@ -76,7 +76,7 @@ dbms.default_listen_address=0.0.0.0
 # The address at which this server can be reached by its clients. This may be the server's IP address or DNS name, or
 # it may be the address of a reverse proxy which sits in front of the server. This setting may be overridden for
 # individual connectors below.
-# dbms.default_advertised_address=knowledge-graph-dev.integration.govuk.digital
+dbms.default_advertised_address=govgraph.dev
 
 # You can also choose a specific advertised hostname or IP address, and
 # configure an advertised port for each connector, by setting their
@@ -88,7 +88,7 @@ dbms.default_listen_address=0.0.0.0
 
 # Bolt connector
 dbms.connector.bolt.enabled=true
-dbms.connector.bolt.tls_level=OPTIONAL
+dbms.connector.bolt.tls_level=REQUIRED
 dbms.connector.bolt.listen_address=:7687
 dbms.connector.bolt.advertised_address=:7687
 
@@ -157,18 +157,18 @@ dbms.connector.https.advertised_address=:7473
 
 # Bolt SSL configuration
 dbms.ssl.policy.bolt.enabled=true
-dbms.ssl.policy.bolt.base_directory=certificates
-dbms.ssl.policy.bolt.private_key=private.key
-dbms.ssl.policy.bolt.public_certificate=public.crt
+dbms.ssl.policy.bolt.base_directory=/var/lib/neo4j/certificates/bolt
+dbms.ssl.policy.bolt.private_key=/var/lib/neo4j/certificates/bolt/neo4j.key
+dbms.ssl.policy.bolt.public_certificate=/var/lib/neo4j/certificates/bolt/neo4j.cert
 dbms.ssl.policy.bolt.client_auth=NONE
 dbms.ssl.policy.bolt.trust_all=true
 
 
 # Https SSL configuration
 dbms.ssl.policy.https.enabled=true
-dbms.ssl.policy.https.base_directory=certificates
-dbms.ssl.policy.https.private_key=private.key
-dbms.ssl.policy.https.public_certificate=public.crt
+dbms.ssl.policy.https.base_directory=/var/lib/neo4j/certificates/https
+dbms.ssl.policy.https.private_key=/var/lib/neo4j/certificates/https/neo4j.key
+dbms.ssl.policy.https.public_certificate=/var/lib/neo4j/certificates/https/neo4j.cert
 dbms.ssl.policy.https.client_auth=NONE
 dbms.ssl.policy.https.trust_all=true
 

--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -1,13 +1,12 @@
 # https://cloud.google.com/load-balancing/docs/https/ext-https-lb-simple
 
-# Static external IP address for Neo4j.  Global addresses don't work, because
-# they are only for load balancers, so it must be regional.
-resource "google_compute_global_address" "govgraph" {
+# Static external IP address for a Neo4j instance.  Global addresses don't work,
+# because they are only for load balancers, so it must be regional.
+resource "google_compute_address" "govgraph" {
   name = "govgraph"
+  region = var.region
+  address = "35.246.18.75"
 }
-
-# Where does the static IP address go?
-# rrdatas = [google_compute_address.neo4j.address]
 
 resource "google_dns_managed_zone" "govgraph" {
   name        = "govgraph"
@@ -16,7 +15,7 @@ resource "google_dns_managed_zone" "govgraph" {
   dnssec_config {
     kind          = "dns#managedZoneDnsSecConfig"
     non_existence = "nsec3"
-    state         = "off"
+    state         = "on"
     default_key_specs {
       algorithm  = "rsasha256"
       key_length = 2048
@@ -37,75 +36,13 @@ resource "google_dns_record_set" "govgraph" {
   type         = "A"
   ttl          = 300 # time to live: seconds
   managed_zone = google_dns_managed_zone.govgraph.name
-  # The IP address must be looked up
-  # https://console.cloud.google.com/networking/addresses/list?project=govuk-knowledge-graph
-  rrdatas = ["34.160.154.17"]
+  rrdatas = [google_compute_address.govgraph.address]
 }
 
 # SSL Certificate
 resource "google_compute_managed_ssl_certificate" "govgraph" {
   name = "govgraph"
-
   managed {
     domains = ["govgraph.dev."]
   }
-}
-
-resource "google_compute_instance_group" "govgraph" {
-  name    = "govgraph"
-  zone    = var.zone
-  network = google_compute_network.default.id
-  named_port {
-    name = "neo4j"
-    port = 7474
-  }
-}
-
-resource "google_compute_firewall" "neo4j-health-check" {
-  name          = "neo4j-health-check"
-  direction     = "INGRESS"
-  network       = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
-  priority      = 1000
-  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  allow {
-    ports    = ["7474"]
-    protocol = "tcp"
-  }
-  target_service_accounts = [google_service_account.gce_neo4j.email]
-}
-
-resource "google_compute_target_https_proxy" "govgraph" {
-  name             = "govgraph"
-  url_map          = google_compute_url_map.govgraph.id
-  ssl_certificates = [google_compute_managed_ssl_certificate.govgraph.id]
-}
-
-resource "google_compute_url_map" "govgraph" {
-  name            = "govgraph"
-  description     = "URL map for govgraph.dev"
-  default_service = google_compute_backend_service.govgraph.id
-}
-
-resource "google_compute_backend_service" "govgraph" {
-  name          = "govgraph"
-  port_name     = "neo4j"
-  health_checks = [google_compute_health_check.govgraph.id]
-  backend {
-    group = google_compute_instance_group.govgraph.id
-  }
-}
-
-resource "google_compute_health_check" "govgraph" {
-  name = "govgraph"
-  http_health_check {
-    port_name = "neo4j"
-  }
-}
-
-resource "google_compute_global_forwarding_rule" "govgraph" {
-  name        = "govgraph"
-  ip_address  = google_compute_global_address.govgraph.id
-  target      = google_compute_target_https_proxy.govgraph.id
-  ip_protocol = "TCP"
-  port_range  = 443
 }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -225,6 +225,13 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role    = "roles/cloudasset.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-cloudasset.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
     role = "roles/cloudbuild.builds.builder"
     members = [
       "serviceAccount:${var.project_number}@cloudbuild.gserviceaccount.com",
@@ -324,6 +331,20 @@ data "google_iam_policy" "project" {
     members = [
       "serviceAccount:${google_service_account.eventarc.email}",
       "serviceAccount:${google_service_account.scheduler_neo4j.email}",
+    ]
+  }
+
+  binding {
+    role    = "roles/run.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@serverless-robot-prod.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role    = "roles/vpcaccess.serviceAgent"
+    members = [
+      "serviceAccount:service-19513753240@gcp-sa-vpcaccess.iam.gserviceaccount.com",
     ]
   }
 

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -162,18 +162,12 @@ main:
           body:
               name: neo4j
               networkInterfaces:
-              - accessConfigs:
+              - network: ${google_compute_network.cloudrun.self_link}
+                subnetwork: ${google_compute_subnetwork.cloudrun.self_link}
+                accessConfigs:
                 - networkTier: STANDARD
-                networkIP: 10.8.0.4
-  - add_neo4j_to_instance_group:
-      call: googleapis.compute.v1.instanceGroups.addInstances
-      args:
-          project: ${var.project_id}
-          zone: ${var.zone}
-          instanceGroup: govgraph
-          body:
-              instances:
-              - instance: projects/${var.project_id}/zones/${var.zone}/instances/neo4j
+                  natIP: ${google_compute_address.govgraph.address}
+                networkIP: ${google_compute_address.neo4j_internal.address}
 EOF
 }
 


### PR DESCRIPTION
Quite apart from being a massive pain, the Google Managed SSL can't get
around the fact that Neo4j Browser communicates with the database via a
different port, which handles its own SSL stuff, so there was simply no
alternative to obtaining a certificate directly from LetsEncrypt.
