### PR TITLE
Add more gcp services to terraform

### DIFF
--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -82,11 +82,14 @@ variable "services" {
     "cloudscheduler.googleapis.com",
     "bigquery.googleapis.com",
     "bigquerydatatransfer.googleapis.com",
+    "run.googleapis.com",
     "compute.googleapis.com",
     "dns.googleapis.com",
     "eventarc.googleapis.com",
+    "networkmanagement.googleapis.com",
     "pubsub.googleapis.com",
     "sourcerepo.googleapis.com",
+    "vpcaccess.googleapis.com",
     "workflows.googleapis.com",
   ]
 }


### PR DESCRIPTION
These services were been enabled by work that was ephemeral or that
hasn't yet been terraformed.  When they were enabled, GCP automatically
created certain service accounts that are in the IAM configuration, so
the services must also be created in the 'dev' terraform config, so that
it can mirror the prod config.  Hence they ought to be enabled in the
prod config too.
