### PR TITLE
The DNS name needs a full point suffix

### DIFF
--- a/terraform-dev/domain.tf
+++ b/terraform-dev/domain.tf
@@ -11,7 +11,7 @@ resource "google_compute_address" "govgraph" {
 resource "google_dns_managed_zone" "govgraph" {
   name        = "govgraph"
   description = "DNS zone for .dev domains"
-  dns_name    = "${var.govgraph_domain}"
+  dns_name    = "${var.govgraph_domain}."
   dnssec_config {
     kind          = "dns#managedZoneDnsSecConfig"
     non_existence = "nsec3"

--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -11,7 +11,7 @@ resource "google_compute_address" "govgraph" {
 resource "google_dns_managed_zone" "govgraph" {
   name        = "govgraph"
   description = "DNS zone for .dev domains"
-  dns_name    = "${var.govgraph_domain}"
+  dns_name    = "${var.govgraph_domain}."
   dnssec_config {
     kind          = "dns#managedZoneDnsSecConfig"
     non_existence = "nsec3"


### PR DESCRIPTION
This isn't documented anywhere, but is in some hint text in the console,
and terraform fails without it.

This was a painful bug.

1. When I changed `govgraph.dev.` to `${var.govgraph_domain}`, I forgot that the `.` suffix is required.
2. Terraform deleted the DNS config, in order to change `govgraph.dev.` to
   `govgraph.dev`.
3. Terraform failed to recreate the DNS config, because of the missing `.`.
4. I reinstated the `.` and ran terraform.
5. Terraform recreated the DNS config, but Google's API defaulted to "Custom name servers" instead of to "Cloud DNS" (even though it's the same name servers): https://console.cloud.google.com/net-services/domains/registrations/list?project=govuk-knowledge-graph
6. The domain wasn't propagated.
7. I eventually figured it out, and manually changed it back to "Cloud DNS".
8. The domain propagated.
9. `terraform refresh` doesn't notice any difference, it still lists the same
   name servers, so the bug must be in Google's API.
