### PR TITLE
Don't use suggested related links as hyperlinks

### DIFF
--- a/src/mongodb/bigquery/hyperlinks_to.sql
+++ b/src/mongodb/bigquery/hyperlinks_to.sql
@@ -35,7 +35,6 @@ SELECT
   to_url AS link_url
 FROM content.expanded_links
 WHERE expanded_links.link_type IN (
-  'suggested_ordered_related_items',
   'ordered_related_items',
   'ordered_related_items_overrides'
 )

--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -292,11 +292,6 @@ MATCH (n)-[r:LINKS_TO {linkTargetType: 'available_translations'}]->(n)
 DELETE r
 ;
 
-// Reuse `suggested_ordered_related_items` links as `HYPERLINKS_TO`.
-MATCH (p)-[:LINKS_TO {linkTargetType: 'suggested_ordered_related_items'}]->(q)
-CREATE (p)-[:HYPERLINKS_TO]->(q)
-;
-
 // Reuse `ordered_related_items` links as `HYPERLINKS_TO`.
 MATCH (p)-[:LINKS_TO {linkTargetType: 'ordered_related_items'}]->(q)
 CREATE (p)-[:HYPERLINKS_TO]->(q)


### PR DESCRIPTION
This surprised users, who didn't expect links suggested by the "related
links" model to be included in searches for hyperlinks in the body of
pages, especially when those links aren't rendered (which can be because
they are overridden by manually curated links, or other ways).

See also:

- https://github.com/alphagov/government-frontend/pull/1429
- https://github.com/alphagov/content-tagger/pull/303
