### PR TITLE
Refactor page-to-page-transitions terraform

### DIFF
--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -10,79 +10,10 @@ resource "google_bigquery_data_transfer_config" "page_to_page_transitions" {
   location       = var.region
   schedule       = "every day 03:00"
   params = {
-    query = <<EOF
--- Count the number of transitions between each page on GOV.UK as collected by GA4.
--- Only transitions between pages that exist in the content store are included.
--- https://stackoverflow.com/a/70033601/937932
-
-CREATE TEMP TABLE page_views AS (
-  SELECT
-    user_pseudo_id,
-    (
-      SELECT
-        value.int_value
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'ga_session_id'
-    ) AS ga_session_id,
-    (
-      SELECT
-        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'page_referrer'
-    ) AS from_url,
-    (
-      SELECT
-        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'page_location'
-    ) AS to_url,
-  FROM `ga4-analytics-352613.analytics_330577055.events_*`
-  WHERE
-    event_name = 'page_view'
-    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 8 DAY))
-    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 2 DAY))
-);
-
-EXPORT DATA OPTIONS(
-  uri='gs://${var.project_id}-data-processed/ga4/page_to_page_transitions_*.csv.gz',
-  format='CSV',
-  compression='GZIP',
-  overwrite=true
-) AS
-
-WITH
-
-all_urls AS (
-  SELECT url FROM `${var.project_id}.content.url`
-  UNION ALL
-  SELECT url FROM `${var.project_id}.content.parts`
-)
-
-SELECT
-  COUNT(*) AS number_of_movements,
-  COUNT(DISTINCT(user_pseudo_id)) AS number_of_user_pseudo_ids,
-  COUNT(DISTINCT(CONCAT(user_pseudo_id, ga_session_id))) AS number_of_sessions,
-  page_views.from_url,
-  page_views.to_url
-FROM page_views
-INNER JOIN all_urls AS urls_from ON urls_from.url = page_views.from_url
-INNER JOIN all_urls AS urls_to ON urls_to.url = page_views.to_url
-GROUP BY
-  page_views.from_url,
-  page_views.to_url
-HAVING
-  number_of_movements > 5
-  AND number_of_user_pseudo_ids > 5
-  AND number_of_sessions > 5
-ORDER BY
-  number_of_movements DESC
-EOF
+    query = templatefile(
+      "bigquery/page-to-page-transitions.sql",
+      { project_id = var.project_id }
+    )
   }
   service_account_name = google_service_account.bigquery_page_transitions.email
 }

