### PR TITLE
Don't compose BigQuery exports into single files

### DIFF
--- a/src/mongodb/Makefile
+++ b/src/mongodb/Makefile
@@ -248,10 +248,6 @@ temp/content.bigquery: data/step_by_step_content.csv.gz data/parts_content.csv.g
 	envsubst < ./bigquery/content.sql \
 		| bq query --use_legacy_sql=false \
 		< /dev/stdin
-	gcloud storage objects compose \
-		"gs://${PROJECT_ID}-data-processed/bigquery/content_header.csv.gz" \
-		"gs://${PROJECT_ID}-data-processed/bigquery/content_[0-9]*.csv.gz" \
-		"gs://${PROJECT_ID}-data-processed/bigquery/content.csv.gz"
 	touch temp/content.bigquery
 
 # Derive a table of one row per line of content per page, export back into a
@@ -263,10 +259,6 @@ temp/lines.bigquery: temp/content.bigquery
 	envsubst < ./bigquery/lines.sql \
 		| bq query --use_legacy_sql=false \
 		< /dev/stdin
-	gcloud storage objects compose \
-		"gs://${PROJECT_ID}-data-processed/bigquery/lines_header.csv.gz" \
-		"gs://${PROJECT_ID}-data-processed/bigquery/lines_[0-9]*.csv.gz" \
-		"gs://${PROJECT_ID}-data-processed/bigquery/lines.csv.gz"
 
 # Combine the tables of embedded_links of each document type, export back into a
 # storage bucket as many files, and concatenate those files into a single file.
@@ -277,10 +269,6 @@ temp/embedded_links.bigquery: data/step_by_step_embedded_links.csv.gz data/parts
 	envsubst < ./bigquery/embedded_links.sql \
 	  | bq query --use_legacy_sql=false \
 	  < /dev/stdin
-	gcloud storage objects compose \
-		"gs://${PROJECT_ID}-data-processed/bigquery/embedded_links_header.csv.gz" \
-		"gs://${PROJECT_ID}-data-processed/bigquery/embedded_links_[0-9]*.csv.gz" \
-		"gs://${PROJECT_ID}-data-processed/bigquery/embedded_links.csv.gz"
 	touch $@
 
 # Redirects of two kinds


### PR DESCRIPTION
This currently fails, and stops the Makefile from doing anything else.
It can't be fixed quickly.  I have asked the only known users of the
files to consider using the individual files instead.  See #409.
