### PR TITLE
Index Neo4j for fulltext search

### DIFF
--- a/src/neo4j/index.cypher
+++ b/src/neo4j/index.cypher
@@ -1,0 +1,43 @@
+CREATE FULLTEXT INDEX title IF NOT EXISTS
+FOR (n:Page)
+ON EACH [n.title]
+OPTIONS {
+  indexConfig: {
+    `fulltext.analyzer`: 'standard',
+    `fulltext.eventually_consistent`: false
+  }
+}
+;
+
+CREATE FULLTEXT INDEX description IF NOT EXISTS
+FOR (n:Page)
+ON EACH [n.description]
+OPTIONS {
+  indexConfig: {
+    `fulltext.analyzer`: 'standard',
+    `fulltext.eventually_consistent`: false
+  }
+}
+;
+
+CREATE FULLTEXT INDEX text IF NOT EXISTS
+FOR (n:Page)
+ON EACH [n.text]
+OPTIONS {
+  indexConfig: {
+    `fulltext.analyzer`: 'standard',
+    `fulltext.eventually_consistent`: false
+  }
+}
+;
+
+CREATE FULLTEXT INDEX title_description_text IF NOT EXISTS
+FOR (n:Page)
+ON EACH [n.title, n.description, n.text]
+OPTIONS {
+  indexConfig: {
+    `fulltext.analyzer`: 'standard',
+    `fulltext.eventually_consistent`: false
+  }
+}
+;


### PR DESCRIPTION
Indexes speed up keyword such from several seconds to less than a second.  Below is a comparison, which also shows how queries must be rewritten to use an index.  The figures to pay attention to are "results consumed after another", which is 18s without the index, and 8ms with the index.  The first result becomes available very quickly in both cases; the search without an index is slow to retrieve the remaining results.

The table compares the top 10 results of each case.  There are two differences, which don't seem significant.  The ordering (by pagerank) is the same, so the difference must be in how the search string is matched to the index vs the original text -- perhaps some kind of tokenisation is going on.

```cypher
// Not using an index
MATCH(n: Page)
WHERE NOT n.documentType IN['gone', 'redirect', 'placeholder', 'placeholder_person']
WITH * WHERE
(toLower(n.text) CONTAINS toLower("children born in the uk"))
RETURN
n.url as url
ORDER BY n.pagerank DESC
LIMIT 10
;
```

```text
10 rows
ready to start consuming query after 38 ms, results consumed after another 18243 ms
```

```cypher
// Using an index
CALL db.index.fulltext.queryNodes("text", '"children born in the uk"')
YIELD node as n, score
WITH n
WHERE NOT n.documentType IN['gone', 'redirect', 'placeholder', 'placeholder_person']
RETURN
n.url as url
ORDER BY n.pagerank DESC
LIMIT 10
;
```

```text
10 rows
ready to start consuming query after 33 ms, results consumed after another 8 ms
```

|                                                                              Without index                                                                             |                                                                               With index                                                                               |
|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
|                                                                                                                                                                        | https://www.gov.uk/apply-citizenship-british-parent                                                                                                                    |
| https://www.gov.uk/settlement-refugee-or-humanitarian-protection                                                                                                       | https://www.gov.uk/settlement-refugee-or-humanitarian-protection                                                                                                       |
| https://www.gov.uk/government/publications/applying-for-a-passport-from-outside-the-uk-applicants-with-links-to-the-philippines/applying-for-a-passport-outside-the-uk | https://www.gov.uk/government/publications/applying-for-a-passport-from-outside-the-uk-applicants-with-links-to-the-philippines/applying-for-a-passport-outside-the-uk |
| https://www.gov.uk/government/publications/continuous-residence/continuous-residence-guidance-accessible-version                                                       | https://www.gov.uk/government/publications/continuous-residence/continuous-residence-guidance-accessible-version                                                       |
|                                                                                                                                                                        | https://www.gov.uk/government/publications/birth-certificates-and-the-full-birth-certificate-policy/birth-certificates-and-the-full-birth-certificate-policy           |
| https://www.gov.uk/government/publications/form-mn1-guidance/form-mn1-guidance-accessible-version                                                                      | https://www.gov.uk/government/publications/form-mn1-guidance/form-mn1-guidance-accessible-version                                                                      |
| https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk                                                                                                       | https://www.gov.uk/guidance/indefinite-leave-to-remain-in-the-uk                                                                                                       |
| https://www.gov.uk/government/publications/automatic-acquisition-nationality-policy-guidance/automatic-acquisition                                                     | https://www.gov.uk/government/publications/automatic-acquisition-nationality-policy-guidance/automatic-acquisition                                                     |
| https://www.gov.uk/government/publications/family-reunion-instruction/family-reunion-accessible                                                                        | https://www.gov.uk/government/publications/family-reunion-instruction/family-reunion-accessible                                                                        |
| https://www.gov.uk/guidance/healthcare-for-eu-and-efta-nationals-living-in-the-uk                                                                                      | https://www.gov.uk/guidance/healthcare-for-eu-and-efta-nationals-living-in-the-uk                                                                                      |
| https://www.gov.uk/guidance/immigration-rules/immigration-rules-appendix-settlement-family-life                                                                        |                                                                                                                                                                        |
| https://www.gov.uk/government/publications/collective-passport-nationality-questionnaire-and-parental-consent-for-for-children-born-in-the-uk                          |                                                                                                                                                                        |