### PR TITLE
Add Transaction as a new node type

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -318,6 +318,11 @@ FIELDTERMINATOR ','
 MATCH (p:Page { url: line.url })
 MERGE (q:Page { url: line.link_url_bare })
 CREATE (p)-[:TRANSACTION_STARTS_AT { linkUrl: line.link_url_bare }]->(q)
+CREATE (s:Transaction {
+  url: line.link_url_bare,
+  name: p.title,
+  description: p.description
+})-[:HAS_START_PAGE]->(p)
 ;
 
 // Transaction start button text


### PR DESCRIPTION
Since transactions are marked as such in the content store it's possible to make them first-class nodes in the Graph. That would for instance make it possible to show an info-box about the service when the user searched for it (e.g. 'universal credit' would show the description and direct link in the info-box)