### PR TITLE
Don't delete the content.lines table

### DIFF
--- a/src/mongodb/bigquery/lines.sql
+++ b/src/mongodb/bigquery/lines.sql
@@ -3,7 +3,8 @@ DECLARE PROJECT_ID STRING DEFAULT 'govuk-knowledge-graph';
 DECLARE URI STRING;
 SET URI=FORMAT('gs://%s-data-processed/bigquery/lines_*.csv.gz', PROJECT_ID);
 
-CREATE OR REPLACE TABLE `content.lines`AS
+DELETE content.lines WHERE TRUE;
+INSERT INTO content.lines
 SELECT
   url,
   line_number + 1 AS line_number,


### PR DESCRIPTION
Instead of deleting and recreating the table, it will now empty and
repopulate it.  This preserves the metadata that is managed by
terraform.
