### PR TITLE
Use page view statistics instead of pagerank

### DIFF
--- a/docker/neo4j/run.sh
+++ b/docker/neo4j/run.sh
@@ -69,6 +69,10 @@ gcloud storage cat \
   "gs://${PROJECT_ID}-data-processed/ga4/page_to_page_transitions_[0-9]*.csv.gz" \
   > /var/lib/neo4j/import/page_to_page_transitions.csv.gz
 
+gcloud storage cp \
+  "gs://${PROJECT_ID}-data-processed/ga4/page_views.csv.gz" \
+  "/var/lib/neo4j/import/page_views.csv.gz"
+
 gcloud storage cp --recursive \
   "gs://${PROJECT_ID}-data-processed/publishing-api/*" \
   "/var/lib/neo4j/import"

--- a/src/mongodb/bigquery/page.sql
+++ b/src/mongodb/bigquery/page.sql
@@ -21,6 +21,7 @@ SELECT
   c.text,
   CAST(NULL AS INT64) AS part_index,
   CAST(NULL AS STRING) AS slug,
+  page_views.number_of_views,
   pagerank.pagerank
 FROM content.url AS u
 LEFT JOIN content.document_type USING (url)
@@ -39,6 +40,7 @@ LEFT JOIN content.title USING (url)
 LEFT JOIN content.description USING (url)
 LEFT JOIN content.department_analytics_profile USING (url)
 LEFT JOIN content.content AS c USING (url)
+LEFT JOIN content.page_views USING (url)
 LEFT JOIN content.pagerank USING (url)
 ;
 
@@ -53,11 +55,13 @@ SELECT
     parts.part_title AS title,
     c.text AS text,
     parts.part_index AS part_index,
-    parts.slug AS slug
+    parts.slug AS slug,
+    page_views.number_of_views,
   )
 FROM graph.page
 INNER JOIN content.parts ON page.url = parts.base_path
 LEFT JOIN content.content AS c ON c.url = parts.url
+LEFT JOIN content.page_views on (page_views.url = parts.url)
 ;
 INSERT INTO graph.page SELECT * FROM graph.part;
 

--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -371,6 +371,16 @@ SET n:ExternalPage
 REMOVE n:Page
 ;
 
+// Page view counts from Google Analytics (GA4, BigQuery)
+USING PERIODIC COMMIT
+LOAD CSV WITH HEADERS
+FROM 'file:///page_views.csv' AS line
+FIELDTERMINATOR ','
+MATCH (p:Page { url: line.from_url })
+SET
+  p.number_of_views = toInteger(line.number_of_views)
+;
+
 // Page-to-page transitions from Google Analytics (GA4, BigQuery)
 USING PERIODIC COMMIT
 LOAD CSV WITH HEADERS

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -17,6 +17,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:${google_service_account.gce_postgres.email}",
       "serviceAccount:${google_service_account.gce_neo4j.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
     ]
   }
   binding {
@@ -29,7 +30,6 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
@@ -1938,6 +1938,29 @@ resource "google_bigquery_table" "bank_holiday_title" {
         name        = "title"
         type        = "STRING"
         description = "Title of the bank holiday"
+      }
+    ]
+  )
+}
+
+resource "google_bigquery_table" "page_views" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "page_views"
+  friendly_name = "Page views"
+  description   = "Number of views of GOV.UK pages over 7 days"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "url"
+        type        = "STRING"
+        description = "URL of a page"
+      },
+      {
+        mode        = "REQUIRED"
+        name        = "number_of_views"
+        type        = "INTEGER"
+        description = "Number of views of the URL"
       }
     ]
   )

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -165,6 +165,12 @@ resource "google_bigquery_table" "page" {
   },
   {
     "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "pagerank",
     "type": "BIGNUMERIC",
     "description": "Page rank of a page on GOV.UK"
@@ -293,6 +299,12 @@ resource "google_bigquery_table" "part" {
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path of the part to get the url"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
   },
   {
     "mode": "NULLABLE",

--- a/terraform-dev/bigquery-search.tf
+++ b/terraform-dev/bigquery-search.tf
@@ -108,6 +108,12 @@ resource "google_bigquery_table" "search_page" {
   },
   {
     "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "pagerank",
     "type": "BIGNUMERIC",
     "description": "Page rank of a page on GOV.UK"

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -52,3 +52,11 @@ ORDER BY
 EOF
   }
 }
+
+resource "google_bigquery_routine" "page_views" {
+  dataset_id = google_bigquery_dataset.content.dataset_id
+  routine_id     = "page_views"
+  routine_type = "PROCEDURE"
+  language = "SQL"
+  definition_body = file("bigquery/page-views.sql")
+}

--- a/terraform-dev/bigquery/page-views.sql
+++ b/terraform-dev/bigquery/page-views.sql
@@ -1,0 +1,32 @@
+-- Count the number of views of pages on GOV.UK as collected by GA4.
+-- Only pages that exist in the content store are included.
+DELETE FROM content.page_views WHERE TRUE;
+INSERT INTO content.page_views
+WITH
+page_views AS (
+  SELECT
+  (
+    SELECT REGEXP_REPLACE(value.string_value, r'[?#].*', '')
+    FROM UNNEST(event_params)
+    WHERE key = 'page_location'
+  ) AS url,
+  FROM `ga4-analytics-352613.analytics_330577055.events_*`
+  WHERE
+    event_name = 'page_view'
+    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL - 8 DAY))
+    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL - 2 DAY))
+),
+all_urls AS (
+  SELECT url FROM `content.url`
+  UNION ALL
+  SELECT url FROM `content.parts`
+)
+SELECT
+  page_views.url,
+  COUNT(*) AS number_of_views
+FROM page_views
+INNER JOIN all_urls ON all_urls.url = page_views.url
+GROUP BY page_views.url
+HAVING number_of_views > 5
+ORDER BY number_of_views DESC
+;

