### PR TITLE
[Not to be merged] Export of terraform when Gov Graph Search works

### DIFF
--- a/terraform-export/19513753240/19513753240/Project/LoggingLogSink/a-default.tf
+++ b/terraform-export/19513753240/19513753240/Project/LoggingLogSink/a-default.tf
@@ -1,0 +1,8 @@
+resource "google_logging_log_sink" "a_default" {
+  destination            = "logging.googleapis.com/projects/govuk-knowledge-graph/locations/global/buckets/_Default"
+  filter                 = "NOT LOG_ID(\"cloudaudit.googleapis.com/activity\") AND NOT LOG_ID(\"externalaudit.googleapis.com/activity\") AND NOT LOG_ID(\"cloudaudit.googleapis.com/system_event\") AND NOT LOG_ID(\"externalaudit.googleapis.com/system_event\") AND NOT LOG_ID(\"cloudaudit.googleapis.com/access_transparency\") AND NOT LOG_ID(\"externalaudit.googleapis.com/access_transparency\")"
+  name                   = "_Default"
+  project                = "19513753240"
+  unique_writer_identity = true
+}
+# terraform import google_logging_log_sink.a_default 19513753240###_Default

--- a/terraform-export/19513753240/19513753240/Project/LoggingLogSink/a-required.tf
+++ b/terraform-export/19513753240/19513753240/Project/LoggingLogSink/a-required.tf
@@ -1,0 +1,8 @@
+resource "google_logging_log_sink" "a_required" {
+  destination            = "logging.googleapis.com/projects/govuk-knowledge-graph/locations/global/buckets/_Required"
+  filter                 = "LOG_ID(\"cloudaudit.googleapis.com/activity\") OR LOG_ID(\"externalaudit.googleapis.com/activity\") OR LOG_ID(\"cloudaudit.googleapis.com/system_event\") OR LOG_ID(\"externalaudit.googleapis.com/system_event\") OR LOG_ID(\"cloudaudit.googleapis.com/access_transparency\") OR LOG_ID(\"externalaudit.googleapis.com/access_transparency\")"
+  name                   = "_Required"
+  project                = "19513753240"
+  unique_writer_identity = true
+}
+# terraform import google_logging_log_sink.a_required 19513753240###_Required

--- a/terraform-export/19513753240/Service/artifactregistry-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/artifactregistry-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "artifactregistry_googleapis_com" {
+  project = "19513753240"
+  service = "artifactregistry.googleapis.com"
+}
+# terraform import google_project_service.artifactregistry_googleapis_com 19513753240/artifactregistry.googleapis.com

--- a/terraform-export/19513753240/Service/bigquery-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/bigquery-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "bigquery_googleapis_com" {
+  project = "19513753240"
+  service = "bigquery.googleapis.com"
+}
+# terraform import google_project_service.bigquery_googleapis_com 19513753240/bigquery.googleapis.com

--- a/terraform-export/19513753240/Service/bigquerydatatransfer-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/bigquerydatatransfer-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "bigquerydatatransfer_googleapis_com" {
+  project = "19513753240"
+  service = "bigquerydatatransfer.googleapis.com"
+}
+# terraform import google_project_service.bigquerydatatransfer_googleapis_com 19513753240/bigquerydatatransfer.googleapis.com

--- a/terraform-export/19513753240/Service/bigquerymigration-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/bigquerymigration-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "bigquerymigration_googleapis_com" {
+  project = "19513753240"
+  service = "bigquerymigration.googleapis.com"
+}
+# terraform import google_project_service.bigquerymigration_googleapis_com 19513753240/bigquerymigration.googleapis.com

--- a/terraform-export/19513753240/Service/bigquerystorage-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/bigquerystorage-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "bigquerystorage_googleapis_com" {
+  project = "19513753240"
+  service = "bigquerystorage.googleapis.com"
+}
+# terraform import google_project_service.bigquerystorage_googleapis_com 19513753240/bigquerystorage.googleapis.com

--- a/terraform-export/19513753240/Service/cloudasset-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/cloudasset-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "cloudasset_googleapis_com" {
+  project = "19513753240"
+  service = "cloudasset.googleapis.com"
+}
+# terraform import google_project_service.cloudasset_googleapis_com 19513753240/cloudasset.googleapis.com

--- a/terraform-export/19513753240/Service/cloudbuild-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/cloudbuild-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "cloudbuild_googleapis_com" {
+  project = "19513753240"
+  service = "cloudbuild.googleapis.com"
+}
+# terraform import google_project_service.cloudbuild_googleapis_com 19513753240/cloudbuild.googleapis.com

--- a/terraform-export/19513753240/Service/cloudresourcemanager-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/cloudresourcemanager-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "cloudresourcemanager_googleapis_com" {
+  project = "19513753240"
+  service = "cloudresourcemanager.googleapis.com"
+}
+# terraform import google_project_service.cloudresourcemanager_googleapis_com 19513753240/cloudresourcemanager.googleapis.com

--- a/terraform-export/19513753240/Service/cloudscheduler-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/cloudscheduler-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "cloudscheduler_googleapis_com" {
+  project = "19513753240"
+  service = "cloudscheduler.googleapis.com"
+}
+# terraform import google_project_service.cloudscheduler_googleapis_com 19513753240/cloudscheduler.googleapis.com

--- a/terraform-export/19513753240/Service/cloudtrace-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/cloudtrace-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "cloudtrace_googleapis_com" {
+  project = "19513753240"
+  service = "cloudtrace.googleapis.com"
+}
+# terraform import google_project_service.cloudtrace_googleapis_com 19513753240/cloudtrace.googleapis.com

--- a/terraform-export/19513753240/Service/compute-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/compute-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "compute_googleapis_com" {
+  project = "19513753240"
+  service = "compute.googleapis.com"
+}
+# terraform import google_project_service.compute_googleapis_com 19513753240/compute.googleapis.com

--- a/terraform-export/19513753240/Service/containerregistry-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/containerregistry-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "containerregistry_googleapis_com" {
+  project = "19513753240"
+  service = "containerregistry.googleapis.com"
+}
+# terraform import google_project_service.containerregistry_googleapis_com 19513753240/containerregistry.googleapis.com

--- a/terraform-export/19513753240/Service/deploymentmanager-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/deploymentmanager-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "deploymentmanager_googleapis_com" {
+  project = "19513753240"
+  service = "deploymentmanager.googleapis.com"
+}
+# terraform import google_project_service.deploymentmanager_googleapis_com 19513753240/deploymentmanager.googleapis.com

--- a/terraform-export/19513753240/Service/dns-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/dns-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "dns_googleapis_com" {
+  project = "19513753240"
+  service = "dns.googleapis.com"
+}
+# terraform import google_project_service.dns_googleapis_com 19513753240/dns.googleapis.com

