### PR TITLE
Update content of part pages in graph and search

### DIFF
--- a/src/mongodb/bigquery/page.sql
+++ b/src/mongodb/bigquery/page.sql
@@ -51,11 +51,13 @@ SELECT
     parts.url AS url,
     page.document_type || "_part" AS document_type,
     parts.part_title AS title,
+    c.text AS text,
     parts.part_index AS part_index,
     parts.slug AS slug
   )
 FROM graph.page
 INNER JOIN content.parts ON page.url = parts.base_path
+LEFT JOIN content.content AS c ON c.url = parts.url
 ;
 INSERT INTO graph.page SELECT * FROM graph.part;
 


### PR DESCRIPTION
The content of parts of `guide` and `travel_advice` pages was being
inherited from the overall page.  It should be the content specific to
that part.