--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -64,6 +64,7 @@ SELECT
   public_updated_at,
   withdrawn_at,
   withdrawn_explanation,
+  page_views,
   pagerank,
   title,
   description,

--- a/terraform-dev/workflow-page-views.yaml
+++ b/terraform-dev/workflow-page-views.yaml
@@ -1,0 +1,247 @@
+# Google Workflow
+#
+# (1) Refresh the content.page_views table
+# (2) Delete any files that were left after last time
+# (3) Export the table to a bucket as a single, compressed CSV file
+# (4) Delete the incremental files
+#
+# https://medium.com/google-cloud/get-a-single-one-csv-file-with-bigquery-export-956d2a147886
+
+main:
+  steps:
+    - init:
+        assign:
+          - projectId: '${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}'
+          - bucket:  '${"govuk-knowledge-graph-dev-data-processed"}'
+          - file_name: page_views
+          - file_prefix: '${"ga4/" + file_name}'
+          - file_suffix: .csv.gz
+          - finalFileName: '${file_prefix + file_suffix}'
+          - listResultDelete:
+              nextPageToken: ''
+          - listResultClean:
+              nextPageToken: ''
+          - listResult:
+              nextPageToken: ''
+          - fileList:
+              - ''
+          - datasetId: content
+          - tableId: page_views
+          - run_date: '${text.substring(time.format(sys.now()), 0, 10)}'
+          - query: "CALL content.page_views();"
+    - refresh-table:
+        call: googleapis.bigquery.v2.jobs.insert
+        args:
+          projectId: ${projectId}
+          body:
+            configuration:
+              query:
+                query: ${query}
+                allowLargeResults: true
+                useLegacySql: false
+    - delete-existing-files:
+        call: list_and_delete_files
+        args:
+          pagetoken: '${listResultDelete.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix}'
+        result: listResultDelete
+    - missed-files-delete: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResultDelete}'
+            next: delete-existing-files
+    - wait:
+        call: sys.sleep
+        args:
+          seconds: 1
+    - export-headers:
+        call: googleapis.bigquery.v2.jobs.query
+        args:
+          projectId: '${projectId}'
+          body:
+            query: >-
+              ${"
+                EXPORT DATA OPTIONS(
+                  uri='gs://" + bucket + "/" + file_prefix + "_0_header_*.csv',
+                  format='CSV',
+                  compression='GZIP', overwrite=true,
+                  header=true
+                )
+                  AS SELECT * FROM `" + datasetId + "." + tableId +"`
+                  LIMIT 0
+                ;
+              "}
+            useLegacySql: false
+    - export-data:
+        call: googleapis.bigquery.v2.jobs.insert
+        args:
+          projectId: '${projectId}'
+          body:
+            configuration:
+              extract:
+                compression: GZIP
+                destinationFormat: CSV
+                destinationUris:
+                  - '${"gs://" + bucket + "/" + file_prefix + "_1_data_*.csv"}'
+                fieldDelimiter: ','
+                printHeader: false
+                sourceTable:
+                  projectId: '${projectId}'
+                  datasetId: '${datasetId}'
+                  tableId: '${tableId}'
+    - create-empty-file:
+        call: http.post
+        args:
+          url: >-
+            ${"https://storage.googleapis.com/upload/storage/v1/b/" + bucket +
+            "/o?name=" + finalFileName + "&uploadType=media"}
+          auth:
+            type: OAuth2
+    - compose:
+        call: list_and_compose_file
+        args:
+          pagetoken: '${listResult.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix}'
+          projectId: '${projectId}'
+          finalFileName: '${finalFileName}'
+        result: listResult
+    - mised-files-compose: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResult}'
+            next: compose
+    - delete-incremental-files:
+        call: list_and_delete_files
+        args:
+          pagetoken: '${listResultClean.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix + "_"}'
+        result: listResultClean
+    - missed-files-incremental: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResultDelete}'
+            next: delete-incremental-files
+    - the-end:
+        return: ${listResultDelete}
+
+# Delete any old files
+# Adapted from:
+# https://github.com/alphagov/govuk-content-metadata/blob/da29f7cbe8767e5b5d440f141a90d0d05b9824b4/src/post_extraction_process/post-extraction-gc-workflow.yaml
+list_and_delete_files:
+    params:
+      - pagetoken
+      - bucket
+      - prefix
+    steps:
+      - list-files:
+          call: googleapis.storage.v1.objects.list
+          args:
+            bucket: ${bucket}
+            pageToken: ${pagetoken}
+            prefix: ${prefix}
+            maxResults: 62
+          result: listResultDelete
+      - check-if-any-files:
+          switch:
+            - condition: '${not("items" in listResultDelete)}'
+              next: return-step
+      - delete-files:
+          try:
+              for:
+                value: file
+                in: ${listResultDelete.items}
+                steps:
+                    - delete-file:
+                          call: googleapis.storage.v1.objects.delete
+                          args:
+                            bucket: ${bucket}
+                            object: ${text.replace_all(file.name,"/","%2F")}
+                          result: deleteResult
+          except:
+            as: e
+            steps:
+              - known-errors:
+                  switch:
+                    - condition: ${not("KeyError" in e)}
+                      return: "files do not exists"
+      - return-step:
+          return: ${listResultDelete}
+
+# Export a BigQuery table to a single file
+# https://medium.com/google-cloud/get-a-single-one-csv-file-with-bigquery-export-956d2a147886
+list_and_compose_file:
+    params:
+      - pagetoken
+      - bucket
+      - prefix
+      - projectId
+      - finalFileName
+    steps:
+      - list-files:
+          call: googleapis.storage.v1.objects.list
+          args:
+            bucket: ${bucket}
+            pageToken: ${pagetoken}
+            prefix: ${prefix}
+            maxResults: 62
+          result: listResult
+      - init-iter:
+          assign:
+            - finalFileFormatted:
+                name: ${finalFileName}
+            - fileList:
+                - ${finalFileFormatted}
+      - process-files:
+          for:
+            value: file
+            in: ${listResult.items}
+            steps:
+              - concat-file:
+                  assign:
+                    - fileFormatted:
+                        name: ${file.name}
+                    - fileList: ${list.concat(fileList, fileFormatted)}
+              - test-concat:
+                  switch:
+                    - condition: ${len(fileList) == 32}
+                      steps:
+                        - compose-files:
+                            call: compose_file
+                            args:
+                              fileList: ${fileList}
+                              projectId: ${projectId}
+                              bucket: ${bucket}
+                              finalFileName: ${finalFileName}
+                            next: init-for-iter
+                        - init-for-iter:
+                            assign:
+                              - fileList:
+                                  - ${finalFileFormatted}
+      - finish-compose: # Process the latest files in the fileList buffer
+          switch:
+            - condition: ${len(fileList) > 1} # If there is more than the finalFileName in the list
+              steps:
+                - last-compose-files:
+                    call: compose_file
+                    args:
+                      fileList: ${fileList}
+                      projectId: ${projectId}
+                      bucket: ${bucket}
+                      finalFileName: ${finalFileName}
+      - return-step:
+          return: ${listResult}
+
+compose_file:
+  params:
+    - fileList
+    - projectId
+    - bucket
+    - finalFileName
+  steps:
+    - compose:
+        call: googleapis.storage.v1.objects.compose
+        args:
+          destinationBucket: ${bucket}
+          destinationObject: ${text.replace_all(finalFileName,"/","%2F")}
+          body:
+            sourceObjects: ${fileList}

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -386,3 +386,35 @@ resource "google_cloud_scheduler_job" "bank_holidays" {
     }
   }
 }
