### PR TITLE
Use `name` instead of `title` for `Role` nodes

### DIFF
--- a/src/neo4j/load_publishing_api_data.cypher
+++ b/src/neo4j/load_publishing_api_data.cypher
@@ -76,7 +76,7 @@ LOAD CSV WITH HEADERS
 FROM 'file:///role_title.csv' AS line
 FIELDTERMINATOR ','
 MATCH (p:Role { url: line.url })
-SET p.title = line.title
+SET p.name = line.title
 ;
 
 USING PERIODIC COMMIT


### PR DESCRIPTION
This will result as all nodes of type `Role`, `BankHoliday`, `Person` and `Organisation` to use `name` as their main descriptor. That way, GovGraphSearch can use a single query in order to look for nodes of any of those types when doing a "meta" search:
```
        MATCH (node)
        WHERE (node:BankHoliday OR node:Person OR node:Organisation OR node:Role)
        AND toLower(node.name) CONTAINS toLower($keywords)
        ...
```