### PR TITLE
Parts property fixes

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -347,8 +347,14 @@ CREATE (p)-[r:HAS_PART {
   slug: line.slug,
   title: line.part_title
 }]->(c)
-SET c.publishingApp = p.publishing_app
-
+SET
+  c.publishingApp = p.publishingApp,
+  c.contentId = p.contentId,
+  c.locale = p.locale,
+  c.firstPublishedAt = p.firstPublishedAt,
+  c.updatedAt = p.updatedAt,
+  c.withdrawnAt = p.withdrawnAt,
+  c.withdrawnExplanation = c.withdrawnExplanation
 ;
 
 USING PERIODIC COMMIT


### PR DESCRIPTION
commit 1. fix publishingApp property name
commit 2. Inherit more properties from parent:
Similarly to publishingApp, those properties don't exist on
parts. So we copy them from the parent Page. updatedAt won't
always be accurate though, since all parts will be marked as
updated even if only one has actually been changed. And we're
missing taxons and organisations, which are a bit more complex
to attach so we leave them to a future PR"
