### PR TITLE
Allow a GovNER service account to read BigQuery

### DIFF
--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -41,6 +41,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
     members = [
       "projectReaders",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
+      "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysts@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
This is for the Content Metadata work
https://github.com/alphagov/govuk-content-metadata.
