### PR TITLE
Don't overwrite bank holiday raw table

### DIFF
--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -295,7 +295,8 @@ main:
             body:
                 useLegacySql: false
                 query: $${
-                    "LOAD DATA OVERWRITE content.bank_holiday_raw " +
+                    "DELETE FROM content.bank_holiday_raw WHERE TRUE; " +
+                    "LOAD DATA INTO content.bank_holiday_raw " +
                     "FROM FILES ( " +
                     "  format = 'JSON', " +
                     "  uris = ['gs://${var.project_id}-data-processed/bank-holidays/bank-holidays.json'] " +

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -295,7 +295,8 @@ main:
             body:
                 useLegacySql: false
                 query: $${
-                    "LOAD DATA OVERWRITE content.bank_holiday_raw " +
+                    "DELETE FROM content.bank_holiday_raw WHERE TRUE; " +
+                    "LOAD DATA INTO content.bank_holiday_raw " +
                     "FROM FILES ( " +
                     "  format = 'JSON', " +
                     "  uris = ['gs://${var.project_id}-data-processed/bank-holidays/bank-holidays.json'] " +

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -295,7 +295,8 @@ main:
             body:
                 useLegacySql: false
                 query: $${
-                    "LOAD DATA OVERWRITE content.bank_holiday_raw " +
+                    "DELETE FROM content.bank_holiday_raw WHERE TRUE; " +
+                    "LOAD DATA INTO content.bank_holiday_raw " +
                     "FROM FILES ( " +
                     "  format = 'JSON', " +
                     "  uris = ['gs://${var.project_id}-data-processed/bank-holidays/bank-holidays.json'] " +


### PR DESCRIPTION
A table that is configured in terraform, with metadata such as field
descriptions, is also being ovewritten by a daily workflow, which wipes
the field descriptions.  This creates noise in terraform plans, to
restore the field descriptions.  The fix is not to overwrite the table,
but instead to empty and then re-populate it.
