### PR TITLE
Don't automatically delete processed data

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -94,14 +94,6 @@ resource "google_storage_bucket" "data_processed" {
   versioning {
     enabled = false
   }
-  lifecycle_rule {
-    condition {
-      age = 7
-    }
-    action {
-      type = "Delete"
-    }
-  }
 }
 
 resource "google_storage_bucket_iam_policy" "data_processed" {


### PR DESCRIPTION
Remove the lifecycle rule that automatically deletes storage objects in
the data-processed bucket after 7 days.  This was sensible when none of
the data was intended to persist, but there are now two kinds of data
that must persist:

- Entities, which won't be recreated very often.
- CSV header files, which must be in the same bucket as the CSV data
  that will be concatenated with them.

It isn't possible to exclude specific objects from a lifecycle rule,
unfortunately.
