### PR TITLE
Combine part and parent document type

### DIFF
--- a/src/mongodb/bigquery/page.sql
+++ b/src/mongodb/bigquery/page.sql
@@ -48,7 +48,8 @@ INSERT INTO graph.part
 SELECT
   page.*
   REPLACE(
-    "part" AS document_type,
+    parts.url AS url,
+    page.document_type || "_part" AS document_type,
     parts.part_title AS title,
     parts.part_index AS part_index,
     parts.slug AS slug


### PR DESCRIPTION
- Don't set the document type of parts to merely 'part', but concatenate
  it onto the document type of the overall document.
- Include the slug in the URL of a part's entry in `graph.page`.
