### PR TITLE
Only export roles in the 'en' locale

### DIFF
--- a/src/postgres/sql/roles.sql
+++ b/src/postgres/sql/roles.sql
@@ -21,4 +21,5 @@ CREATE TABLE roles AS
     schema_name IN ('role', 'role_appointment')
     AND content_store = 'live'
     AND editions.state = 'published'
+    AND documents.locale = 'en'
 ;


### PR DESCRIPTION
The schema in Neo4j doesn't yet allow for multiple locales of roles.
