### PR TITLE
Load-test Neo4j for Gov Graph Search

### DIFF
--- a/load-testing/README.md
+++ b/load-testing/README.md
@@ -1,0 +1,57 @@
+# Load testing of Neo4j
+
+Can Neo4j handle enough concurrent requests from Gov Graph Search?  We use
+[locust](https://docs.locust.io/en/stable/what-is-locust.html) to find out.
+
+The code in this directory has been adapted from
+https://github.com/QAInsights/neo4j-locust, as follows:
+
+- Everything from `neo4j-locust/requirements.txt` was removed except for the
+  entries for `locust` and `neo4j`, but their version numbers were removed too,
+  because of this issue: https://github.com/locustio/locust/issues/1759.
+- The connection string was changed from `bolt` to `neo4j+s`.
+- The query to be executed was changed, for relevance.
+
+## Use
+
+SSH into a running Neo4j instance of the Knowledge Graph.  For example:
+
+```shell
+gcloud compute ssh --zone "europe-west2-b" "neo4j" --project "govuk-knowledge-graph" --container "klt--pdoq"
+```
+
+The container ID might have changed.  It can be found by omitting `--container`,
+to SSH into the instance hosting the container, and then using `docker ps` to
+show the name of the container.
+
+Install python and venv, create a virtual environment, and install the
+dependencies.
+
+```shell
+apt install python3-venv
+python3 -m venv venv
+. venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+Temporariliy raise the limit of the number of files that processes in the shell
+are allowed to open.
+
+- https://github.com/locustio/locust/wiki/Installation#increasing-maximum-number-of-open-files-limit
+- https://wiki.archlinux.org/title/Limits.conf
+
+```shell
+ulimit -Sn unlimited
+```
+
+Run locust.  Redirect stdout to `/dev/null`.  Statistics are reported via
+stderror.
+
+```shell
+locust -f locustfile.py --headless --users 100 --spawn-rate 10 1>/dev/null
+```
+
+Neo4j is currently configured to only allow 100 concurrent requests, so there is
+no point simulating more than that, unless we really do need to serve more than
+that number of users, in which case we could reconfigure that, or use a
+different database.

--- a/load-testing/neo4j-locust/README.md
+++ b/load-testing/neo4j-locust/README.md
@@ -1,0 +1,43 @@
+# Locust Library for Neo4j database
+
+This library helps you to performance test the neo4j database from Locust.
+
+## Install
+
+`git clone https://github.com/QAInsights/neo4j-locust`  
+`cd neo4j-locust`  
+`pip install -r requirements.txt`
+
+## Usage
+
+`from neo4j_client import *`
+
+### Boilerplate
+
+```
+class Neo4jTasks(SequentialTaskSet):
+    def on_start(self):
+        try:
+            self.client.connect("naveenkumar", "neo4j")
+        except ConnectionError as exception:
+            logging.info(f"Caught {exception}")
+            self.user.environment.runner.quit()
+
+    @task
+    def send_query(self):
+        cypher_query = '''
+        MATCH (n:Actor) RETURN n LIMIT 25
+        '''
+        database = "neo4j"
+
+        res = self.client.send(cypher_query, database)
+        
+    def on_stop(self):
+        self.client.disconnect()
+
+class Neo4jCustom(Neo4jUser):
+    tasks = [Neo4jTasks]
+    host = "localhost:7687"
+    wait_time = constant(1)
+
+```

--- a/load-testing/neo4j-locust/locustfile.py
+++ b/load-testing/neo4j-locust/locustfile.py
@@ -1,0 +1,67 @@
+from locust import constant, SequentialTaskSet
+
+from neo4j_client import *
+
+
+class Neo4jTasks(SequentialTaskSet):
+
+    def on_start(self):
+        try:
+            self.client.connect("neo4j", "password")
+        except ConnectionError as exception:
+            logging.info(f"Caught {exception}")
+            self.user.environment.runner.quit()
+
+    @task
+    def send_query(self):
+        cypher_query = '''
+            CALL db.index.fulltext.queryNodes("description_text", 'children born in the uk')
+            YIELD node as n, score
+            WITH n, score
+            ORDER BY score DESC
+            LIMIT 50
+            WITH n
+            WHERE NOT n.documentType IN['gone', 'redirect', 'placeholder', 'placeholder_person']
+            OPTIONAL MATCH(n: Page) - [: IS_TAGGED_TO] -> (taxon:Taxon)
+            OPTIONAL MATCH(n: Page) - [r: HAS_PRIMARY_PUBLISHING_ORGANISATION] -> (o:Organisation)
+            OPTIONAL MATCH(n: Page) - [: HAS_ORGANISATIONS] -> (o2:Organisation)
+            RETURN
+              n.url as url,
+              n.title AS title,
+              n.documentType AS documentType,
+              n.contentID AS contentID,
+              n.locale AS locale,
+              n.publishingApp AS publishing_app,
+              n.firstPublishedAt AS first_published_at,
+              n.publicUpdatedAt AS public_updated_at,
+              n.withdrawnAt AS withdrawn_at,
+              n.withdrawnExplanation AS withdrawn_explanation,
+              n.pagerank AS pagerank,
+              COLLECT(distinct taxon.name) AS taxons,
+              COLLECT(distinct o.name) AS primary_organisation,
+              COLLECT(distinct o2.name) AS all_organisations
+            ORDER BY n.pagerank DESC
+            ;
+        '''
+        database = "neo4j"
+
+        res = self.client.send(cypher_query, database)
+        # print(res)
+
+    # @task
+    # def write_query(self):
+    #     cypher_query = '''
+    #     CREATE (u:User { name: "dataproducts", userId: "714" })
+    #     '''
+    #     database = "neo4j"
+    #     res = self.client.write(cypher_query, database)
+    #     print(res)
+
+    def on_stop(self):
+        self.client.disconnect()
+
+
+class Neo4jCustom(Neo4jUser):
+    tasks = [Neo4jTasks]
+    host = "govgraph.dev:7687"
+    wait_time = constant(1)

--- a/load-testing/neo4j-locust/neo4j_client/__init__.py
+++ b/load-testing/neo4j-locust/neo4j_client/__init__.py
@@ -1,0 +1,1 @@
+from .neo4j_client_package import *

--- a/load-testing/neo4j-locust/neo4j_client/neo4j_client_package.py
+++ b/load-testing/neo4j-locust/neo4j_client/neo4j_client_package.py
@@ -1,0 +1,114 @@
+from neo4j import GraphDatabase, basic_auth
+from neo4j.exceptions import *
+from neo4j._exceptions import *
+from locust import events, User, task
+
+import logging
+import inspect
+import time
+
+"""Return a duration
+
+Decorator to measure the timings for the tasks.
+"""
+
+
+def stopwatch(func):
+    def wrapper(*args, **kwargs):
+        previous_frame = inspect.currentframe().f_back
+        _, _, task_name, _, _ = inspect.getframeinfo(previous_frame)
+        start = time.time()
+        result = None
+        try:
+            result = func(*args, **kwargs)
+        except Exception as e:
+            total = int((time.time() - start) * 1000)
+            events.request_failure.fire(request_type="TYPE",
+                                        name=task_name,
+                                        response_time=total,
+                                        exception=e)
+        else:
+            total = int((time.time() - start) * 1000)
+            events.request_success.fire(request_type="TYPE",
+                                        name=task_name,
+                                        response_time=total,
+                                        response_length=0)
+        return result
+
+    return wrapper
+
+
+"""Class for the Neo4j Client """
+
+
+class Neo4jClient(User):
+    abstract = True
+
+    def __init__(self, host):
+        self.host = host
+        # self.username = username
+        # self.password = password
+        self.driver = None
+
+    """Connects to neo4j database"""
+
+    def connect(self, username, password):
+        bolt_url = "neo4j+s://" + self.host
+        try:
+            self.driver = GraphDatabase.driver(
+                bolt_url,
+                auth=basic_auth(username, password))
+            print("Connected to the database successfully")
+
+        except ConnectionError as exception:
+            logging.error(f"Caught 1 {exception}")
+            self.environment.runner.quit()
+        except BoltHandshakeError as exception:
+            logging.error(f"Caught 2 {exception}")
+            self.environment.runner.quit()
+        except ServiceUnavailable as exception:
+            logging.error(f"Caught 3 {exception}")
+            self.environment.runner.quit()
+
+    """Send query to neo4j"""
+
+    @stopwatch
+    def send(self, cypher_query, database):
+        with self.driver.session(database=database) as session:
+            results = session.read_transaction(
+                lambda tx: tx.run(cypher_query).data())
+        return results
+
+    """Write query to neo4j"""
+
+    @stopwatch
+    def write(self, cypher_query, database, **kwargs):
+        try:
+            with self.driver.session(database=database) as session:
+                results = session.write_transaction(
+                    lambda tx: tx.run(cypher_query).data())
+            return results
+
+        except ConstraintError as exception:
+            logging.error(f"{cypher_query} raised an exception with {exception}")
+            self.user.environment.runner.quit()
+        except DatabaseError as exception:
+            logging.error(f"{cypher_query} raised an exception with {exception}")
+            self.user.environment.runner.quit()
+
+    """Disconnects from neo3j database"""
+
+    def disconnect(self):
+        self.driver.close()
+
+
+"""Abstract class for Neo4j"""
+
+
+class Neo4jUser(User):
+    abstract = True
+
+    def __init__(self, *args, **kwargs):
+        super(Neo4jUser, self).__init__(*args, **kwargs)
+        self.client = Neo4jClient(self.host)
+        self.client.environment = self.environment

--- a/load-testing/neo4j-locust/requirements.txt
+++ b/load-testing/neo4j-locust/requirements.txt
@@ -1,0 +1,2 @@
+locust
+neo4j


### PR DESCRIPTION
This is a README and code to do some simple load-testing of Neo4j, to
check whether it can serve as many users of Gov Graph Search as we
expect.

- Define a complex example of a Gov Graph Search query
- Simulate 100 concurrent users running that query, on a running Neo4j
  instance

The result today was that a single user would be served in about 0.3
seconds, whereas a user among 100 concurrent users might have to wait
up to 3 seconds.  That is a tenfold increase in latency, but it isn't
important, and we don't expect so many concurrent users.
