### PR TITLE
Make GitHub a storage.admin for sync workflow

### DIFF
--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -38,7 +38,7 @@ resource "google_storage_bucket_iam_policy" "repository" {
 
 data "google_iam_policy" "bucket_repository" {
   binding {
-    role = "roles/storage.objectAdmin"
+    role = "roles/storage.admin"
     members = [
       "serviceAccount:${google_service_account.storage_github.email}",
     ]

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -38,7 +38,7 @@ resource "google_storage_bucket_iam_policy" "repository" {
 
 data "google_iam_policy" "bucket_repository" {
   binding {
-    role = "roles/storage.objectAdmin"
+    role = "roles/storage.admin"
     members = [
       "serviceAccount:${google_service_account.storage_github.email}",
     ]

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -38,7 +38,7 @@ resource "google_storage_bucket_iam_policy" "repository" {
 
 data "google_iam_policy" "bucket_repository" {
   binding {
-    role = "roles/storage.objectAdmin"
+    role = "roles/storage.admin"
     members = [
       "serviceAccount:${google_service_account.storage_github.email}",
     ]


### PR DESCRIPTION
This used to work with mere storage.objectAdmin, but now it needs
storage.buckets.get, for some reason.
