### PR TITLE
Fix the neo4j network

### DIFF
--- a/docker/neo4j/run.sh
+++ b/docker/neo4j/run.sh
@@ -2,7 +2,13 @@
 
 # Generate certificates needed for HTTPS/BOLT connections"
 # https://medium.com/neo4j/getting-certificates-for-neo4j-with-letsencrypt-a8d05c415bbd
-certbot certonly -n --nginx -d govgraph.dev
+su - root
+certbot certonly \
+  --agree-tos \
+  --email data-products@digital.cabinet-office.gov.uk \
+  -n \
+  --nginx \
+  -d govgraph.dev
 chgrp -R neo4j /etc/letsencrypt/*
 chmod -R g+rx /etc/letsencrypt/*
 cd /var/lib/neo4j/certificates
@@ -16,6 +22,7 @@ for certsource in bolt cluster https ; do
 done
 chgrp -R neo4j *
 chmod -R g+rx *
+exit
 
 # Run both neo4j and scripts that interact with the database
 
@@ -57,12 +64,12 @@ neo4j status
 # Ingest the Content Store data
 gcloud storage cat \
   gs://govuk-knowledge-graph-repository/src/neo4j/load_content_store_data.cypher \
-  | cypher-shell
+  | cypher-shell --address neo4j+s://govgraph.dev:7687
 
 # Ingest the Publishing API data
 gcloud storage cat \
   gs://govuk-knowledge-graph-repository/src/neo4j/load_content_store_data.cypher \
-  | cypher-shell
+  | cypher-shell --address neo4j+s://govgraph.dev:7687
 
 # Stay alive
 sleep infinity

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -100,7 +100,11 @@ resource "google_compute_firewall" "neo4j-ingress" {
     "213.86.153.211",
     "213.86.153.231",
     "51.149.8.0/25",
-    "51.149.8.128/29"
+    "51.149.8.128/29",
+    # It needs to accept connections from itself so that cypher-shell can access
+    # the database by its domain name, which the certificate requires, instead
+    # of localhost.
+    google_compute_address.govgraph.address
   ]
 
   target_service_accounts = [google_service_account.gce_neo4j.email]


### PR DESCRIPTION
- Use premium tier for Neo4j external IP address
- Run certbot as root
- Allow Neo4j through its own firewall so that `cypher-shell` can access itself using the domain name, which the certificate requires.
