### PR TITLE
Add description and phase to parts in Neo4j

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -210,6 +210,8 @@ CREATE (p)-[r:HAS_PART {
 SET
   p.text = c.text,
   c.publishingApp = p.publishingApp,
+  c.description = p.description,
+  c.phase = p.phase,
   c.contentId = p.contentId,
   c.locale = p.locale,
   c.firstPublishedAt = p.firstPublishedAt,


### PR DESCRIPTION
In BigQuery representations of page parts, the part inherits the
description and phase from its parent.  This commit makes Neo4j the
same.
