### PR TITLE
Fix letsencrypt renewal

### DIFF
--- a/docker/neo4j/run.sh
+++ b/docker/neo4j/run.sh
@@ -5,6 +5,7 @@ DOMAIN="govgraph.dev"
 # Refresh certificates needed for HTTPS/BOLT connections"
 # https://medium.com/neo4j/getting-certificates-for-neo4j-with-letsencrypt-a8d05c415bbd
 cd /var/lib/neo4j/certificates
+mkdir letsencrypt
 # Copy the most recent certificates from the bucket
 gsutil -m rsync -J -r -d -C "gs://${PROJECT_ID}-ssl-certificates/letsencrypt" letsencrypt
 # rsync doesn't copy empty directories, so make sure any empty ones do exist


### PR DESCRIPTION
This was a misunderstanding of rsync syntax.

1. It wasn't creating the `letsencrypt` directory locally
2. So it didn't download the contents of the `letsencrypt` directory
   from the bucket
3. So certbot tried to get a new certificate
4. So the LetsEncrypt rate limit was eventually hit
5. So there was no valid certificate in the virtual machine (even though
   the one in the bucket was still valid)
