### PR TITLE
Clean text on upload into Neo4j

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -129,7 +129,7 @@ LOAD CSV WITH HEADERS
 FROM 'file:///title.csv' AS line
 FIELDTERMINATOR ','
 MATCH (p:Page { url: line.url })
-SET p.title = line.title
+SET p.title = apoc.text.clean(line.title)
 ;
 
 USING PERIODIC COMMIT
@@ -137,7 +137,7 @@ LOAD CSV WITH HEADERS
 FROM 'file:///description.csv' AS line
 FIELDTERMINATOR ','
 MATCH (p:Page { url: line.url })
-SET p.description = line.description
+SET p.description = apoc.text.clean(line.description)
 ;
 
 USING PERIODIC COMMIT
@@ -152,7 +152,7 @@ LOAD CSV WITH HEADERS
 FROM 'file:///content.csv' AS line
 FIELDTERMINATOR ','
 MATCH (p:Page { url: line.url })
-SET p.text = line.text
+SET p.text = apoc.text.clean(line.text)
 ;
 
 // coalesce() handles a handful of links that have malformed URLs, or empty link


### PR DESCRIPTION
GOV.UK content includes non-printable characters such as non-breaking
spaces.  In BigQuery, the `CONTAINS_SUBSTR()` function normalizes the
text before looking for matches, but Neo4j doesn't, so Neo4j searches
miss some matches that we believe users expect.  The `apoc.text.clean()`
function in Neo4j does the equivalent normalization to BigQuery, but it
takes a long time, so instead of asking users to use that function, this
commit uses the function when the content is imported into Neo4j.
