### PR TITLE
Increase shared memory for postgres

### DIFF
--- a/docker/postgres/run.sh
+++ b/docker/postgres/run.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Increase the amount of shared memory available.
+# This requires the containe to run in privileged mode.
+# It prevents a postgres error
+# "could not resize shared memory segment: No space left on device"
+mount -o remount,size=8G /dev/shm
+
 # Run both postgres and scripts that interact with the database
 
 # Obtain the latest state of the repository

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -212,6 +212,9 @@ module "postgres-container" {
     image = "europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/postgres:latest"
     tty : true
     stdin : true
+    securityContext = {
+      privileged : true
+    }
     env = [
       {
         name  = "POSTGRES_HOST_AUTH_METHOD"


### PR DESCRIPTION
It's difficult to believe that 16GB isn't enough, given that it runs
fine on a laptop with 16GB, yet here is the error.

```text
2022-10-26T20:20:39.749569241Z source functions.sh; source sh/appointment_person.sh
2022-10-26T20:20:40.173017179Z 2022-10-26 20:20:40.172 UTC [540] ERROR:  could not resize shared memory segment "/PostgreSQL.1219136073" to 16777216 bytes: No space left on device
2022-10-26T20:20:40.173053749Z 2022-10-26 20:20:40.172 UTC [540] STATEMENT:  SELECT
2022-10-26T20:20:40.173061209Z 	 role_appointments.content_id AS role_appointment_content_id,
2022-10-26T20:20:40.173066849Z 	 links.target_content_id AS person_content_id
2022-10-26T20:20:40.173070979Z 	FROM role_appointments
2022-10-26T20:20:40.173075759Z 	INNER JOIN link_sets ON link_sets.content_id = role_appointments.content_id
2022-10-26T20:20:40.173080819Z 	INNER JOIN links ON links.link_set_id = link_sets.id
2022-10-26T20:20:40.173085409Z 	WHERE links.link_type = 'person'
2022-10-26T20:20:40.173090199Z 	;
2022-10-26T20:20:40.178242018Z 2022-10-26 20:20:40.178 UTC [541] ERROR:  could not resize shared memory segment "/PostgreSQL.1944830777" to 16777216 bytes: No space left on device
2022-10-26T20:20:40.178258088Z 2022-10-26 20:20:40.178 UTC [541] STATEMENT:  SELECT
2022-10-26T20:20:40.178264378Z 	 role_appointments.content_id AS role_appointment_content_id,
2022-10-26T20:20:40.178283848Z 	 links.target_content_id AS person_content_id
2022-10-26T20:20:40.178289158Z 	FROM role_appointments
2022-10-26T20:20:40.178301108Z 	INNER JOIN link_sets ON link_sets.content_id = role_appointments.content_id
2022-10-26T20:20:40.178305948Z 	INNER JOIN links ON links.link_set_id = link_sets.id
2022-10-26T20:20:40.178310238Z 	WHERE links.link_type = 'person'
2022-10-26T20:20:40.178314418Z 	;
2022-10-26T20:20:40.181388608Z 2022-10-26 20:20:40.181 UTC [542] ERROR:  could not resize shared memory segment "/PostgreSQL.1423069972" to 16777216 bytes: No space left on device
2022-10-26T20:20:40.181409318Z 2022-10-26 20:20:40.181 UTC [542] STATEMENT:  SELECT
2022-10-26T20:20:40.181415488Z 	 role_appointments.content_id AS role_appointment_content_id,
2022-10-26T20:20:40.181420158Z 	 links.target_content_id AS person_content_id
2022-10-26T20:20:40.181424368Z 	FROM role_appointments
2022-10-26T20:20:40.181428258Z 	INNER JOIN link_sets ON link_sets.content_id = role_appointments.content_id
2022-10-26T20:20:40.181432618Z 	INNER JOIN links ON links.link_set_id = link_sets.id
2022-10-26T20:20:40.181436448Z 	WHERE links.link_type = 'person'
2022-10-26T20:20:40.181439788Z 	;
2022-10-26T20:20:40.185886247Z 2022-10-26 20:20:40.185 UTC [69] LOG:  background worker "parallel worker" (PID 542) exited with exit code 1
2022-10-26T20:20:40.188743437Z 2022-10-26 20:20:40.188 UTC [69] LOG:  background worker "parallel worker" (PID 541) exited with exit code 1
2022-10-26T20:20:40.195844966Z psql:sql/appointment_person.sql:8: ERROR:  could not resize shared memory segment "/PostgreSQL.1219136073" to 16777216 bytes: No space left on device
```