--- a/terraform-dev/bigquery/page-to-page-transitions.sql
+++ b/terraform-dev/bigquery/page-to-page-transitions.sql
@@ -1,0 +1,71 @@
+-- Count the number of transitions between each page on GOV.UK as collected by GA4.
+-- Only transitions between pages that exist in the content store are included.
+-- https://stackoverflow.com/a/70033601/937932
+
+CREATE TEMP TABLE page_views AS (
+  SELECT
+    user_pseudo_id,
+    (
+      SELECT
+        value.int_value
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'ga_session_id'
+    ) AS ga_session_id,
+    (
+      SELECT
+        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'page_referrer'
+    ) AS from_url,
+    (
+      SELECT
+        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'page_location'
+    ) AS to_url,
+  FROM `ga4-analytics-352613.analytics_330577055.events_*`
+  WHERE
+    event_name = 'page_view'
+    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 8 DAY))
+    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 2 DAY))
+);
+
+EXPORT DATA OPTIONS(
+  uri='gs://${project_id}-data-processed/ga4/page_to_page_transitions_*.csv.gz',
+  format='CSV',
+  compression='GZIP',
+  overwrite=true
+) AS
+
+WITH
+
+all_urls AS (
+  SELECT url FROM `${project_id}.content.url`
+  UNION ALL
+  SELECT url FROM `${project_id}.content.parts`
+)
+
+SELECT
+  COUNT(*) AS number_of_movements,
+  COUNT(DISTINCT(user_pseudo_id)) AS number_of_user_pseudo_ids,
+  COUNT(DISTINCT(CONCAT(user_pseudo_id, ga_session_id))) AS number_of_sessions,
+  page_views.from_url,
+  page_views.to_url
+FROM page_views
+INNER JOIN all_urls AS urls_from ON urls_from.url = page_views.from_url
+INNER JOIN all_urls AS urls_to ON urls_to.url = page_views.to_url
+GROUP BY
+  page_views.from_url,
+  page_views.to_url
+HAVING
+  number_of_movements > 5
+  AND number_of_user_pseudo_ids > 5
+  AND number_of_sessions > 5
+ORDER BY
+  number_of_movements DESC

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -10,79 +10,10 @@ resource "google_bigquery_data_transfer_config" "page_to_page_transitions" {
   location       = var.region
   schedule       = "every day 03:00"
   params = {
-    query = <<EOF
--- Count the number of transitions between each page on GOV.UK as collected by GA4.
--- Only transitions between pages that exist in the content store are included.
--- https://stackoverflow.com/a/70033601/937932
-
-CREATE TEMP TABLE page_views AS (
-  SELECT
-    user_pseudo_id,
-    (
-      SELECT
-        value.int_value
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'ga_session_id'
-    ) AS ga_session_id,
-    (
-      SELECT
-        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'page_referrer'
-    ) AS from_url,
-    (
-      SELECT
-        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'page_location'
-    ) AS to_url,
-  FROM `ga4-analytics-352613.analytics_330577055.events_*`
-  WHERE
-    event_name = 'page_view'
-    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 8 DAY))
-    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 2 DAY))
-);
-
-EXPORT DATA OPTIONS(
-  uri='gs://${var.project_id}-data-processed/ga4/page_to_page_transitions_*.csv.gz',
-  format='CSV',
-  compression='GZIP',
-  overwrite=true
-) AS
-
-WITH
-
-all_urls AS (
-  SELECT url FROM `${var.project_id}.content.url`
-  UNION ALL
-  SELECT url FROM `${var.project_id}.content.parts`
-)
-
-SELECT
-  COUNT(*) AS number_of_movements,
-  COUNT(DISTINCT(user_pseudo_id)) AS number_of_user_pseudo_ids,
-  COUNT(DISTINCT(CONCAT(user_pseudo_id, ga_session_id))) AS number_of_sessions,
-  page_views.from_url,
-  page_views.to_url
-FROM page_views
-INNER JOIN all_urls AS urls_from ON urls_from.url = page_views.from_url
-INNER JOIN all_urls AS urls_to ON urls_to.url = page_views.to_url
-GROUP BY
-  page_views.from_url,
-  page_views.to_url
-HAVING
-  number_of_movements > 5
-  AND number_of_user_pseudo_ids > 5
-  AND number_of_sessions > 5
-ORDER BY
-  number_of_movements DESC
-EOF
+    query = templatefile(
+      "bigquery/page-to-page-transitions.sql",
+      { project_id = var.project_id }
+    )
   }
   service_account_name = google_service_account.bigquery_page_transitions.email
 }

--- a/terraform-staging/bigquery/page-to-page-transitions.sql
+++ b/terraform-staging/bigquery/page-to-page-transitions.sql
@@ -1,0 +1,71 @@
+-- Count the number of transitions between each page on GOV.UK as collected by GA4.
+-- Only transitions between pages that exist in the content store are included.
+-- https://stackoverflow.com/a/70033601/937932
+
+CREATE TEMP TABLE page_views AS (
+  SELECT
+    user_pseudo_id,
+    (
+      SELECT
+        value.int_value
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'ga_session_id'
+    ) AS ga_session_id,
+    (
+      SELECT
+        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'page_referrer'
+    ) AS from_url,
+    (
+      SELECT
+        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'page_location'
+    ) AS to_url,
+  FROM `ga4-analytics-352613.analytics_330577055.events_*`
+  WHERE
+    event_name = 'page_view'
+    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 8 DAY))
+    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 2 DAY))
+);
+
+EXPORT DATA OPTIONS(
+  uri='gs://${project_id}-data-processed/ga4/page_to_page_transitions_*.csv.gz',
+  format='CSV',
+  compression='GZIP',
+  overwrite=true
+) AS
+
+WITH
+
+all_urls AS (
+  SELECT url FROM `${project_id}.content.url`
+  UNION ALL
+  SELECT url FROM `${project_id}.content.parts`
+)
+
+SELECT
+  COUNT(*) AS number_of_movements,
+  COUNT(DISTINCT(user_pseudo_id)) AS number_of_user_pseudo_ids,
+  COUNT(DISTINCT(CONCAT(user_pseudo_id, ga_session_id))) AS number_of_sessions,
+  page_views.from_url,
+  page_views.to_url
+FROM page_views
+INNER JOIN all_urls AS urls_from ON urls_from.url = page_views.from_url
+INNER JOIN all_urls AS urls_to ON urls_to.url = page_views.to_url
+GROUP BY
+  page_views.from_url,
+  page_views.to_url
+HAVING
+  number_of_movements > 5
+  AND number_of_user_pseudo_ids > 5
+  AND number_of_sessions > 5
+ORDER BY
+  number_of_movements DESC

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -10,79 +10,10 @@ resource "google_bigquery_data_transfer_config" "page_to_page_transitions" {
   location       = var.region
   schedule       = "every day 03:00"
   params = {
-    query = <<EOF
--- Count the number of transitions between each page on GOV.UK as collected by GA4.
--- Only transitions between pages that exist in the content store are included.
--- https://stackoverflow.com/a/70033601/937932
-
-CREATE TEMP TABLE page_views AS (
-  SELECT
-    user_pseudo_id,
-    (
-      SELECT
-        value.int_value
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'ga_session_id'
-    ) AS ga_session_id,
-    (
-      SELECT
-        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'page_referrer'
-    ) AS from_url,
-    (
-      SELECT
-        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
-      FROM
-        UNNEST(event_params)
-      WHERE
-        key = 'page_location'
-    ) AS to_url,
-  FROM `ga4-analytics-352613.analytics_330577055.events_*`
-  WHERE
-    event_name = 'page_view'
-    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 8 DAY))
-    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 2 DAY))
-);
-
-EXPORT DATA OPTIONS(
-  uri='gs://${var.project_id}-data-processed/ga4/page_to_page_transitions_*.csv.gz',
-  format='CSV',
-  compression='GZIP',
-  overwrite=true
-) AS
-
-WITH
-
-all_urls AS (
-  SELECT url FROM `${var.project_id}.content.url`
-  UNION ALL
-  SELECT url FROM `${var.project_id}.content.parts`
-)
-
-SELECT
-  COUNT(*) AS number_of_movements,
-  COUNT(DISTINCT(user_pseudo_id)) AS number_of_user_pseudo_ids,
-  COUNT(DISTINCT(CONCAT(user_pseudo_id, ga_session_id))) AS number_of_sessions,
-  page_views.from_url,
-  page_views.to_url
-FROM page_views
-INNER JOIN all_urls AS urls_from ON urls_from.url = page_views.from_url
-INNER JOIN all_urls AS urls_to ON urls_to.url = page_views.to_url
-GROUP BY
-  page_views.from_url,
-  page_views.to_url
-HAVING
-  number_of_movements > 5
-  AND number_of_user_pseudo_ids > 5
-  AND number_of_sessions > 5
-ORDER BY
-  number_of_movements DESC
-EOF
+    query = templatefile(
+      "bigquery/page-to-page-transitions.sql",
+      { project_id = var.project_id }
+    )
   }
   service_account_name = google_service_account.bigquery_page_transitions.email
 }

