### PR TITLE
Increase disk size of neo4j instance

### DIFF
--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -258,7 +258,7 @@ resource "google_compute_instance_template" "neo4j" {
   disk {
     boot         = true
     source_image = module.neo4j-container.source_image
-    disk_size_gb = 40
+    disk_size_gb = 100
   }
 
   metadata = {


### PR DESCRIPTION
PageRank ran out of space, and space is cheap, so more than double it.