### PR TITLE
Respell trade.gov.uk as bis.gov.uk in IAP

### DIFF
--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -5,8 +5,12 @@ govgraph_domain            = "govgraph.dev"
 govgraphsearch_domain      = "govgraphsearch.dev"
 govsearch_domain            = "gov-search.service.gov.uk"
 application_title          = "GovGraph Search"
+
 govgraphsearch_iap_members = [
   "domain:digital.cabinet-office.gov.uk",
-  "domain:trade.gov.uk",
+
+  # We want to allow trade.gov.uk, and when we do, Google silently respells it as
+  # bis.gov.uk, presumably because of some DNS registration by BEIS as part of a
+  # machinery of government change.
   "domain:bis.gov.uk",
 ]


### PR DESCRIPTION
We want to allow trade.gov.uk, and when we do, Google silently respells
it as bis.gov.uk, presumably because of some DNS registration by BEIS as
part of a machinery of government change.