### PR TITLE
Allow Dept International Trade into govgraphsearch

### DIFF
--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -5,3 +5,8 @@ govgraph_domain            = "govgraph.dev"
 govgraph_static_ip_address = "35.246.18.75"
 govgraphsearch_domain      = "govgraphsearch.dev"
 application_title          = "GovGraph Search"
+govgraphsearch_iap_members = [
+  "domain:digital.cabinet-office.gov.uk",
+  "domain:trade.gov.uk",
+  "domain:bis.gov.uk",
+]

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -82,15 +82,13 @@ resource "google_vpc_access_connector" "cloudrun_connector" {
 data "google_iam_policy" "govgraphsearch_iap" {
   binding {
     role = "roles/iap.httpsResourceAccessor"
-    members = [
-      "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
-      "user:max.froumentin@digital.cabinet-office.gov.uk",
-    ]
+    members = var.govgraphsearch_iap_members
   }
 }
 
-resource "google_iap_web_iam_policy" "policy" {
-  policy_data = data.google_iam_policy.govgraphsearch_iap.policy_data
+resource "google_iap_web_backend_service_iam_policy" "govgraphsearch" {
+  web_backend_service = module.govgraphsearch_lb.backend_services["govgraphsearch"].name
+  policy_data         = data.google_iam_policy.govgraphsearch_iap.policy_data
 }
 
 # Allow anyone who has already been through IAP to load the app
@@ -108,7 +106,6 @@ resource "google_cloud_run_service_iam_policy" "govgraphsearch" {
   service     = google_cloud_run_service.govgraphsearch.name
   policy_data = data.google_iam_policy.govgraphsearch.policy_data
 }
-
 
 # The app itself
 resource "google_cloud_run_service" "govgraphsearch" {

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -69,6 +69,10 @@ variable "application_title" {
   type = string
 }
 
+variable "govgraphsearch_iap_members" {
+  type = set(string)
+}
+
 variable "services" {
   type = list(any)
 }


### PR DESCRIPTION
Also:

- manage IAM for IAP per service, not for IAP as a whole
- configure with variables, because this will differ by environment