--- a/terraform-export/19513753240/Service/domains-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/domains-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "domains_googleapis_com" {
+  project = "19513753240"
+  service = "domains.googleapis.com"
+}
+# terraform import google_project_service.domains_googleapis_com 19513753240/domains.googleapis.com

--- a/terraform-export/19513753240/Service/eventarc-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/eventarc-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "eventarc_googleapis_com" {
+  project = "19513753240"
+  service = "eventarc.googleapis.com"
+}
+# terraform import google_project_service.eventarc_googleapis_com 19513753240/eventarc.googleapis.com

--- a/terraform-export/19513753240/Service/iam-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/iam-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "iam_googleapis_com" {
+  project = "19513753240"
+  service = "iam.googleapis.com"
+}
+# terraform import google_project_service.iam_googleapis_com 19513753240/iam.googleapis.com

--- a/terraform-export/19513753240/Service/iamcredentials-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/iamcredentials-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "iamcredentials_googleapis_com" {
+  project = "19513753240"
+  service = "iamcredentials.googleapis.com"
+}
+# terraform import google_project_service.iamcredentials_googleapis_com 19513753240/iamcredentials.googleapis.com

--- a/terraform-export/19513753240/Service/iap-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/iap-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "iap_googleapis_com" {
+  project = "19513753240"
+  service = "iap.googleapis.com"
+}
+# terraform import google_project_service.iap_googleapis_com 19513753240/iap.googleapis.com

--- a/terraform-export/19513753240/Service/logging-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/logging-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "logging_googleapis_com" {
+  project = "19513753240"
+  service = "logging.googleapis.com"
+}
+# terraform import google_project_service.logging_googleapis_com 19513753240/logging.googleapis.com

--- a/terraform-export/19513753240/Service/monitoring-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/monitoring-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "monitoring_googleapis_com" {
+  project = "19513753240"
+  service = "monitoring.googleapis.com"
+}
+# terraform import google_project_service.monitoring_googleapis_com 19513753240/monitoring.googleapis.com

--- a/terraform-export/19513753240/Service/networkmanagement-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/networkmanagement-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "networkmanagement_googleapis_com" {
+  project = "19513753240"
+  service = "networkmanagement.googleapis.com"
+}
+# terraform import google_project_service.networkmanagement_googleapis_com 19513753240/networkmanagement.googleapis.com

--- a/terraform-export/19513753240/Service/oslogin-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/oslogin-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "oslogin_googleapis_com" {
+  project = "19513753240"
+  service = "oslogin.googleapis.com"
+}
+# terraform import google_project_service.oslogin_googleapis_com 19513753240/oslogin.googleapis.com

--- a/terraform-export/19513753240/Service/pubsub-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/pubsub-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "pubsub_googleapis_com" {
+  project = "19513753240"
+  service = "pubsub.googleapis.com"
+}
+# terraform import google_project_service.pubsub_googleapis_com 19513753240/pubsub.googleapis.com

--- a/terraform-export/19513753240/Service/serviceusage-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/serviceusage-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "serviceusage_googleapis_com" {
+  project = "19513753240"
+  service = "serviceusage.googleapis.com"
+}
+# terraform import google_project_service.serviceusage_googleapis_com 19513753240/serviceusage.googleapis.com

--- a/terraform-export/19513753240/Service/sourcerepo-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/sourcerepo-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "sourcerepo_googleapis_com" {
+  project = "19513753240"
+  service = "sourcerepo.googleapis.com"
+}
+# terraform import google_project_service.sourcerepo_googleapis_com 19513753240/sourcerepo.googleapis.com

--- a/terraform-export/19513753240/Service/storage-api-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/storage-api-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "storage_api_googleapis_com" {
+  project = "19513753240"
+  service = "storage-api.googleapis.com"
+}
+# terraform import google_project_service.storage_api_googleapis_com 19513753240/storage-api.googleapis.com

--- a/terraform-export/19513753240/Service/storage-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/storage-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "storage_googleapis_com" {
+  project = "19513753240"
+  service = "storage.googleapis.com"
+}
+# terraform import google_project_service.storage_googleapis_com 19513753240/storage.googleapis.com

--- a/terraform-export/19513753240/Service/workflowexecutions-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/workflowexecutions-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "workflowexecutions_googleapis_com" {
+  project = "19513753240"
+  service = "workflowexecutions.googleapis.com"
+}
+# terraform import google_project_service.workflowexecutions_googleapis_com 19513753240/workflowexecutions.googleapis.com

--- a/terraform-export/19513753240/Service/workflows-googleapis-com.tf
+++ b/terraform-export/19513753240/Service/workflows-googleapis-com.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "workflows_googleapis_com" {
+  project = "19513753240"
+  service = "workflows.googleapis.com"
+}
+# terraform import google_project_service.workflows_googleapis_com 19513753240/workflows.googleapis.com

--- a/terraform-export/278098142879/Project/govuk-knowledge-graph.tf
+++ b/terraform-export/278098142879/Project/govuk-knowledge-graph.tf
@@ -1,0 +1,14 @@
+resource "google_project" "govuk_knowledge_graph" {
+  auto_create_network = true
+  billing_account     = "015C7A-FAF970-B0D375"
+  folder_id           = "278098142879"
+
+  labels = {
+    programme = "cpto"
+    team      = "data-products"
+  }
+
+  name       = "govuk-knowledge-graph"
+  project_id = "govuk-knowledge-graph"
+}
+# terraform import google_project.govuk_knowledge_graph projects/govuk-knowledge-graph

--- a/terraform-export/govuk-knowledge-graph/BigQueryDataset/europe-west2/content.tf
+++ b/terraform-export/govuk-knowledge-graph/BigQueryDataset/europe-west2/content.tf
@@ -1,0 +1,34 @@
+resource "google_bigquery_dataset" "content" {
+  access {
+    role          = "OWNER"
+    special_group = "projectOwners"
+  }
+
+  access {
+    role          = "READER"
+    special_group = "projectReaders"
+  }
+
+  access {
+    role          = "READER"
+    user_by_email = "bigquery-page-transitions@govuk-knowledge-graph.iam.gserviceaccount.com"
+  }
+
+  access {
+    role          = "WRITER"
+    special_group = "projectWriters"
+  }
+
+  access {
+    role          = "WRITER"
+    user_by_email = "gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com"
+  }
+
+  dataset_id                 = "content"
+  delete_contents_on_destroy = false
+  description                = "GOV.UK content data"
+  friendly_name              = "content"
+  location                   = "europe-west2"
+  project                    = "govuk-knowledge-graph"
+}
+# terraform import google_bigquery_dataset.content projects/govuk-knowledge-graph/datasets/content

