### PR TITLE
Prevent accidentally destroying GCP project

### DIFF
--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -141,6 +141,9 @@ resource "google_project" "project" {
     programme = "cpto",
     team      = "data-products",
   }
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Use `gcloud` to enable:

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -141,6 +141,9 @@ resource "google_project" "project" {
     programme = "cpto",
     team      = "data-products",
   }
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Use `gcloud` to enable:

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -156,6 +156,9 @@ resource "google_project" "project" {
     programme = "cpto",
     team      = "data-products",
   }
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Use `gcloud` to enable:


### PR DESCRIPTION
It's too easy to accidentally destroy a GCP project with terraform when
switching between prod, dev and staging, because if you accidentally
change the project name in one of the terraform folders, it will try to
rename the project by deleting it first, and then recreating it.  The
lifecycle rule prevents it from doing that.
