### PR TITLE
Terraform the new gov-search.service.gov.uk domain

### DIFF
--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -3,6 +3,7 @@ project_id                 = "govuk-knowledge-graph"
 project_number             = "19513753240"
 govgraph_domain            = "govgraph.dev"
 govgraphsearch_domain      = "govgraphsearch.dev"
+govsearch_domain            = "gov-search.service.gov.uk"
 application_title          = "GovGraph Search"
 govgraphsearch_iap_members = [
   "domain:digital.cabinet-office.gov.uk",

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -60,6 +60,10 @@ variable "govgraphsearch_domain" {
   type = string
 }
 
+variable "govsearch_domain" {
+  type = string
+}
+
 variable "application_title" {
   type = string
 }


### PR DESCRIPTION
This required abandoning the convenient, official Google terraform
module for load balancers, and replacing it with several terraform
resources written by hand.  Doing so avoids down-time when adding a
domain to the certificate (which is what the module would do, replacing
the certificate altogether), by instead adding a certificate to the
https proxy.

https://cloud.google.com/blog/topics/developers-practitioners/new-terraform-module-serverless-load-balancing

https://github.com/terraform-google-modules/terraform-google-lb-http/issues/241
