### PR TITLE
Use content IDs for taxon URLs everywhere

### DIFF
--- a/src/mongodb/js/taxon_levels.js
+++ b/src/mongodb/js/taxon_levels.js
@@ -2,30 +2,43 @@
 db.content_items.aggregate([
   { $match: { document_type: "taxon" } },
   { $project: {
-    "children": "$expanded_links.child_taxons.base_path",
+    "homepage_url": { "$concat": [ "https://www.gov.uk", "$_id" ] },
+    "_id": "$content_id",
+    "children": "$expanded_links.child_taxons.content_id",
   } },
   { $out: "taxons" }
 ])
 db.content_items.aggregate([
   { $match: { "_id": "/" } },
-  { $project: { "children": "$expanded_links.level_one_taxons.base_path" } },
+  { $project: {
+    _id: false,
+    homepage_url: true,
+    "children": "$expanded_links.level_one_taxons.content_id",
+  } },
   { $graphLookup: {
         from: "taxons",
         startWith: "$children",
         connectFromField: "children",
         connectToField: "_id",
+        // connectToField: "content_id",
         as: "descendants",
         depthField: "level",
      } },
-  { $project: { "descendants._id": true, "descendants.level": true } },
+  { $project: {
+    "descendants._id": true,
+    "descendants.homepage_url": true,
+    "descendants.level": true
+  } },
   { $unwind: "$descendants" },
   { $set: {
-    "url": { "$concat": [ "https://www.gov.uk", "$descendants._id" ] },
+    "url": { "$concat": [ "https://www.gov.uk/taxon/", "$descendants._id" ] },
+    "homepage_url": "$descendants.homepage_url",
     "level": { $add: [ "$descendants.level", 1 ] }
   } },
   { $project: {
     _id: false,
     "url": true,
+    "homepage_url": true,
     "level": true,
   } },
   { $out: "taxon_levels" }

--- a/src/mongodb/sh/taxon_levels.sh
+++ b/src/mongodb/sh/taxon_levels.sh
@@ -2,7 +2,7 @@ FILE_NAME=taxon_levels
 
 query_mongo \
   collection=taxon_levels \
-  fields=level,url \
+  fields=url,homepage_url,level \
 | (read -r; printf "%s\n" "$REPLY"; sort) \
 | upload file_name=$FILE_NAME
 

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -1204,16 +1204,22 @@ resource "google_bigquery_table" "taxon_levels" {
   schema        = <<EOF
 [
   {
-    "name": "level",
-    "type": "INTEGER",
-    "mode": "REQUIRED",
-    "description": "Level of the taxon in the hierarchy, wiht level 1 as the top"
-  },
-  {
     "name": "url",
     "type": "STRING",
     "mode": "REQUIRED",
-    "description": "URL of a piece of static content on the www.gov.uk domain"
+    "description": "URL of a taxon"
+  },
+  {
+    "name": "homepage_url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a taxon's home page on GOV.UK"
+  },
+  {
+    "name": "level",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Level of the taxon in the hierarchy, with level 1 as the top"
   }
 ]
 EOF


### PR DESCRIPTION
The taxon_levels table didn't construct URLs from the content IDs, but
other tables did use such URLs.
