### PR TITLE
Handle travel advice summary parts in Neo4j

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -5,19 +5,6 @@ FIELDTERMINATOR ','
 CREATE (p:Page { url: line.url })
 ;
 
-USING PERIODIC COMMIT
-LOAD CSV WITH HEADERS
-FROM 'file:///parts.csv' AS line
-FIELDTERMINATOR ','
-CREATE (p:Page { url: line.url })
-SET
-  p:Part,
-  p.partNumber = toInteger(line.part_index),
-  p.documentType = "part",
-  p.slug = line.slug,
-  p.title = line.part_title
-;
-
 CREATE CONSTRAINT ON (p:Page) ASSERT p.url IS UNIQUE;
 CREATE CONSTRAINT ON (p:Organisation) ASSERT p.url IS UNIQUE;
 CREATE CONSTRAINT ON (p:Taxon) ASSERT p.url IS UNIQUE;
@@ -25,6 +12,21 @@ CREATE CONSTRAINT ON (p:BankHoliday) ASSERT p.url IS UNIQUE;
 CREATE CONSTRAINT ON (p:Date) ASSERT p.url IS UNIQUE;
 CREATE CONSTRAINT ON (p:Division) ASSERT p.url IS UNIQUE;
 CREATE CONSTRAINT ON (p:Person) ASSERT p.url IS UNIQUE;
+
+USING PERIODIC COMMIT
+LOAD CSV WITH HEADERS
+FROM 'file:///parts.csv' AS line
+FIELDTERMINATOR ','
+// The 'summary' part of travel_advice pages has the same URL as the whole set
+// of parts, so we can't use CREATE, we have to use MERGE.
+MERGE (p:Page { url: line.url })
+SET
+  p:Part,
+  p.partNumber = toInteger(line.part_index),
+  p.documentType = "part",
+  p.slug = line.slug,
+  p.title = line.part_title
+;
 
 USING PERIODIC COMMIT
 LOAD CSV WITH HEADERS


### PR DESCRIPTION
We now extract the 'summary' part of travel advice pages correctly.
However, because they have the same URL as the overall page, Neo4j
encounters the URL in both url.csv and parts.csv.  That means that we
have to use `MERGE`, not `CREATE` when creating nodes from parts.csv, so
that it reuses any node already created from url.csv.

To speed up the `MERGE`, it's worth creating the uniqueness constraint
before loading parts.csv.
