### PR TITLE
Set the publishing app of parts from their parent document

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -347,6 +347,7 @@ CREATE (p)-[r:HAS_PART {
   slug: line.slug,
   title: line.part_title
 }]->(c)
+SET c.publishing_app = p.publishing_app
 ;
 
 USING PERIODIC COMMIT


### PR DESCRIPTION
A part isn't a content item in the content-store so doesn't have a publishing app attached. When we create Page nodes from parts we therefore add a publishing_app field that is set to be that of its parent Page. This prevents Page nodes having null publishing_app fields.