### PR TITLE
Add a document type for parts and change Chapter to Parts node type

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -11,8 +11,9 @@ FROM 'file:///parts.csv' AS line
 FIELDTERMINATOR ','
 CREATE (p:Page { url: line.url })
 SET
-  p:Chapter,
-  p.chapterNumber = toInteger(line.part_index),
+  p:Part,
+  p.partNumber = toInteger(line.part_index),
+  p.documentType = "part",
   p.slug = line.slug,
   p.title = line.part_title
 ;
@@ -339,10 +340,10 @@ USING PERIODIC COMMIT
 LOAD CSV WITH HEADERS
 FROM 'file:///parts.csv' AS line
 FIELDTERMINATOR ','
-MATCH (c:Chapter { url: line.url })
+MATCH (c:Part { url: line.url })
 MATCH (p:Page { url: line.base_path })
-CREATE (p)-[r:HAS_CHAPTER {
-  chapterNumber: toInteger(line.part_index),
+CREATE (p)-[r:HAS_PART {
+  partNumber: toInteger(line.part_index),
   slug: line.slug,
   title: line.part_title
 }]->(c)


### PR DESCRIPTION
Guide and travel_advice content items are made up of multiple parts, which have
a URL but no documentType field in the content store. Since we're turning them
into individual Page nodes, there isn't a document_type property assigned,
which leads to a bug in GovGraphSearch where those pages would be
ignored. Therefore this commit creates a specific document type for those parts
turned into Page nodes. We also rename "Chapter" node type to "Part" for consistency.
