### PR TITLE
Clean up the govgraphsearch terraform config

### DIFF
--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -2647,3 +2647,26 @@ resource "google_bigquery_table" "taxon_ancestors" {
 ]
 EOF
 }
+
+resource "google_bigquery_table" "has_successor" {
+  dataset_id    = google_bigquery_dataset.graph.dataset_id
+  table_id      = "has_successor"
+  friendly_name = "Has Successor relationship"
+  description   = "Relationships between an organisation and its successor"
+  schema        = <<EOF
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of an organisation"
+  },
+  {
+    "name": "successor_url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of its successor organisation"
+  }
+]
+EOF
+}

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -94,14 +94,6 @@ resource "google_storage_bucket" "data_processed" {
   versioning {
     enabled = false
   }
-  lifecycle_rule {
-    condition {
-      age = 7
-    }
-    action {
-      type = "Delete"
-    }
-  }
 }
 
 resource "google_storage_bucket_iam_policy" "data_processed" {

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -2,116 +2,49 @@ resource "google_artifact_registry_repository" "cloud_run_source_deploy" {
   description   = "Cloud Run Source Deployments"
   format        = "DOCKER"
   location      = "europe-west2"
-  project       = "govuk-knowledge-graph"
   repository_id = "cloud-run-source-deploy"
 }
-# terraform import google_artifact_registry_repository.cloud_run_source_deploy projects/govuk-knowledge-graph/locations/europe-west2/repositories/cloud-run-source-deploy
 
 resource "google_compute_target_https_proxy" "govgraphsearch_lb_target_proxy" {
   name             = "govgraphsearch-lb-target-proxy"
-  project          = "govuk-knowledge-graph"
   quic_override    = "NONE"
-  ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/sslCertificates/govgraphsearch-cert"]
-  url_map          = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/urlMaps/govgraphsearch-lb"
+  ssl_certificates = [google_compute_managed_ssl_certificate.govgraphsearch_cert.id]
+  url_map          = google_compute_url_map.govgraphsearch_lb.id
 }
-# terraform import google_compute_target_https_proxy.govgraphsearch_lb_target_proxy projects/govuk-knowledge-graph/global/targetHttpsProxies/govgraphsearch-lb-target-proxy
 
 resource "google_compute_global_forwarding_rule" "govgraphsearch_fc" {
-  ip_address            = "34.160.154.17"
+  ip_address            = google_compute_global_address.govgraphsearch_ip.address
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
   name                  = "govgraphsearch-fc"
   port_range            = "443-443"
-  project               = "govuk-knowledge-graph"
-  target                = "https://www.googleapis.com/compute/beta/projects/govuk-knowledge-graph/global/targetHttpsProxies/govgraphsearch-lb-target-proxy"
+  target                = google_compute_target_https_proxy.govgraphsearch_lb_target_proxy.id
 }
-# terraform import google_compute_global_forwarding_rule.govgraphsearch_fc projects/govuk-knowledge-graph/global/forwardingRules/govgraphsearch-fc
 
 resource "google_dns_managed_zone" "govgraphsearcg" {
   dns_name      = "govgraphsearch.dev."
   force_destroy = false
   name          = "govgraphsearcg"
-  project       = "govuk-knowledge-graph"
   visibility    = "public"
 }
-# terraform import google_dns_managed_zone.govgraphsearcg projects/govuk-knowledge-graph/managedZones/govgraphsearcg
 
 resource "google_compute_global_address" "govgraphsearch_ip" {
-  address      = "34.160.154.17"
+  address      = "${var.govgraphsearch_static_ip_address}"
   address_type = "EXTERNAL"
   description  = "External IP address for GovGraph Search"
   ip_version   = "IPV4"
   name         = "govgraphsearch-ip"
-  project      = "govuk-knowledge-graph"
 }
-# terraform import google_compute_global_address.govgraphsearch_ip projects/govuk-knowledge-graph/global/addresses/govgraphsearch-ip
 
 resource "google_compute_url_map" "govgraphsearch_lb" {
-  default_service = "https://www.googleapis.com/compute/v1/projects/govuk-knowledge-graph/global/backendServices/govgraphsearch-be"
+  default_service = "govgraphsearch-be"
   name            = "govgraphsearch-lb"
-  project         = "govuk-knowledge-graph"
 }
-# terraform import google_compute_url_map.govgraphsearch_lb projects/govuk-knowledge-graph/global/urlMaps/govgraphsearch-lb
 
 # SSL Certificate
 resource "google_compute_managed_ssl_certificate" "govgraphsearch_cert" {
   name = "govgraphsearch-cert"
   managed {
     domains = ["govgraphsearch.dev."]
-  }
-}
-# terraform import google_compute_ssl_certificate.govgraphsearch_cert projects/govuk-knowledge-graph/global/sslCertificates/govgraphsearch-cert
-
-# resource "google_compute_backend_service" "govgraphsearch_be" {
-#   cdn_policy {
-#     cache_key_policy {
-#       include_host         = true
-#       include_protocol     = true
-#       include_query_string = true
-#     }
-
-#     cache_mode                   = "CACHE_ALL_STATIC"
-#     client_ttl                   = 3600
-#     default_ttl                  = 3600
-#     max_ttl                      = 86400
-#     signed_url_cache_max_age_sec = 0
-#   }
-
-#   connection_draining_timeout_sec = 0
-
-#   iap {
-#     oauth2_client_id = "19513753240-3ug13t89unh4hhcqnpunr0741ou6k2k2.apps.googleusercontent.com"
-#   }
-
-#   load_balancing_scheme = "EXTERNAL"
-#   name                  = "govgraphsearch-be"
-#   port_name             = "http"
-#   project               = "govuk-knowledge-graph"
-#   protocol              = "HTTPS"
-#   session_affinity      = "NONE"
-#   timeout_sec           = 30
-# }
-# terraform import google_compute_backend_service.govgraphsearch_be projects/govuk-knowledge-graph/global/backendServices/govgraphsearch-be
-
-resource "google_cloud_run_service" "default" {
-  autogenerate_revision_name = true
-  location                   = "europe-west2"
-  name                       = "govuk-knowledge-graph-search"
-  project                    = "govuk-knowledge-graph"
-
-  template {
-    spec {
-      container_concurrency = 80
-      timeout_seconds       = 300
-
-      containers {
-        image   = "europe-west2-docker.pkg.dev/govuk-knowledge-graph/cloud-run-source-deploy/govuk-knowledge-graph-search:latest"
-
-        env {
-          name  = "NEO4J_URL"
-          value = "http://10.8.0.4:7474/db/neo4j/tx"
-        }
-      }
-    }
   }
 }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -71,6 +71,12 @@ variable "govgraph_static_ip_address" {
   default = "35.246.18.75"
 }
 
+# Static IP address for govgraphsearch
+variable "govgraphsearch_static_ip_address" {
+  type    = string
+  default = "34.160.154.17"
+}
+
 variable "services" {
   type = list(any)
   default = [


### PR DESCRIPTION
- Don't set the project ID anywhere, so that it defaults to the globally
  defined project ID.
- Refer to resources by their name in the terraform config, rather than
  by their URL
- Remove the commented "terraform import" statements, because they are
  only to be used once, and don't generalise to the non-production
  environments