+
+# A workflow to fetch page views from GA4 and export them to a file in a bucket
+resource "google_workflows_workflow" "page_views" {
+  name            = "page-views"
+  region          = var.region
+  description     = "Fetch page view counts from GA4 into BigQuery and export to a bucket"
+  service_account = google_service_account.bigquery_page_transitions.id
+  source_contents = file("workflow-page-views.yaml")
+}
+
+# A service account for Cloud Scheduler to run the page_views workflow
+resource "google_service_account" "scheduler_page_views" {
+  account_id   = "scheduler-page-views"
+  display_name = "Service Account for scheduling the page-views workflow"
+  description  = "Service Account for scheduling the page-views workflow"
+}
+
+# A schedule to fetch page view statistics
+resource "google_cloud_scheduler_job" "page_views" {
+  name        = "page-views"
+  description = "Fetch page-view statistics"
+  schedule    = "0 3 * * *"
+  time_zone   = "Europe/London"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.page_views.id}/executions"
+    oauth_token {
+      service_account_email = google_service_account.scheduler_page_views.email
+    }
+  }
+}

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -17,6 +17,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:${google_service_account.gce_postgres.email}",
       "serviceAccount:${google_service_account.gce_neo4j.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
     ]
   }
   binding {
@@ -29,7 +30,6 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
@@ -1938,6 +1938,29 @@ resource "google_bigquery_table" "bank_holiday_title" {
         name        = "title"
         type        = "STRING"
         description = "Title of the bank holiday"
+      }
+    ]
+  )
+}
+
+resource "google_bigquery_table" "page_views" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "page_views"
+  friendly_name = "Page views"
+  description   = "Number of views of GOV.UK pages over 7 days"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "url"
+        type        = "STRING"
+        description = "URL of a page"
+      },
+      {
+        mode        = "REQUIRED"
+        name        = "number_of_views"
+        type        = "INTEGER"
+        description = "Number of views of the URL"
       }
     ]
   )

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -165,6 +165,12 @@ resource "google_bigquery_table" "page" {
   },
   {
     "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "pagerank",
     "type": "BIGNUMERIC",
     "description": "Page rank of a page on GOV.UK"
@@ -293,6 +299,12 @@ resource "google_bigquery_table" "part" {
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path of the part to get the url"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
   },
   {
     "mode": "NULLABLE",

--- a/terraform-staging/bigquery-search.tf
+++ b/terraform-staging/bigquery-search.tf
@@ -108,6 +108,12 @@ resource "google_bigquery_table" "search_page" {
   },
   {
     "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "pagerank",
     "type": "BIGNUMERIC",
     "description": "Page rank of a page on GOV.UK"

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -52,3 +52,11 @@ ORDER BY
 EOF
   }
 }
+
+resource "google_bigquery_routine" "page_views" {
+  dataset_id = google_bigquery_dataset.content.dataset_id
+  routine_id     = "page_views"
+  routine_type = "PROCEDURE"
+  language = "SQL"
+  definition_body = file("bigquery/page-views.sql")
+}

--- a/terraform-staging/bigquery/page-views.sql
+++ b/terraform-staging/bigquery/page-views.sql
@@ -1,0 +1,32 @@
+-- Count the number of views of pages on GOV.UK as collected by GA4.
+-- Only pages that exist in the content store are included.
+DELETE FROM content.page_views WHERE TRUE;
+INSERT INTO content.page_views
+WITH
+page_views AS (
+  SELECT
+  (
+    SELECT REGEXP_REPLACE(value.string_value, r'[?#].*', '')
+    FROM UNNEST(event_params)
+    WHERE key = 'page_location'
+  ) AS url,
+  FROM `ga4-analytics-352613.analytics_330577055.events_*`
+  WHERE
+    event_name = 'page_view'
+    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL - 8 DAY))
+    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL - 2 DAY))
+),
+all_urls AS (
+  SELECT url FROM `content.url`
+  UNION ALL
+  SELECT url FROM `content.parts`
+)
+SELECT
+  page_views.url,
+  COUNT(*) AS number_of_views
+FROM page_views
+INNER JOIN all_urls ON all_urls.url = page_views.url
+GROUP BY page_views.url
+HAVING number_of_views > 5
+ORDER BY number_of_views DESC
+;

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -64,6 +64,7 @@ SELECT
   public_updated_at,
   withdrawn_at,
   withdrawn_explanation,
