### PR TITLE
Allow users to query BigQuery data

### DIFF
--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -207,6 +207,9 @@ data "google_iam_policy" "project" {
     members = [
       "serviceAccount:${google_service_account.gce_mongodb.email}",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
+      "group:data-engineering@digital.cabinet-office.gov.uk",
+      "group:data-analysts@digital.cabinet-office.gov.uk",
+      "group:data-products@digital.cabinet-office.gov.uk"
     ]
   }
 


### PR DESCRIPTION
Allows the same Google Groups that can view the data to also query the data.