--- a/terraform-export/govuk-knowledge-graph/BigQueryDataset/europe-west2/temp.tf
+++ b/terraform-export/govuk-knowledge-graph/BigQueryDataset/europe-west2/temp.tf
@@ -1,0 +1,28 @@
+resource "google_bigquery_dataset" "temp" {
+  access {
+    role          = "OWNER"
+    special_group = "projectOwners"
+  }
+
+  access {
+    role          = "OWNER"
+    user_by_email = "duncan.garmonsway@digital.cabinet-office.gov.uk"
+  }
+
+  access {
+    role          = "READER"
+    special_group = "projectReaders"
+  }
+
+  access {
+    role          = "WRITER"
+    special_group = "projectWriters"
+  }
+
+  dataset_id                  = "temp"
+  default_table_expiration_ms = 604800000
+  delete_contents_on_destroy  = false
+  location                    = "europe-west2"
+  project                     = "govuk-knowledge-graph"
+}
+# terraform import google_bigquery_dataset.temp projects/govuk-knowledge-graph/datasets/temp

--- a/terraform-export/govuk-knowledge-graph/ComputeDisk/europe-west2-b/neo4j.tf
+++ b/terraform-export/govuk-knowledge-graph/ComputeDisk/europe-west2-b/neo4j.tf
@@ -1,0 +1,10 @@
+resource "google_compute_disk" "neo4j" {
+  image                     = "https://www.googleapis.com/compute/beta/projects/cos-cloud/global/images/cos-stable-101-17162-40-5"
+  name                      = "neo4j"
+  physical_block_size_bytes = 4096
+  project                   = "govuk-knowledge-graph"
+  size                      = 40
+  type                      = "pd-standard"
+  zone                      = "europe-west2-b"
+}
+# terraform import google_compute_disk.neo4j projects/govuk-knowledge-graph/zones/europe-west2-b/disks/neo4j

--- a/terraform-export/govuk-knowledge-graph/ComputeDisk/europe-west2-b/postgres.tf
+++ b/terraform-export/govuk-knowledge-graph/ComputeDisk/europe-west2-b/postgres.tf
@@ -1,0 +1,10 @@
+resource "google_compute_disk" "postgres" {
+  image                     = "https://www.googleapis.com/compute/beta/projects/cos-cloud/global/images/cos-stable-101-17162-40-5"
+  name                      = "postgres"
+  physical_block_size_bytes = 4096
+  project                   = "govuk-knowledge-graph"
+  size                      = 10
+  type                      = "pd-standard"
+  zone                      = "europe-west2-b"
+}
+# terraform import google_compute_disk.postgres projects/govuk-knowledge-graph/zones/europe-west2-b/disks/postgres

--- a/terraform-export/projects/govuk-knowledge-graph/ArtifactRegistryRepository/europe-west2/docker.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ArtifactRegistryRepository/europe-west2/docker.tf
@@ -1,0 +1,8 @@
+resource "google_artifact_registry_repository" "docker" {
+  description   = "Docker repository"
+  format        = "DOCKER"
+  location      = "europe-west2"
+  project       = "govuk-knowledge-graph"
+  repository_id = "docker"
+}
+# terraform import google_artifact_registry_repository.docker projects/govuk-knowledge-graph/locations/europe-west2/repositories/docker

--- a/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/body-lines.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/body-lines.tf
@@ -1,0 +1,8 @@
+resource "google_bigquery_table" "body_lines" {
+  dataset_id      = "temp"
+  expiration_time = 1665007134531
+  project         = "govuk-knowledge-graph"
+  schema          = "[{\"mode\":\"NULLABLE\",\"name\":\"string_field_0\",\"type\":\"STRING\"},{\"mode\":\"NULLABLE\",\"name\":\"string_field_1\",\"type\":\"STRING\"}]"
+  table_id        = "body_lines"
+}
+# terraform import google_bigquery_table.body_lines projects/govuk-knowledge-graph/datasets/temp/tables/body_lines

--- a/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/line-count-counts.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/line-count-counts.tf
@@ -1,0 +1,8 @@
+resource "google_bigquery_table" "line_count_counts" {
+  dataset_id      = "temp"
+  expiration_time = 1665007493057
+  project         = "govuk-knowledge-graph"
+  schema          = "[{\"name\":\"n\",\"type\":\"INTEGER\"},{\"name\":\"n_count\",\"type\":\"INTEGER\"}]"
+  table_id        = "line_count_counts"
+}
+# terraform import google_bigquery_table.line_count_counts projects/govuk-knowledge-graph/datasets/temp/tables/line_count_counts

--- a/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/line-counts.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/line-counts.tf
@@ -1,0 +1,8 @@
+resource "google_bigquery_table" "line_counts" {
+  dataset_id      = "temp"
+  expiration_time = 1665007491303
+  project         = "govuk-knowledge-graph"
+  schema          = "[{\"name\":\"string_field_1\",\"type\":\"STRING\"},{\"name\":\"n\",\"type\":\"INTEGER\"}]"
+  table_id        = "line_counts"
+}
+# terraform import google_bigquery_table.line_counts projects/govuk-knowledge-graph/datasets/temp/tables/line_counts

--- a/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/parts.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/parts.tf
@@ -1,0 +1,9 @@
+resource "google_bigquery_table" "parts" {
+  dataset_id    = "content"
+  description   = "URLs, base_paths, slugs, indexes and titles of parts of guide and travel_advice documents"
+  friendly_name = "URLs and titles of parts of guide and travel_advice documents"
+  project       = "govuk-knowledge-graph"
+  schema        = "[{\"description\":\"Complete URL of the part\",\"mode\":\"REQUIRED\",\"name\":\"url\",\"type\":\"STRING\"},{\"description\":\"URL of the parent document of the part\",\"mode\":\"REQUIRED\",\"name\":\"base_path\",\"type\":\"STRING\"},{\"description\":\"What to add to the base_path to get the url\",\"mode\":\"REQUIRED\",\"name\":\"slug\",\"type\":\"STRING\"},{\"description\":\"The order of the part among other parts in the same document, counting from 0\",\"mode\":\"REQUIRED\",\"name\":\"part_index\",\"type\":\"STRING\"},{\"description\":\"The title of the part\",\"mode\":\"REQUIRED\",\"name\":\"part_title\",\"type\":\"STRING\"}]"
+  table_id      = "parts"
+}
+# terraform import google_bigquery_table.parts projects/govuk-knowledge-graph/datasets/content/tables/parts

