### PR TITLE
Allow govgraphsearch to use BigQuery

### DIFF
--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -118,6 +118,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"
@@ -2026,6 +2027,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"

--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -107,6 +107,13 @@ resource "google_cloud_run_service_iam_policy" "govgraphsearch" {
   policy_data = data.google_iam_policy.govgraphsearch.policy_data
 }
 
+# Service account for the service
+resource "google_service_account" "govgraphsearch" {
+  account_id   = "govgraphsearch"
+  display_name = "GovGraph Search"
+  description  = "Service account for the GovGraph search Cloud Run app"
+}
+
 # The app itself
 resource "google_cloud_run_service" "govgraphsearch" {
   name                       = "govuk-knowledge-graph-search"
@@ -123,6 +130,7 @@ resource "google_cloud_run_service" "govgraphsearch" {
       }
     }
     spec {
+      service_account_name       = google_service_account.govgraphsearch.name
       containers {
         image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -201,6 +201,7 @@ data "google_iam_policy" "project" {
       "serviceAccount:${google_service_account.gce_neo4j.email}",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -118,6 +118,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"
@@ -2026,6 +2027,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -107,6 +107,13 @@ resource "google_cloud_run_service_iam_policy" "govgraphsearch" {
   policy_data = data.google_iam_policy.govgraphsearch.policy_data
 }
 
+# Service account for the service
+resource "google_service_account" "govgraphsearch" {
+  account_id   = "govgraphsearch"
+  display_name = "GovGraph Search"
+  description  = "Service account for the GovGraph search Cloud Run app"
+}
+
 # The app itself
 resource "google_cloud_run_service" "govgraphsearch" {
   name                       = "govuk-knowledge-graph-search"
@@ -123,6 +130,7 @@ resource "google_cloud_run_service" "govgraphsearch" {
       }
     }
     spec {
+      service_account_name       = google_service_account.govgraphsearch.name
       containers {
         image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -201,6 +201,7 @@ data "google_iam_policy" "project" {
       "serviceAccount:${google_service_account.gce_neo4j.email}",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -118,6 +118,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"
@@ -2026,6 +2027,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -107,6 +107,13 @@ resource "google_cloud_run_service_iam_policy" "govgraphsearch" {
   policy_data = data.google_iam_policy.govgraphsearch.policy_data
 }
 
+# Service account for the service
+resource "google_service_account" "govgraphsearch" {
+  account_id   = "govgraphsearch"
+  display_name = "GovGraph Search"
+  description  = "Service account for the GovGraph search Cloud Run app"
+}
+
 # The app itself
 resource "google_cloud_run_service" "govgraphsearch" {
   name                       = "govuk-knowledge-graph-search"
@@ -123,6 +130,7 @@ resource "google_cloud_run_service" "govgraphsearch" {
       }
     }
     spec {
+      service_account_name       = google_service_account.govgraphsearch.name
       containers {
         image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -201,6 +201,7 @@ data "google_iam_policy" "project" {
       "serviceAccount:${google_service_account.gce_neo4j.email}",
       "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
- Create a service account
- Assign the account to the app
- Grant it BigQuery permissions