+  page_views,
   pagerank,
   title,
   description,

--- a/terraform-staging/workflow-page-views.yaml
+++ b/terraform-staging/workflow-page-views.yaml
@@ -1,0 +1,247 @@
+# Google Workflow
+#
+# (1) Refresh the content.page_views table
+# (2) Delete any files that were left after last time
+# (3) Export the table to a bucket as a single, compressed CSV file
+# (4) Delete the incremental files
+#
+# https://medium.com/google-cloud/get-a-single-one-csv-file-with-bigquery-export-956d2a147886
+
+main:
+  steps:
+    - init:
+        assign:
+          - projectId: '${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}'
+          - bucket:  '${"govuk-knowledge-graph-dev-data-processed"}'
+          - file_name: page_views
+          - file_prefix: '${"ga4/" + file_name}'
+          - file_suffix: .csv.gz
+          - finalFileName: '${file_prefix + file_suffix}'
+          - listResultDelete:
+              nextPageToken: ''
+          - listResultClean:
+              nextPageToken: ''
+          - listResult:
+              nextPageToken: ''
+          - fileList:
+              - ''
+          - datasetId: content
+          - tableId: page_views
+          - run_date: '${text.substring(time.format(sys.now()), 0, 10)}'
+          - query: "CALL content.page_views();"
+    - refresh-table:
+        call: googleapis.bigquery.v2.jobs.insert
+        args:
+          projectId: ${projectId}
+          body:
+            configuration:
+              query:
+                query: ${query}
+                allowLargeResults: true
+                useLegacySql: false
+    - delete-existing-files:
+        call: list_and_delete_files
+        args:
+          pagetoken: '${listResultDelete.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix}'
+        result: listResultDelete
+    - missed-files-delete: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResultDelete}'
+            next: delete-existing-files
+    - wait:
+        call: sys.sleep
+        args:
+          seconds: 1
+    - export-headers:
+        call: googleapis.bigquery.v2.jobs.query
+        args:
+          projectId: '${projectId}'
+          body:
+            query: >-
+              ${"
+                EXPORT DATA OPTIONS(
+                  uri='gs://" + bucket + "/" + file_prefix + "_0_header_*.csv',
+                  format='CSV',
+                  compression='GZIP', overwrite=true,
+                  header=true
+                )
+                  AS SELECT * FROM `" + datasetId + "." + tableId +"`
+                  LIMIT 0
+                ;
+              "}
+            useLegacySql: false
+    - export-data:
+        call: googleapis.bigquery.v2.jobs.insert
+        args:
+          projectId: '${projectId}'
+          body:
+            configuration:
+              extract:
+                compression: GZIP
+                destinationFormat: CSV
+                destinationUris:
+                  - '${"gs://" + bucket + "/" + file_prefix + "_1_data_*.csv"}'
+                fieldDelimiter: ','
+                printHeader: false
+                sourceTable:
+                  projectId: '${projectId}'
+                  datasetId: '${datasetId}'
+                  tableId: '${tableId}'
+    - create-empty-file:
+        call: http.post
+        args:
+          url: >-
+            ${"https://storage.googleapis.com/upload/storage/v1/b/" + bucket +
+            "/o?name=" + finalFileName + "&uploadType=media"}
+          auth:
+            type: OAuth2
+    - compose:
+        call: list_and_compose_file
+        args:
+          pagetoken: '${listResult.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix}'
+          projectId: '${projectId}'
+          finalFileName: '${finalFileName}'
+        result: listResult
+    - mised-files-compose: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResult}'
+            next: compose
+    - delete-incremental-files:
+        call: list_and_delete_files
+        args:
+          pagetoken: '${listResultClean.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix + "_"}'
+        result: listResultClean
+    - missed-files-incremental: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResultDelete}'
+            next: delete-incremental-files
+    - the-end:
+        return: ${listResultDelete}
+
+# Delete any old files
+# Adapted from:
+# https://github.com/alphagov/govuk-content-metadata/blob/da29f7cbe8767e5b5d440f141a90d0d05b9824b4/src/post_extraction_process/post-extraction-gc-workflow.yaml
+list_and_delete_files:
+    params:
+      - pagetoken
+      - bucket
+      - prefix
+    steps:
+      - list-files:
+          call: googleapis.storage.v1.objects.list
+          args:
+            bucket: ${bucket}
+            pageToken: ${pagetoken}
+            prefix: ${prefix}
+            maxResults: 62
+          result: listResultDelete
+      - check-if-any-files:
+          switch:
+            - condition: '${not("items" in listResultDelete)}'
+              next: return-step
+      - delete-files:
+          try:
+              for:
+                value: file
+                in: ${listResultDelete.items}
+                steps:
+                    - delete-file:
+                          call: googleapis.storage.v1.objects.delete
+                          args:
+                            bucket: ${bucket}
+                            object: ${text.replace_all(file.name,"/","%2F")}
+                          result: deleteResult
+          except:
+            as: e
+            steps:
+              - known-errors:
+                  switch:
+                    - condition: ${not("KeyError" in e)}
+                      return: "files do not exists"
+      - return-step:
+          return: ${listResultDelete}
+
+# Export a BigQuery table to a single file
+# https://medium.com/google-cloud/get-a-single-one-csv-file-with-bigquery-export-956d2a147886
+list_and_compose_file:
+    params:
+      - pagetoken
+      - bucket
+      - prefix
+      - projectId
+      - finalFileName
+    steps:
+      - list-files:
+          call: googleapis.storage.v1.objects.list
+          args:
+            bucket: ${bucket}
+            pageToken: ${pagetoken}
+            prefix: ${prefix}
+            maxResults: 62
+          result: listResult
+      - init-iter:
+          assign:
+            - finalFileFormatted:
+                name: ${finalFileName}
+            - fileList:
+                - ${finalFileFormatted}
+      - process-files:
+          for:
+            value: file
+            in: ${listResult.items}
+            steps:
+              - concat-file:
+                  assign:
+                    - fileFormatted:
+                        name: ${file.name}
+                    - fileList: ${list.concat(fileList, fileFormatted)}
+              - test-concat:
+                  switch:
+                    - condition: ${len(fileList) == 32}
+                      steps:
+                        - compose-files:
+                            call: compose_file
+                            args:
+                              fileList: ${fileList}
+                              projectId: ${projectId}
+                              bucket: ${bucket}
+                              finalFileName: ${finalFileName}
+                            next: init-for-iter
+                        - init-for-iter:
+                            assign:
+                              - fileList:
+                                  - ${finalFileFormatted}
+      - finish-compose: # Process the latest files in the fileList buffer
+          switch:
+            - condition: ${len(fileList) > 1} # If there is more than the finalFileName in the list
+              steps:
+                - last-compose-files:
+                    call: compose_file
+                    args:
+                      fileList: ${fileList}
+                      projectId: ${projectId}
+                      bucket: ${bucket}
+                      finalFileName: ${finalFileName}
+      - return-step:
+          return: ${listResult}
+
+compose_file:
+  params:
+    - fileList
+    - projectId
+    - bucket
+    - finalFileName
+  steps:
+    - compose:
+        call: googleapis.storage.v1.objects.compose
+        args:
+          destinationBucket: ${bucket}
+          destinationObject: ${text.replace_all(finalFileName,"/","%2F")}
+          body:
+            sourceObjects: ${fileList}

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -386,3 +386,35 @@ resource "google_cloud_scheduler_job" "bank_holidays" {
     }
   }
 }