--- a/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/url.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/BigQueryTable/url.tf
@@ -1,0 +1,9 @@
+resource "google_bigquery_table" "url" {
+  dataset_id    = "content"
+  description   = "Unique URLs of static content on the www.gov.uk domain, not including parts of 'guide' and 'travel_advice' pages"
+  friendly_name = "GOV.UK unique URLs"
+  project       = "govuk-knowledge-graph"
+  schema        = "[{\"description\":\"URL of a piece of content on the www.gov.uk domain\",\"mode\":\"REQUIRED\",\"name\":\"url\",\"type\":\"STRING\"}]"
+  table_id      = "url"
+}
+# terraform import google_bigquery_table.url projects/govuk-knowledge-graph/datasets/content/tables/url

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeAddress/europe-west2/neo4j.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeAddress/europe-west2/neo4j.tf
@@ -1,0 +1,10 @@
+resource "google_compute_address" "neo4j" {
+  address      = "34.105.179.197"
+  address_type = "EXTERNAL"
+  description  = "Static external IP address for Neo4j instances"
+  name         = "neo4j"
+  network_tier = "PREMIUM"
+  project      = "govuk-knowledge-graph"
+  region       = "europe-west2"
+}
+# terraform import google_compute_address.neo4j projects/govuk-knowledge-graph/regions/europe-west2/addresses/neo4j

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeBackendService/global/govgraph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeBackendService/global/govgraph.tf
@@ -1,0 +1,12 @@
+resource "google_compute_backend_service" "govgraph" {
+  connection_draining_timeout_sec = 300
+  health_checks                   = ["https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/httpHealthChecks/govgraph"]
+  load_balancing_scheme           = "EXTERNAL"
+  name                            = "govgraph"
+  port_name                       = "http"
+  project                         = "govuk-knowledge-graph"
+  protocol                        = "HTTP"
+  session_affinity                = "NONE"
+  timeout_sec                     = 10
+}
+# terraform import google_compute_backend_service.govgraph projects/govuk-knowledge-graph/global/backendServices/govgraph

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-icmp.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-icmp.tf
@@ -1,0 +1,14 @@
+resource "google_compute_firewall" "default_allow_icmp" {
+  allow {
+    protocol = "icmp"
+  }
+
+  description   = "Allow ICMP from anywhere"
+  direction     = "INGRESS"
+  name          = "default-allow-icmp"
+  network       = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  priority      = 65534
+  project       = "govuk-knowledge-graph"
+  source_ranges = ["0.0.0.0/0"]
+}
+# terraform import google_compute_firewall.default_allow_icmp projects/govuk-knowledge-graph/global/firewalls/default-allow-icmp

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-internal.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-internal.tf
@@ -1,0 +1,24 @@
+resource "google_compute_firewall" "default_allow_internal" {
+  allow {
+    ports    = ["0-65535"]
+    protocol = "tcp"
+  }
+
+  allow {
+    ports    = ["0-65535"]
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  description   = "Allow internal traffic on the default network"
+  direction     = "INGRESS"
+  name          = "default-allow-internal"
+  network       = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  priority      = 65534
+  project       = "govuk-knowledge-graph"
+  source_ranges = ["10.128.0.0/9"]
+}
+# terraform import google_compute_firewall.default_allow_internal projects/govuk-knowledge-graph/global/firewalls/default-allow-internal

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-rdp.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-rdp.tf
@@ -1,0 +1,15 @@
+resource "google_compute_firewall" "default_allow_rdp" {
+  allow {
+    ports    = ["3389"]
+    protocol = "tcp"
+  }
+
+  description   = "Allow RDP from anywhere"
+  direction     = "INGRESS"
+  name          = "default-allow-rdp"
+  network       = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  priority      = 65534
+  project       = "govuk-knowledge-graph"
+  source_ranges = ["0.0.0.0/0"]
+}
+# terraform import google_compute_firewall.default_allow_rdp projects/govuk-knowledge-graph/global/firewalls/default-allow-rdp

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-ssh.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/default-allow-ssh.tf
@@ -1,0 +1,15 @@
+resource "google_compute_firewall" "default_allow_ssh" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+
+  description   = "Allow SSH from anywhere"
+  direction     = "INGRESS"
+  name          = "default-allow-ssh"
+  network       = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  priority      = 65534
+  project       = "govuk-knowledge-graph"
+  source_ranges = ["0.0.0.0/0"]
+}
+# terraform import google_compute_firewall.default_allow_ssh projects/govuk-knowledge-graph/global/firewalls/default-allow-ssh

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/firewall-neo4j-egress.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/firewall-neo4j-egress.tf
@@ -1,0 +1,15 @@
+resource "google_compute_firewall" "firewall_neo4j_egress" {
+  allow {
+    ports    = ["7473", "7687"]
+    protocol = "tcp"
+  }
+
+  destination_ranges      = ["213.86.153.211", "213.86.153.212", "213.86.153.213", "213.86.153.214", "213.86.153.231", "213.86.153.235", "213.86.153.236", "213.86.153.237", "51.149.8.0/25", "51.149.8.128/29"]
+  direction               = "EGRESS"
+  name                    = "firewall-neo4j-egress"
+  network                 = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  priority                = 1000
+  project                 = "govuk-knowledge-graph"
+  target_service_accounts = ["gce-neo4j@govuk-knowledge-graph.iam.gserviceaccount.com"]
+}
+# terraform import google_compute_firewall.firewall_neo4j_egress projects/govuk-knowledge-graph/global/firewalls/firewall-neo4j-egress

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/firewall-neo4j-ingress.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeFirewall/firewall-neo4j-ingress.tf
@@ -1,0 +1,15 @@
+resource "google_compute_firewall" "firewall_neo4j_ingress" {
+  allow {
+    ports    = ["7473", "7474", "7687"]
+    protocol = "tcp"
+  }
+
+  direction               = "INGRESS"
+  name                    = "firewall-neo4j-ingress"
+  network                 = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  priority                = 1000
+  project                 = "govuk-knowledge-graph"
+  source_ranges           = ["213.86.153.211", "213.86.153.212", "213.86.153.213", "213.86.153.214", "213.86.153.231", "213.86.153.235", "213.86.153.236", "213.86.153.237", "51.149.8.0/25", "51.149.8.128/29"]
+  target_service_accounts = ["gce-neo4j@govuk-knowledge-graph.iam.gserviceaccount.com"]
+}
+# terraform import google_compute_firewall.firewall_neo4j_ingress projects/govuk-knowledge-graph/global/firewalls/firewall-neo4j-ingress

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeForwardingRule/global/govgraph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeForwardingRule/global/govgraph.tf
@@ -1,0 +1,10 @@
+resource "google_compute_global_forwarding_rule" "govgraph" {
+  ip_address            = "34.120.89.80"
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  name                  = "govgraph"
+  port_range            = "443-443"
+  project               = "govuk-knowledge-graph"
+  target                = "https://www.googleapis.com/compute/beta/projects/govuk-knowledge-graph/global/targetHttpsProxies/govgraph"
+}
+# terraform import google_compute_global_forwarding_rule.govgraph projects/govuk-knowledge-graph/global/forwardingRules/govgraph

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeHTTPHealthCheck/govgraph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeHTTPHealthCheck/govgraph.tf
@@ -1,0 +1,11 @@
+resource "google_compute_http_health_check" "govgraph" {
+  check_interval_sec  = 1
+  healthy_threshold   = 2
+  name                = "govgraph"
+  port                = 80
+  project             = "govuk-knowledge-graph"
+  request_path        = "/"
+  timeout_sec         = 1
+  unhealthy_threshold = 2
+}
+# terraform import google_compute_http_health_check.govgraph projects/govuk-knowledge-graph/global/httpHealthChecks/govgraph

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeInstance/europe-west2-b/neo4j.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeInstance/europe-west2-b/neo4j.tf
@@ -1,0 +1,57 @@
+resource "google_compute_instance" "neo4j" {
+  boot_disk {
+    auto_delete = true
+    device_name = "persistent-disk-0"
+
+    initialize_params {
+      image = "https://www.googleapis.com/compute/beta/projects/cos-cloud/global/images/cos-stable-101-17162-40-5"
+      size  = 40
+      type  = "pd-standard"
+    }
+
+    mode   = "READ_WRITE"
+    source = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/zones/europe-west2-b/disks/neo4j"
+  }
+
+  machine_type = "e2-highmem-4"
+
+  metadata = {
+    gce-container-declaration = "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"NEO4JLABS_PLUGINS\"\n      \"value\": \"[\\\"apoc\\\"]\"\n    \"image\": \"europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/neo4j:latest\"\n    \"stdin\": true\n    \"tty\": true\n  \"restartPolicy\": \"OnFailure\"\n  \"volumes\": []\n"
+  }
+
+  name = "neo4j"
+
+  network_interface {
+    access_config {
+      nat_ip       = "34.105.209.240"
+      network_tier = "PREMIUM"
+    }
+
+    network            = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+    network_ip         = "10.154.0.3"
+    stack_type         = "IPV4_ONLY"
+    subnetwork         = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/regions/europe-west2/subnetworks/default"
+    subnetwork_project = "govuk-knowledge-graph"
+  }
+
+  project = "govuk-knowledge-graph"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
+  }
+
+  service_account {
+    email  = "gce-neo4j@govuk-knowledge-graph.iam.gserviceaccount.com"
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  shielded_instance_config {
+    enable_integrity_monitoring = true
+    enable_vtpm                 = true
+  }
+
+  zone = "europe-west2-b"
+}
+# terraform import google_compute_instance.neo4j projects/govuk-knowledge-graph/zones/europe-west2-b/instances/neo4j

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeInstance/europe-west2-b/postgres.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeInstance/europe-west2-b/postgres.tf
@@ -1,0 +1,64 @@
+resource "google_compute_instance" "postgres" {
+  boot_disk {
+    auto_delete = true
+    device_name = "persistent-disk-0"
+
+    initialize_params {
+      image = "https://www.googleapis.com/compute/beta/projects/cos-cloud/global/images/cos-stable-101-17162-40-5"
+      size  = 10
+      type  = "pd-standard"
+    }
+
+    mode   = "READ_WRITE"
+    source = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/zones/europe-west2-b/disks/postgres"
+  }
+
+  machine_type = "c2d-highmem-2"
+
+  metadata = {
+    object_bucket             = "govuk-s3-mirror_govuk-integration-database-backups"
+    user-data                 = "#cloud-config\n\nbootcmd:\n- mkfs.ext4 -F /dev/nvme0n1\n- mkdir -p /mnt/disks/local-ssd\n- mount -o discard,defaults,nobarrier /dev/nvme0n1 /mnt/disks/local-ssd\n- mkdir -p /mnt/disks/local-ssd/postgresql-data\n- mkdir -p /mnt/disks/local-ssd/data\n"
+    gce-container-declaration = "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"POSTGRES_HOST_AUTH_METHOD\"\n      \"value\": \"trust\"\n    \"image\": \"europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/postgres:latest\"\n    \"stdin\": true\n    \"tty\": true\n    \"volumeMounts\":\n    - \"mountPath\": \"/var/lib/postgresql/data\"\n      \"name\": \"local-ssd-postgresql-data\"\n      \"readOnly\": false\n    - \"mountPath\": \"/data\"\n      \"name\": \"local-ssd-data\"\n      \"readOnly\": false\n  \"restartPolicy\": \"Never\"\n  \"volumes\":\n  - \"hostPath\":\n      \"path\": \"/mnt/disks/local-ssd/postgresql-data\"\n    \"name\": \"local-ssd-postgresql-data\"\n  - \"hostPath\":\n      \"path\": \"/mnt/disks/local-ssd/data\"\n    \"name\": \"local-ssd-data\"\n"
+    object_name               = "publishing-api-postgres/2022-09-29T05:00:02-publishing_api_production.gz"
+  }
+
+  name = "postgres"
+
+  network_interface {
+    access_config {
+      nat_ip       = "35.214.84.153"
+      network_tier = "STANDARD"
+    }
+
+    network            = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+    network_ip         = "10.154.0.4"
+    stack_type         = "IPV4_ONLY"
+    subnetwork         = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/regions/europe-west2/subnetworks/default"
+    subnetwork_project = "govuk-knowledge-graph"
+  }
+
+  project = "govuk-knowledge-graph"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
+  }
+
+  scratch_disk {
+    interface = "NVME"
+  }
+
+  service_account {
+    email  = "gce-postgres@govuk-knowledge-graph.iam.gserviceaccount.com"
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  shielded_instance_config {
+    enable_integrity_monitoring = true
+    enable_vtpm                 = true
+  }
+
+  zone = "europe-west2-b"
+}
+# terraform import google_compute_instance.postgres projects/govuk-knowledge-graph/zones/europe-west2-b/instances/postgres

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeInstanceTemplate/mongodb.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeInstanceTemplate/mongodb.tf
@@ -1,0 +1,48 @@
+resource "google_compute_instance_template" "mongodb" {
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disk-0"
+    disk_size_gb = 20
+    disk_type    = "pd-standard"
+    interface    = "SCSI"
+    mode         = "READ_WRITE"
+    source_image = "projects/cos-cloud/global/images/cos-stable-101-17162-40-5"
+    type         = "PERSISTENT"
+  }
+
+  labels = {
+    managed-by-cnrm = "true"
+  }
+
+  machine_type = "e2-highcpu-32"
+
+  metadata = {
+    gce-container-declaration = "\"spec\":\n  \"containers\":\n  - \"image\": \"europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/mongodb:latest\"\n    \"stdin\": true\n    \"tty\": true\n    \"volumeMounts\":\n    - \"mountPath\": \"/data/db\"\n      \"name\": \"tempfs-0\"\n      \"readOnly\": false\n    - \"mountPath\": \"/data/configdb\"\n      \"name\": \"tempfs-1\"\n      \"readOnly\": false\n  \"restartPolicy\": \"Never\"\n  \"volumes\":\n  - \"emptyDir\":\n      \"medium\": \"Memory\"\n    \"name\": \"tempfs-0\"\n  - \"emptyDir\":\n      \"medium\": \"Memory\"\n    \"name\": \"tempfs-1\"\n"
+  }
+
+  name = "mongodb"
+
+  network_interface {
+    access_config {
+      nat_ip       = "35.214.119.84"
+      network_tier = "STANDARD"
+    }
+
+    network = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  }
+
+  project = "govuk-knowledge-graph"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
+  }
+
+  service_account {
+    email  = "gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com"
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+# terraform import google_compute_instance_template.mongodb projects/govuk-knowledge-graph/global/instanceTemplates/mongodb

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeInstanceTemplate/neo4j.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeInstanceTemplate/neo4j.tf
@@ -1,0 +1,50 @@
+resource "google_compute_instance_template" "neo4j" {
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disk-0"
+    disk_size_gb = 40
+    disk_type    = "pd-standard"
+    interface    = "SCSI"
+    mode         = "READ_WRITE"
+    source_image = "projects/cos-cloud/global/images/cos-stable-101-17162-40-5"
+    type         = "PERSISTENT"
+  }
+
+  labels = {
+    managed-by-cnrm = "true"
+  }
+
+  machine_type = "e2-highmem-4"
+
+  metadata = {
+    gce-container-declaration = "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"NEO4JLABS_PLUGINS\"\n      \"value\": \"[\\\"apoc\\\"]\"\n    \"image\": \"europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/neo4j:latest\"\n    \"stdin\": true\n    \"tty\": true\n  \"restartPolicy\": \"OnFailure\"\n  \"volumes\": []\n"
+  }
+
+  name = "neo4j"
+
+  network_interface {
+    access_config {
+      nat_ip       = "34.105.179.197"
+      network_tier = "PREMIUM"
+    }
+
+    network = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  }
+
+  project = "govuk-knowledge-graph"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
+  }
+
+  service_account {
+    email  = "gce-neo4j@govuk-knowledge-graph.iam.gserviceaccount.com"
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  tags = ["allow-health-check"]
+}
+# terraform import google_compute_instance_template.neo4j projects/govuk-knowledge-graph/global/instanceTemplates/neo4j

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeInstanceTemplate/postgres.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeInstanceTemplate/postgres.tf
@@ -1,0 +1,58 @@
+resource "google_compute_instance_template" "postgres" {
+  disk {
+    auto_delete  = true
+    boot         = true
+    device_name  = "persistent-disk-0"
+    disk_size_gb = 10
+    disk_type    = "pd-standard"
+    interface    = "SCSI"
+    mode         = "READ_WRITE"
+    source_image = "projects/cos-cloud/global/images/cos-stable-101-17162-40-5"
+    type         = "PERSISTENT"
+  }
+
+  disk {
+    auto_delete  = true
+    device_name  = "local-ssd"
+    disk_size_gb = 375
+    disk_type    = "local-ssd"
+    interface    = "NVME"
+    mode         = "READ_WRITE"
+    type         = "SCRATCH"
+  }
+
+  labels = {
+    managed-by-cnrm = "true"
+  }
+
+  machine_type = "c2d-highmem-2"
+
+  metadata = {
+    gce-container-declaration = "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"POSTGRES_HOST_AUTH_METHOD\"\n      \"value\": \"trust\"\n    \"image\": \"europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/postgres:latest\"\n    \"stdin\": true\n    \"tty\": true\n    \"volumeMounts\":\n    - \"mountPath\": \"/var/lib/postgresql/data\"\n      \"name\": \"local-ssd-postgresql-data\"\n      \"readOnly\": false\n    - \"mountPath\": \"/data\"\n      \"name\": \"local-ssd-data\"\n      \"readOnly\": false\n  \"restartPolicy\": \"Never\"\n  \"volumes\":\n  - \"hostPath\":\n      \"path\": \"/mnt/disks/local-ssd/postgresql-data\"\n    \"name\": \"local-ssd-postgresql-data\"\n  - \"hostPath\":\n      \"path\": \"/mnt/disks/local-ssd/data\"\n    \"name\": \"local-ssd-data\"\n"
+    user-data                 = "#cloud-config\n\nbootcmd:\n- mkfs.ext4 -F /dev/nvme0n1\n- mkdir -p /mnt/disks/local-ssd\n- mount -o discard,defaults,nobarrier /dev/nvme0n1 /mnt/disks/local-ssd\n- mkdir -p /mnt/disks/local-ssd/postgresql-data\n- mkdir -p /mnt/disks/local-ssd/data\n"
+  }
+
+  name = "postgres"
+
+  network_interface {
+    access_config {
+      network_tier = "STANDARD"
+    }
+
+    network = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/networks/default"
+  }
+
+  project = "govuk-knowledge-graph"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
+  }
+
+  service_account {
+    email  = "gce-postgres@govuk-knowledge-graph.iam.gserviceaccount.com"
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+# terraform import google_compute_instance_template.postgres projects/govuk-knowledge-graph/global/instanceTemplates/postgres

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeSSLCertificate/global/govgraph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeSSLCertificate/global/govgraph.tf
@@ -1,0 +1,5 @@
+resource "google_compute_ssl_certificate" "govgraph" {
+  name    = "govgraph"
+  project = "govuk-knowledge-graph"
+}
+# terraform import google_compute_ssl_certificate.govgraph projects/govuk-knowledge-graph/global/sslCertificates/govgraph

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeTargetHTTPSProxy/global/govgraph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeTargetHTTPSProxy/global/govgraph.tf
@@ -1,0 +1,8 @@
+resource "google_compute_target_https_proxy" "govgraph" {
+  name             = "govgraph"
+  project          = "govuk-knowledge-graph"
+  quic_override    = "NONE"
+  ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/sslCertificates/govgraph"]
+  url_map          = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/urlMaps/govgraph"
+}
+# terraform import google_compute_target_https_proxy.govgraph projects/govuk-knowledge-graph/global/targetHttpsProxies/govgraph

--- a/terraform-export/projects/govuk-knowledge-graph/ComputeURLMap/global/govgraph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/ComputeURLMap/global/govgraph.tf
@@ -1,0 +1,24 @@
+resource "google_compute_url_map" "govgraph" {
+  default_service = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/backendServices/govgraph"
+  description     = "URL map for govgraph.dev"
+
+  host_rule {
+    hosts        = ["govgraph.dev."]
+    path_matcher = "allpaths"
+  }
+
+  name = "govgraph"
+
+  path_matcher {
+    default_service = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/backendServices/govgraph"
+    name            = "allpaths"
+
+    path_rule {
+      paths   = ["/*"]
+      service = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/backendServices/govgraph"
+    }
+  }
+
+  project = "govuk-knowledge-graph"
+}
+# terraform import google_compute_url_map.govgraph projects/govuk-knowledge-graph/global/urlMaps/govgraph

--- a/terraform-export/projects/govuk-knowledge-graph/DNSManagedZone/govgraph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/DNSManagedZone/govgraph.tf
@@ -1,0 +1,9 @@
+resource "google_dns_managed_zone" "govgraph" {
+  description   = "DNS zone for .dev domains"
+  dns_name      = "govgraph.dev."
+  force_destroy = false
+  name          = "govgraph"
+  project       = "govuk-knowledge-graph"
+  visibility    = "public"
+}
+# terraform import google_dns_managed_zone.govgraph projects/govuk-knowledge-graph/managedZones/govgraph

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/19513753240-compute.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/19513753240-compute.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "19513753240_compute" {
+  account_id   = "19513753240-compute"
+  display_name = "Compute Engine default service account"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.19513753240_compute projects/govuk-knowledge-graph/serviceAccounts/19513753240-compute@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/artifact-registry-docker.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/artifact-registry-docker.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "artifact_registry_docker" {
+  account_id   = "artifact-registry-docker"
+  description  = "Service account for pushing docker images"
+  display_name = "Artifact Registry Service Account for Docker"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.artifact_registry_docker projects/govuk-knowledge-graph/serviceAccounts/artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/bigquery-page-transitions.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/bigquery-page-transitions.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "bigquery_page_transitions" {
+  account_id   = "bigquery-page-transitions"
+  description  = "Service account for a scheduled BigQuery query of page-to-page transition counts"
+  display_name = "Service account for page transitions query"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.bigquery_page_transitions projects/govuk-knowledge-graph/serviceAccounts/bigquery-page-transitions@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/eventarc.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/eventarc.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "eventarc" {
+  account_id   = "eventarc"
+  display_name = "Service account for EventArc to trigger workflows"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.eventarc projects/govuk-knowledge-graph/serviceAccounts/eventarc@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/gce-mongodb.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/gce-mongodb.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "gce_mongodb" {
+  account_id   = "gce-mongodb"
+  description  = "Service account for the MongoDB instance on GCE"
+  display_name = "Service Account for MongoDB Instance"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.gce_mongodb projects/govuk-knowledge-graph/serviceAccounts/gce-mongodb@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/gce-neo4j.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/gce-neo4j.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "gce_neo4j" {
+  account_id   = "gce-neo4j"
+  description  = "Service account for the Neo4j instance on GCE"
+  display_name = "Service Account for Neo4j Instance"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.gce_neo4j projects/govuk-knowledge-graph/serviceAccounts/gce-neo4j@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/gce-postgres.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/gce-postgres.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "gce_postgres" {
+  account_id   = "gce-postgres"
+  description  = "Service account for the postgres instance on GCE"
+  display_name = "Service Account for postgres Instance"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.gce_postgres projects/govuk-knowledge-graph/serviceAccounts/gce-postgres@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/govuk-knowledge-graph.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/govuk-knowledge-graph.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "govuk_knowledge_graph" {
+  account_id   = "govuk-knowledge-graph"
+  display_name = "App Engine default service account"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.govuk_knowledge_graph projects/govuk-knowledge-graph/serviceAccounts/govuk-knowledge-graph@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/scheduler-neo4j.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/scheduler-neo4j.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "scheduler_neo4j" {
+  account_id   = "scheduler-neo4j"
+  description  = "Service Account for scheduling the Neo4j workflow"
+  display_name = "Service Account for scheduling the Neo4j workflow"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.scheduler_neo4j projects/govuk-knowledge-graph/serviceAccounts/scheduler-neo4j@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/source-repositories-github.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/source-repositories-github.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "source_repositories_github" {
+  account_id   = "source-repositories-github"
+  description  = "Service account for pushing git repositories from GitHub Actions"
+  display_name = "Source Repositories Service Account for GitHub"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.source_repositories_github projects/govuk-knowledge-graph/serviceAccounts/source-repositories-github@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/storage-github.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/storage-github.tf
@@ -1,0 +1,7 @@
+resource "google_service_account" "storage_github" {
+  account_id   = "storage-github"
+  description  = "Service account for using Cloud Storage from GitHub Actions"
+  display_name = "Storage Service Account for GitHub"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.storage_github projects/govuk-knowledge-graph/serviceAccounts/storage-github@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/workflow-database-backups.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/workflow-database-backups.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "workflow_database_backups" {
+  account_id   = "workflow-database-backups"
+  display_name = "Service account for the govuk-integration-database-backups workflow"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.workflow_database_backups projects/govuk-knowledge-graph/serviceAccounts/workflow-database-backups@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/workflow-neo4j.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/IAMServiceAccount/workflow-neo4j.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "workflow_neo4j" {
+  account_id   = "workflow-neo4j"
+  display_name = "Service account for the neo4j workflow"
+  project      = "govuk-knowledge-graph"
+}
+# terraform import google_service_account.workflow_neo4j projects/govuk-knowledge-graph/serviceAccounts/workflow-neo4j@govuk-knowledge-graph.iam.gserviceaccount.com

--- a/terraform-export/projects/govuk-knowledge-graph/PubSubSubscription/eventarc-europe-west2-govuk-integration-database-backups-sub-934.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/PubSubSubscription/eventarc-europe-west2-govuk-integration-database-backups-sub-934.tf
@@ -1,0 +1,28 @@
+resource "google_pubsub_subscription" "eventarc_europe_west2_govuk_integration_database_backups_sub_934" {
+  ack_deadline_seconds = 10
+
+  labels = {
+    goog-eventarc = ""
+  }
+
+  message_retention_duration = "86400s"
+  name                       = "eventarc-europe-west2-govuk-integration-database-backups-sub-934"
+  project                    = "govuk-knowledge-graph"
+
+  push_config {
+    oidc_token {
+      audience              = "https://workflowexecutions.googleapis.com/v1/projects/govuk-knowledge-graph/locations/europe-west2/workflows/govuk-integration-database-backups:triggerPubsubExecution"
+      service_account_email = "eventarc@govuk-knowledge-graph.iam.gserviceaccount.com"
+    }
+
+    push_endpoint = "https://workflowexecutions.googleapis.com/v1/projects/govuk-knowledge-graph/locations/europe-west2/workflows/govuk-integration-database-backups:triggerPubsubExecution?__GCP_CloudEventsMode=CUSTOM_PUBSUB_projects%2Fgovuk-knowledge-graph%2Ftopics%2Fgovuk-integration-database-backups"
+  }
+
+  retry_policy {
+    maximum_backoff = "600s"
+    minimum_backoff = "10s"
+  }
+
+  topic = "projects/govuk-knowledge-graph/topics/govuk-integration-database-backups"
+}
+# terraform import google_pubsub_subscription.eventarc_europe_west2_govuk_integration_database_backups_sub_934 projects/govuk-knowledge-graph/subscriptions/eventarc-europe-west2-govuk-integration-database-backups-sub-934

--- a/terraform-export/projects/govuk-knowledge-graph/PubSubSubscription/govuk-integration-database-backups.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/PubSubSubscription/govuk-integration-database-backups.tf
@@ -1,0 +1,9 @@
+resource "google_pubsub_subscription" "govuk_integration_database_backups" {
+  ack_deadline_seconds       = 10
+  message_retention_duration = "604800s"
+  name                       = "govuk-integration-database-backups"
+  project                    = "govuk-knowledge-graph"
+  retain_acked_messages      = true
+  topic                      = "projects/govuk-knowledge-graph/topics/govuk-integration-database-backups"
+}
+# terraform import google_pubsub_subscription.govuk_integration_database_backups projects/govuk-knowledge-graph/subscriptions/govuk-integration-database-backups

--- a/terraform-export/projects/govuk-knowledge-graph/PubSubTopic/govuk-integration-database-backups.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/PubSubTopic/govuk-integration-database-backups.tf
@@ -1,0 +1,11 @@
+resource "google_pubsub_topic" "govuk_integration_database_backups" {
+  message_retention_duration = "604800s"
+
+  message_storage_policy {
+    allowed_persistence_regions = ["europe-west2"]
+  }
+
+  name    = "govuk-integration-database-backups"
+  project = "govuk-knowledge-graph"
+}
+# terraform import google_pubsub_topic.govuk_integration_database_backups projects/govuk-knowledge-graph/topics/govuk-integration-database-backups

--- a/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EU/eu-artifacts-govuk-knowledge-graph-appspot-com.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EU/eu-artifacts-govuk-knowledge-graph-appspot-com.tf
@@ -1,0 +1,9 @@
+resource "google_storage_bucket" "eu_artifacts_govuk_knowledge_graph_appspot_com" {
+  force_destroy            = false
+  location                 = "EU"
+  name                     = "eu.artifacts.govuk-knowledge-graph.appspot.com"
+  project                  = "govuk-knowledge-graph"
+  public_access_prevention = "inherited"
+  storage_class            = "STANDARD"
+}
+# terraform import google_storage_bucket.eu_artifacts_govuk_knowledge_graph_appspot_com eu.artifacts.govuk-knowledge-graph.appspot.com

--- a/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-appspot-com.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-appspot-com.tf
@@ -1,0 +1,9 @@
+resource "google_storage_bucket" "govuk_knowledge_graph_appspot_com" {
+  force_destroy            = false
+  location                 = "EUROPE-WEST2"
+  name                     = "govuk-knowledge-graph.appspot.com"
+  project                  = "govuk-knowledge-graph"
+  public_access_prevention = "inherited"
+  storage_class            = "STANDARD"
+}
+# terraform import google_storage_bucket.govuk_knowledge_graph_appspot_com govuk-knowledge-graph.appspot.com

--- a/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-data-processed.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-data-processed.tf
@@ -1,0 +1,26 @@
+resource "google_storage_bucket" "govuk_knowledge_graph_data_processed" {
+  force_destroy = false
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age        = 7
+      with_state = "ANY"
+    }
+  }
+
+  location                    = "EUROPE-WEST2"
+  name                        = "govuk-knowledge-graph-data-processed"
+  project                     = "govuk-knowledge-graph"
+  public_access_prevention    = "inherited"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = false
+  }
+}
+# terraform import google_storage_bucket.govuk_knowledge_graph_data_processed govuk-knowledge-graph-data-processed

--- a/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-repository.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-repository.tf
@@ -1,0 +1,14 @@
+resource "google_storage_bucket" "govuk_knowledge_graph_repository" {
+  force_destroy               = false
+  location                    = "EUROPE-WEST2"
+  name                        = "govuk-knowledge-graph-repository"
+  project                     = "govuk-knowledge-graph"
+  public_access_prevention    = "inherited"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = false
+  }
+}
+# terraform import google_storage_bucket.govuk_knowledge_graph_repository govuk-knowledge-graph-repository

--- a/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-tfstate.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/govuk-knowledge-graph-tfstate.tf
@@ -1,0 +1,14 @@
+resource "google_storage_bucket" "govuk_knowledge_graph_tfstate" {
+  force_destroy               = false
+  location                    = "EUROPE-WEST2"
+  name                        = "govuk-knowledge-graph-tfstate"
+  project                     = "govuk-knowledge-graph"
+  public_access_prevention    = "inherited"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+}
+# terraform import google_storage_bucket.govuk_knowledge_graph_tfstate govuk-knowledge-graph-tfstate

--- a/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/staging-govuk-knowledge-graph-appspot-com.tf
+++ b/terraform-export/projects/govuk-knowledge-graph/StorageBucket/EUROPE-WEST2/staging-govuk-knowledge-graph-appspot-com.tf
@@ -1,0 +1,21 @@
+resource "google_storage_bucket" "staging_govuk_knowledge_graph_appspot_com" {
+  force_destroy = false
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age        = 15
+      with_state = "ANY"
+    }
+  }
+
+  location                 = "EUROPE-WEST2"
+  name                     = "staging.govuk-knowledge-graph.appspot.com"
+  project                  = "govuk-knowledge-graph"
+  public_access_prevention = "inherited"
+  storage_class            = "STANDARD"
+}
+# terraform import google_storage_bucket.staging_govuk_knowledge_graph_appspot_com staging.govuk-knowledge-graph.appspot.com


### PR DESCRIPTION
Gov Graph Search hasn't been terraformed, so recovery from disaster
depends on us remembering how to rebuild it.  This commit contains the
automatic terraform config exported from GCP, which will help us to
recover from disasters, and when we get around to terraforming it by
hand.

This isn't intended to be merged.