--- a/terraform/bigquery/page-to-page-transitions.sql
+++ b/terraform/bigquery/page-to-page-transitions.sql
@@ -1,0 +1,71 @@
+-- Count the number of transitions between each page on GOV.UK as collected by GA4.
+-- Only transitions between pages that exist in the content store are included.
+-- https://stackoverflow.com/a/70033601/937932
+
+CREATE TEMP TABLE page_views AS (
+  SELECT
+    user_pseudo_id,
+    (
+      SELECT
+        value.int_value
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'ga_session_id'
+    ) AS ga_session_id,
+    (
+      SELECT
+        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'page_referrer'
+    ) AS from_url,
+    (
+      SELECT
+        REGEXP_REPLACE(value.string_value, r"[?#].*", "")
+      FROM
+        UNNEST(event_params)
+      WHERE
+        key = 'page_location'
+    ) AS to_url,
+  FROM `ga4-analytics-352613.analytics_330577055.events_*`
+  WHERE
+    event_name = 'page_view'
+    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 8 DAY))
+    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(DATE(@run_date), INTERVAL - 2 DAY))
+);
+
+EXPORT DATA OPTIONS(
+  uri='gs://${project_id}-data-processed/ga4/page_to_page_transitions_*.csv.gz',
+  format='CSV',
+  compression='GZIP',
+  overwrite=true
+) AS
+
+WITH
+
+all_urls AS (
+  SELECT url FROM `${project_id}.content.url`
+  UNION ALL
+  SELECT url FROM `${project_id}.content.parts`
+)
+
+SELECT
+  COUNT(*) AS number_of_movements,
+  COUNT(DISTINCT(user_pseudo_id)) AS number_of_user_pseudo_ids,
+  COUNT(DISTINCT(CONCAT(user_pseudo_id, ga_session_id))) AS number_of_sessions,
+  page_views.from_url,
+  page_views.to_url
+FROM page_views
+INNER JOIN all_urls AS urls_from ON urls_from.url = page_views.from_url
+INNER JOIN all_urls AS urls_to ON urls_to.url = page_views.to_url
+GROUP BY
+  page_views.from_url,
+  page_views.to_url
+HAVING
+  number_of_movements > 5
+  AND number_of_user_pseudo_ids > 5
+  AND number_of_sessions > 5
+ORDER BY
+  number_of_movements DESC


### PR DESCRIPTION
Move the query out of a "here document" in the terraform config, and
into a separate SQL file.  This makes the SQL available to text editor
linting etc. and tidies up the terraform.