+
+# A workflow to fetch page views from GA4 and export them to a file in a bucket
+resource "google_workflows_workflow" "page_views" {
+  name            = "page-views"
+  region          = var.region
+  description     = "Fetch page view counts from GA4 into BigQuery and export to a bucket"
+  service_account = google_service_account.bigquery_page_transitions.id
+  source_contents = file("workflow-page-views.yaml")
+}
+
+# A service account for Cloud Scheduler to run the page_views workflow
+resource "google_service_account" "scheduler_page_views" {
+  account_id   = "scheduler-page-views"
+  display_name = "Service Account for scheduling the page-views workflow"
+  description  = "Service Account for scheduling the page-views workflow"
+}
+
+# A schedule to fetch page view statistics
+resource "google_cloud_scheduler_job" "page_views" {
+  name        = "page-views"
+  description = "Fetch page-view statistics"
+  schedule    = "0 3 * * *"
+  time_zone   = "Europe/London"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.page_views.id}/executions"
+    oauth_token {
+      service_account_email = google_service_account.scheduler_page_views.email
+    }
+  }
+}

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -17,6 +17,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:${google_service_account.gce_postgres.email}",
       "serviceAccount:${google_service_account.gce_neo4j.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
     ]
   }
   binding {
@@ -29,7 +30,6 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
@@ -1938,6 +1938,29 @@ resource "google_bigquery_table" "bank_holiday_title" {
         name        = "title"
         type        = "STRING"
         description = "Title of the bank holiday"
+      }
+    ]
+  )
+}
+
+resource "google_bigquery_table" "page_views" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "page_views"
+  friendly_name = "Page views"
+  description   = "Number of views of GOV.UK pages over 7 days"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "url"
+        type        = "STRING"
+        description = "URL of a page"
+      },
+      {
+        mode        = "REQUIRED"
+        name        = "number_of_views"
+        type        = "INTEGER"
+        description = "Number of views of the URL"
       }
     ]
   )

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -165,6 +165,12 @@ resource "google_bigquery_table" "page" {
   },
   {
     "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "pagerank",
     "type": "BIGNUMERIC",
     "description": "Page rank of a page on GOV.UK"
@@ -293,6 +299,12 @@ resource "google_bigquery_table" "part" {
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path of the part to get the url"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "INTEGER",
+    "description": "Number of page views from GA4 over 7 recent days"
   },
   {
     "mode": "NULLABLE",

--- a/terraform/bigquery-search.tf
+++ b/terraform/bigquery-search.tf
@@ -108,6 +108,12 @@ resource "google_bigquery_table" "search_page" {
   },
   {
     "mode": "NULLABLE",
+    "name": "page_views",
+    "type": "BIGNUMERIC",
+    "description": "Number of page views from GA4 over 7 recent days"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "pagerank",
     "type": "BIGNUMERIC",
     "description": "Page rank of a page on GOV.UK"

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -52,3 +52,11 @@ ORDER BY
 EOF
   }
 }
+
+resource "google_bigquery_routine" "page_views" {
+  dataset_id = google_bigquery_dataset.content.dataset_id
+  routine_id     = "page_views"
+  routine_type = "PROCEDURE"
+  language = "SQL"
+  definition_body = file("bigquery/page-views.sql")
+}

--- a/terraform/bigquery/page-views.sql
+++ b/terraform/bigquery/page-views.sql
@@ -1,0 +1,32 @@
+-- Count the number of views of pages on GOV.UK as collected by GA4.
+-- Only pages that exist in the content store are included.
+DELETE FROM content.page_views WHERE TRUE;
+INSERT INTO content.page_views
+WITH
+page_views AS (
+  SELECT
+  (
+    SELECT REGEXP_REPLACE(value.string_value, r'[?#].*', '')
+    FROM UNNEST(event_params)
+    WHERE key = 'page_location'
+  ) AS url,
+  FROM `ga4-analytics-352613.analytics_330577055.events_*`
+  WHERE
+    event_name = 'page_view'
+    AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL - 8 DAY))
+    AND _TABLE_SUFFIX <= FORMAT_DATE('%Y%m%d', DATE_ADD(CURRENT_DATE(), INTERVAL - 2 DAY))
+),
+all_urls AS (
+  SELECT url FROM `content.url`
+  UNION ALL
+  SELECT url FROM `content.parts`
+)
+SELECT
+  page_views.url,
+  COUNT(*) AS number_of_views
+FROM page_views
+INNER JOIN all_urls ON all_urls.url = page_views.url
+GROUP BY page_views.url
+HAVING number_of_views > 5
+ORDER BY number_of_views DESC
+;

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -64,6 +64,7 @@ SELECT
   public_updated_at,
   withdrawn_at,
   withdrawn_explanation,
