### PR TITLE
Use the 'english' analyzer for our indexes

### DIFF
--- a/src/neo4j/index.cypher
+++ b/src/neo4j/index.cypher
@@ -3,7 +3,7 @@ FOR (n:Page)
 ON EACH [n.title]
 OPTIONS {
   indexConfig: {
-    `fulltext.analyzer`: 'standard',
+    `fulltext.analyzer`: 'english',
     `fulltext.eventually_consistent`: false
   }
 }
@@ -14,7 +14,7 @@ FOR (n:Page)
 ON EACH [n.description]
 OPTIONS {
   indexConfig: {
-    `fulltext.analyzer`: 'standard',
+    `fulltext.analyzer`: 'english',
     `fulltext.eventually_consistent`: false
   }
 }
@@ -25,7 +25,7 @@ FOR (n:Page)
 ON EACH [n.text]
 OPTIONS {
   indexConfig: {
-    `fulltext.analyzer`: 'standard',
+    `fulltext.analyzer`: 'english',
     `fulltext.eventually_consistent`: false
   }
 }
@@ -36,7 +36,7 @@ FOR (n:Page)
 ON EACH [n.title, n.description, n.text]
 OPTIONS {
   indexConfig: {
-    `fulltext.analyzer`: 'standard',
+    `fulltext.analyzer`: 'english',
     `fulltext.eventually_consistent`: false
   }
 }
@@ -47,7 +47,7 @@ FOR (n:Page)
 ON EACH [n.description, n.text]
 OPTIONS {
   indexConfig: {
-    `fulltext.analyzer`: 'standard',
+    `fulltext.analyzer`: 'english',
     `fulltext.eventually_consistent`: false
   }
 }


### PR DESCRIPTION
In order to be as close as possible to the CONTAIN behaviour we need our indexes not to do stemming. The 'cypher' analyser would be ideal but doesn't seem to be working (reported at [1]). Same problem with the keyword analyzer. 'english' seems to be the index that returns the best results but doesn't work well with foreign-language pages. We'll experiment with GGS once 'english' is used here.

[1] https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/287