### PR TITLE
Fix govsearch domain terraform config (fix #418)

### DIFF
--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -3,6 +3,7 @@ project_id            = "govuk-knowledge-graph-dev"
 project_number        = "628722085506"
 govgraph_domain       = "govgraphdev.dev"
 govgraphsearch_domain = "govgraphsearchdev.dev"
+govsearch_domain      = "NOT_IN_USE"
 application_title     = "GovGraph Search (development)"
 govgraphsearch_iap_members = [
   "domain:digital.cabinet-office.gov.uk",

--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -48,12 +48,6 @@ resource "google_dns_managed_zone" "govgraphsearch" {
   dns_name    = "${var.govgraphsearch_domain}."
 }
 
-resource "google_dns_managed_zone" "govsearch" {
-  name        = "gov-search-zone"
-  description = "The zone for the gov-search service domain"
-  dns_name    = "${var.govsearch_domain}."
-}
-
 # Then manually buy a domain in Cloud Domains and link it to this zone.
 
 # Then create everything else below.
@@ -229,13 +223,5 @@ resource "google_dns_record_set" "govgraphsearch" {
   type         = "A"
   ttl          = 300
   managed_zone = google_dns_managed_zone.govgraphsearch.name
-  rrdatas      = [google_compute_global_address.govgraphsearch.address]
-}
-
-resource "google_dns_record_set" "govsearch" {
-  name         = google_dns_managed_zone.govsearch.dns_name
-  type         = "A"
-  ttl          = 300
-  managed_zone = google_dns_managed_zone.govsearch.name
   rrdatas      = [google_compute_global_address.govgraphsearch.address]
 }

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -3,6 +3,7 @@ project_id            = "govuk-knowledge-graph-staging"
 project_number        = "957740527277"
 govgraph_domain       = "govgraphstaging.dev"
 govgraphsearch_domain = "govgraphsearchstaging.dev"
+govsearch_domain      = "NOT_IN_USE"
 application_title     = "GovGraph Search (staging)"
 govgraphsearch_iap_members = [
   "user:duncan.garmonsway@digital.cabinet-office.gov.uk",

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -48,12 +48,6 @@ resource "google_dns_managed_zone" "govgraphsearch" {
   dns_name    = "${var.govgraphsearch_domain}."
 }
 
-resource "google_dns_managed_zone" "govsearch" {
-  name        = "gov-search-zone"
-  description = "The zone for the gov-search service domain"
-  dns_name    = "${var.govsearch_domain}."
-}
-
 # Then manually buy a domain in Cloud Domains and link it to this zone.
 
 # Then create everything else below.
@@ -229,13 +223,5 @@ resource "google_dns_record_set" "govgraphsearch" {
   type         = "A"
   ttl          = 300
   managed_zone = google_dns_managed_zone.govgraphsearch.name
-  rrdatas      = [google_compute_global_address.govgraphsearch.address]
-}
-
-resource "google_dns_record_set" "govsearch" {
-  name         = google_dns_managed_zone.govsearch.dns_name
-  type         = "A"
-  ttl          = 300
-  managed_zone = google_dns_managed_zone.govsearch.name
   rrdatas      = [google_compute_global_address.govgraphsearch.address]
 }

--- a/terraform/environment.tf
+++ b/terraform/environment.tf
@@ -1,5 +1,28 @@
 # Resources that are specific to this environment
 
+resource "google_compute_target_https_proxy" "govgraphsearch" {
+  name = "govgraphsearch-https-proxy"
+  ssl_certificates = [
+    google_compute_managed_ssl_certificate.govgraphsearch.self_link,
+    google_compute_managed_ssl_certificate.govsearch.self_link,
+  ]
+  url_map = google_compute_url_map.govgraphsearch.self_link
+}
+
+resource "google_dns_managed_zone" "govsearch" {
+  name        = "gov-search-zone"
+  description = "The zone for the gov-search service domain"
+  dns_name    = "${var.govsearch_domain}."
+}
+
+resource "google_dns_record_set" "govsearch" {
+  name         = google_dns_managed_zone.govsearch.dns_name
+  type         = "A"
+  ttl          = 300
+  managed_zone = google_dns_managed_zone.govsearch.name
+  rrdatas      = [google_compute_global_address.govgraphsearch.address]
+}
+
 resource "google_compute_managed_ssl_certificate" "govsearch" {
   name        = "govsearch-cert"
   description = "The SSL certificate of the GGS service domain: gov-search.service.gov.uk"
@@ -8,13 +31,4 @@ resource "google_compute_managed_ssl_certificate" "govsearch" {
       var.govsearch_domain,
     ]
   }
-}
-
-resource "google_compute_target_https_proxy" "govgraphsearch" {
-  name = "govgraphsearch-https-proxy"
-  ssl_certificates = [
-    google_compute_managed_ssl_certificate.govgraphsearch.self_link,
-    google_compute_managed_ssl_certificate.govsearch.self_link,
-  ]
-  url_map = google_compute_url_map.govgraphsearch.self_link
 }

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -48,12 +48,6 @@ resource "google_dns_managed_zone" "govgraphsearch" {
   dns_name    = "${var.govgraphsearch_domain}."
 }
 
-resource "google_dns_managed_zone" "govsearch" {
-  name        = "gov-search-zone"
-  description = "The zone for the gov-search service domain"
-  dns_name    = "${var.govsearch_domain}."
-}
-
 # Then manually buy a domain in Cloud Domains and link it to this zone.
 
 # Then create everything else below.
@@ -229,13 +223,5 @@ resource "google_dns_record_set" "govgraphsearch" {
   type         = "A"
   ttl          = 300
   managed_zone = google_dns_managed_zone.govgraphsearch.name
-  rrdatas      = [google_compute_global_address.govgraphsearch.address]
-}
-
-resource "google_dns_record_set" "govsearch" {
-  name         = google_dns_managed_zone.govsearch.dns_name
-  type         = "A"
-  ttl          = 300
-  managed_zone = google_dns_managed_zone.govsearch.name
   rrdatas      = [google_compute_global_address.govgraphsearch.address]
 }


### PR DESCRIPTION
In #418 some resources in the dev and staging environments depended on a
variable that didn't exist.  The resources were a DNS record set and a
DNS managed zone.  This PR removes those resources from dev and staging.
In production, the resources are moved into environment.tf because they
are specific to that environment.

The variable definitions are reinstated in dev and staging, because they
have to be declared both in the .tfvars file and in main-gcp.tf.  We
could have removed them from main-gcp.tf, which would mean that
main-gcp.tf is yet another special file that varies between
environments.  Instead, we define them in the .tfvars file with a
default value of `"NOT_IN_USE"`.