+  page_views,
   pagerank,
   title,
   description,

--- a/terraform/workflow-page-views.yaml
+++ b/terraform/workflow-page-views.yaml
@@ -1,0 +1,247 @@
+# Google Workflow
+#
+# (1) Refresh the content.page_views table
+# (2) Delete any files that were left after last time
+# (3) Export the table to a bucket as a single, compressed CSV file
+# (4) Delete the incremental files
+#
+# https://medium.com/google-cloud/get-a-single-one-csv-file-with-bigquery-export-956d2a147886
+
+main:
+  steps:
+    - init:
+        assign:
+          - projectId: '${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}'
+          - bucket:  '${"govuk-knowledge-graph-dev-data-processed"}'
+          - file_name: page_views
+          - file_prefix: '${"ga4/" + file_name}'
+          - file_suffix: .csv.gz
+          - finalFileName: '${file_prefix + file_suffix}'
+          - listResultDelete:
+              nextPageToken: ''
+          - listResultClean:
+              nextPageToken: ''
+          - listResult:
+              nextPageToken: ''
+          - fileList:
+              - ''
+          - datasetId: content
+          - tableId: page_views
+          - run_date: '${text.substring(time.format(sys.now()), 0, 10)}'
+          - query: "CALL content.page_views();"
+    - refresh-table:
+        call: googleapis.bigquery.v2.jobs.insert
+        args:
+          projectId: ${projectId}
+          body:
+            configuration:
+              query:
+                query: ${query}
+                allowLargeResults: true
+                useLegacySql: false
+    - delete-existing-files:
+        call: list_and_delete_files
+        args:
+          pagetoken: '${listResultDelete.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix}'
+        result: listResultDelete
+    - missed-files-delete: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResultDelete}'
+            next: delete-existing-files
+    - wait:
+        call: sys.sleep
+        args:
+          seconds: 1
+    - export-headers:
+        call: googleapis.bigquery.v2.jobs.query
+        args:
+          projectId: '${projectId}'
+          body:
+            query: >-
+              ${"
+                EXPORT DATA OPTIONS(
+                  uri='gs://" + bucket + "/" + file_prefix + "_0_header_*.csv',
+                  format='CSV',
+                  compression='GZIP', overwrite=true,
+                  header=true
+                )
+                  AS SELECT * FROM `" + datasetId + "." + tableId +"`
+                  LIMIT 0
+                ;
+              "}
+            useLegacySql: false
+    - export-data:
+        call: googleapis.bigquery.v2.jobs.insert
+        args:
+          projectId: '${projectId}'
+          body:
+            configuration:
+              extract:
+                compression: GZIP
+                destinationFormat: CSV
+                destinationUris:
+                  - '${"gs://" + bucket + "/" + file_prefix + "_1_data_*.csv"}'
+                fieldDelimiter: ','
+                printHeader: false
+                sourceTable:
+                  projectId: '${projectId}'
+                  datasetId: '${datasetId}'
+                  tableId: '${tableId}'
+    - create-empty-file:
+        call: http.post
+        args:
+          url: >-
+            ${"https://storage.googleapis.com/upload/storage/v1/b/" + bucket +
+            "/o?name=" + finalFileName + "&uploadType=media"}
+          auth:
+            type: OAuth2
+    - compose:
+        call: list_and_compose_file
+        args:
+          pagetoken: '${listResult.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix}'
+          projectId: '${projectId}'
+          finalFileName: '${finalFileName}'
+        result: listResult
+    - mised-files-compose: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResult}'
+            next: compose
+    - delete-incremental-files:
+        call: list_and_delete_files
+        args:
+          pagetoken: '${listResultClean.nextPageToken}'
+          bucket: '${bucket}'
+          prefix: '${file_prefix + "_"}'
+        result: listResultClean
+    - missed-files-incremental: # Non recursive loop, to prevent depth errors
+        switch:
+          - condition: '${"nextPageToken" in listResultDelete}'
+            next: delete-incremental-files
+    - the-end:
+        return: ${listResultDelete}
+
+# Delete any old files
+# Adapted from:
+# https://github.com/alphagov/govuk-content-metadata/blob/da29f7cbe8767e5b5d440f141a90d0d05b9824b4/src/post_extraction_process/post-extraction-gc-workflow.yaml
+list_and_delete_files:
+    params:
+      - pagetoken
+      - bucket
+      - prefix
+    steps:
+      - list-files:
+          call: googleapis.storage.v1.objects.list
+          args:
+            bucket: ${bucket}
+            pageToken: ${pagetoken}
+            prefix: ${prefix}
+            maxResults: 62
+          result: listResultDelete
+      - check-if-any-files:
+          switch:
+            - condition: '${not("items" in listResultDelete)}'
+              next: return-step
+      - delete-files:
+          try:
+              for:
+                value: file
+                in: ${listResultDelete.items}
+                steps:
+                    - delete-file:
+                          call: googleapis.storage.v1.objects.delete
+                          args:
+                            bucket: ${bucket}
+                            object: ${text.replace_all(file.name,"/","%2F")}
+                          result: deleteResult
+          except:
+            as: e
+            steps:
+              - known-errors:
+                  switch:
+                    - condition: ${not("KeyError" in e)}
+                      return: "files do not exists"
+      - return-step:
+          return: ${listResultDelete}
+
+# Export a BigQuery table to a single file
+# https://medium.com/google-cloud/get-a-single-one-csv-file-with-bigquery-export-956d2a147886
+list_and_compose_file:
+    params:
+      - pagetoken
+      - bucket
+      - prefix
+      - projectId
+      - finalFileName
+    steps:
+      - list-files:
+          call: googleapis.storage.v1.objects.list
+          args:
+            bucket: ${bucket}
+            pageToken: ${pagetoken}
+            prefix: ${prefix}
+            maxResults: 62
+          result: listResult
+      - init-iter:
+          assign:
+            - finalFileFormatted:
+                name: ${finalFileName}
+            - fileList:
+                - ${finalFileFormatted}
+      - process-files:
+          for:
+            value: file
+            in: ${listResult.items}
+            steps:
+              - concat-file:
+                  assign:
+                    - fileFormatted:
+                        name: ${file.name}
+                    - fileList: ${list.concat(fileList, fileFormatted)}
+              - test-concat:
+                  switch:
+                    - condition: ${len(fileList) == 32}
+                      steps:
+                        - compose-files:
+                            call: compose_file
+                            args:
+                              fileList: ${fileList}
+                              projectId: ${projectId}
+                              bucket: ${bucket}
+                              finalFileName: ${finalFileName}
+                            next: init-for-iter
+                        - init-for-iter:
+                            assign:
+                              - fileList:
+                                  - ${finalFileFormatted}
+      - finish-compose: # Process the latest files in the fileList buffer
+          switch:
+            - condition: ${len(fileList) > 1} # If there is more than the finalFileName in the list
+              steps:
+                - last-compose-files:
+                    call: compose_file
+                    args:
+                      fileList: ${fileList}
+                      projectId: ${projectId}
+                      bucket: ${bucket}
+                      finalFileName: ${finalFileName}
+      - return-step:
+          return: ${listResult}
+
+compose_file:
+  params:
+    - fileList
+    - projectId
+    - bucket
+    - finalFileName
+  steps:
+    - compose:
+        call: googleapis.storage.v1.objects.compose
+        args:
+          destinationBucket: ${bucket}
+          destinationObject: ${text.replace_all(finalFileName,"/","%2F")}
+          body:
+            sourceObjects: ${fileList}

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -386,3 +386,35 @@ resource "google_cloud_scheduler_job" "bank_holidays" {
     }
   }
 }
