### PR TITLE
Simplify 'parts'

### DIFF
--- a/src/mongodb/js/parts_content.js
+++ b/src/mongodb/js/parts_content.js
@@ -24,7 +24,7 @@ db.content_items.aggregate([
     "base_path": true,
     "slug": true,
     "part_index": true,
-    "part_title": true,
+    "title": true,
     "html": "$body.content",
   } },
   { $match: { "html": { "$exists": true, $ne: null } } },

--- a/src/mongodb/sh/parts_content.sh
+++ b/src/mongodb/sh/parts_content.sh
@@ -3,10 +3,10 @@ FILE_NAME=parts_content
 query_mongo \
   type=json \
   collection=parts_content \
-  fields=url,base_path,part_index,html \
+  fields=url,html \
 | extract_text_from_html \
   input_col=html \
-  id_cols=url,base_path,part_index,html \
+  id_cols=url,html \
 | upload file_name=$FILE_NAME
 
 send_to_bigquery file_name=$FILE_NAME

--- a/src/mongodb/sh/parts_embedded_links.sh
+++ b/src/mongodb/sh/parts_embedded_links.sh
@@ -3,10 +3,10 @@ FILE_NAME=parts_embedded_links
 query_mongo \
   type=json \
   collection=parts_content \
-  fields=url,base_path,part_index,html \
+  fields=url,html \
 | extract_hyperlinks_from_html \
   input_col=html \
-  id_cols=url,base_path,part_index \
+  id_cols=url \
 | count_distinct escape_cols=link_text \
 | upload file_name=$FILE_NAME
 

--- a/src/mongodb/sh/parts_lines.sh
+++ b/src/mongodb/sh/parts_lines.sh
@@ -3,10 +3,10 @@ FILE_NAME=parts_lines
 query_mongo \
   type=json \
   collection=parts_content \
-  fields=url,base_path,part_index,html \
+  fields=url,html \
 | extract_lines_from_html \
   input_col=html \
-  id_cols=url,base_path,part_index \
+  id_cols=url \
 | upload file_name=$FILE_NAME
 
 send_to_bigquery file_name=$FILE_NAME

--- a/src/mongodb/sh/parts_title.sh
+++ b/src/mongodb/sh/parts_title.sh
@@ -1,0 +1,8 @@
+FILE_NAME=parts_title
+
+query_mongo \
+  collection=parts_content \
+  fields=url,title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -350,7 +350,7 @@ resource "google_bigquery_table" "title" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "title"
   friendly_name = "Title"
-  description   = "Titles of static content on the www.gov.uk domain, not including parts of 'guide' and 'travel_advice' pages, which are in the 'parts' table."
+  description   = "Titles of static content on the www.gov.uk domain, not including parts of 'guide' and 'travel_advice' pages, which are in the 'parts_title' table."
   schema        = <<EOF
 [
   {
@@ -555,9 +555,26 @@ resource "google_bigquery_table" "parts" {
     "type": "STRING",
     "mode": "REQUIRED",
     "description": "The order of the part among other parts in the same document, counting from 0"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "parts_title" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "parts_title"
+  friendly_name = "Parts titles"
+  description   = "Titles of parts of 'guide' and 'travel_advice' documents"
+  schema        = <<EOF
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "Complete URL of the part"
   },
   {
-    "name": "part_title",
+    "name": "title",
     "type": "STRING",
     "mode": "REQUIRED",
     "description": "The title of the part"
@@ -613,18 +630,6 @@ resource "google_bigquery_table" "parts_content" {
     "type": "STRING",
     "mode": "REQUIRED",
     "description": "URL of a piece of static content on the www.gov.uk domain"
-  },
-  {
-    "name": "base_path",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "URL of the parent document of the part"
-  },
-  {
-    "name": "part_index",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "The order of the part among other parts in the same document, counting from 0"
   },
   {
     "name": "html",
@@ -831,18 +836,6 @@ resource "google_bigquery_table" "parts_lines" {
     "description": "URL of a piece of static content on the www.gov.uk domain"
   },
   {
-    "name": "base_path",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "URL of the parent document of the part"
-  },
-  {
-    "name": "part_index",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "The order of the part among other parts in the same document, counting from 0"
-  },
-  {
     "name": "line_number",
     "type": "INTEGER",
     "mode": "REQUIRED",
@@ -1033,18 +1026,6 @@ resource "google_bigquery_table" "parts_embedded_links" {
     "type": "STRING",
     "mode": "REQUIRED",
     "description": "URL of a piece of static content on the www.gov.uk domain"
-  },
-  {
-    "name": "base_path",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "URL of the parent document of the part"
-  },
-  {
-    "name": "part_index",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "The order of the part among other parts in the same document, counting from 0"
   },
   {
     "name": "link_url",


### PR DESCRIPTION
Close #259

Currently, several tables relating to 'parts' of guide and travel_advice
documents include columns for the base_path and part_index.  They only
need the URL, same as similar tables.  There only needs to be one table
of parts url,base_path,part_index, and the other tables can have the
same schema as `title`, `content`, `lines`, `embedded_hyperlinks`, etc.,
so that they can eventually be combined.
