### PR TITLE
Abort postgres data pipeline if database too small

### DIFF
--- a/docker/postgres/run.sh
+++ b/docker/postgres/run.sh
@@ -44,6 +44,20 @@ FILE_PATH="data/$OBJECT"
 # https://stackoverflow.com/questions/6575221
 date
 gcloud storage cp "$OBJECT_URL" "$FILE_PATH"
+
+# Check that the file size is larger than an arbitrary size of 2GiB.
+# Typically they are about 27GiB.
+# On 2023-03-03 the database backup files had a problem and were only a few
+# megabytes.
+minimumsize=2147483648
+actualsize=$(wc -c <"$FILE_PATH")
+if [ $actualsize -le $minimumsize ]; then
+  # Turn this instance off and exit.  The data that is currrently in BigQuery
+  # will remain there.
+  gcloud compute instances delete postgres --quiet --zone=$ZONE
+  exit 1
+fi
+
 date
 pg_restore \
   -U postgres \


### PR DESCRIPTION
A problem with GOV.UK's backups means that the postgres database backup
file is corrupt, and too small.  The fact that the table exists triggers
the postgres pipeline, which wipes the BigQuery tables and is then
unable to repopulate them.  This commit checks the size of the database
file first, and aborts if it is too small.