+
+# A workflow to fetch page views from GA4 and export them to a file in a bucket
+resource "google_workflows_workflow" "page_views" {
+  name            = "page-views"
+  region          = var.region
+  description     = "Fetch page view counts from GA4 into BigQuery and export to a bucket"
+  service_account = google_service_account.bigquery_page_transitions.id
+  source_contents = file("workflow-page-views.yaml")
+}
+
+# A service account for Cloud Scheduler to run the page_views workflow
+resource "google_service_account" "scheduler_page_views" {
+  account_id   = "scheduler-page-views"
+  display_name = "Service Account for scheduling the page-views workflow"
+  description  = "Service Account for scheduling the page-views workflow"
+}
+
+# A schedule to fetch page view statistics
+resource "google_cloud_scheduler_job" "page_views" {
+  name        = "page-views"
+  description = "Fetch page-view statistics"
+  schedule    = "0 3 * * *"
+  time_zone   = "Europe/London"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.page_views.id}/executions"
+    oauth_token {
+      service_account_email = google_service_account.scheduler_page_views.email
+    }
+  }
+}


### PR DESCRIPTION
Users are confused about pagerank and assume that the statistic is
derived from the number of page views.  We think that the number of page
views will be just as useful for ranking search results.

This also removes a dependency on Neo4j to calculate the pagerank,
although #411 has some skeleton code to do calculate it in Python
instead.

The pagerank statistic remains, for now, because it does little harm.

The page view counts are loaded into Neo4j, because users still use
Neo4j.

The implementation is rather more complicated than for the similar task
of extracting page-to-page transition counts from GA4.  That task was
never tidy:

- BigQuery won't export a table to a single file
- `gcloud compose` can only compose a maximum of 32 files at once

We were relying on the export always fitting into exactly one file, by
chance.  Since then, @exfalsoquodlibet has developed a method with GCP
Workflows to recursively compose an arbitrary number of files.  It's a
faff, but it's robust, so we'll use it.
