### PR TITLE
Revert "Merge pull request #429 from alphagov/clean-text-neo4j"

### DIFF
--- a/src/neo4j/load_content_store_data.cypher
+++ b/src/neo4j/load_content_store_data.cypher
@@ -129,7 +129,7 @@ LOAD CSV WITH HEADERS
 FROM 'file:///title.csv' AS line
 FIELDTERMINATOR ','
 MATCH (p:Page { url: line.url })
-SET p.title = apoc.text.clean(line.title)
+SET p.title = line.title
 ;
 
 USING PERIODIC COMMIT
@@ -137,7 +137,7 @@ LOAD CSV WITH HEADERS
 FROM 'file:///description.csv' AS line
 FIELDTERMINATOR ','
 MATCH (p:Page { url: line.url })
-SET p.description = apoc.text.clean(line.description)
+SET p.description = line.description
 ;
 
 USING PERIODIC COMMIT
@@ -152,7 +152,7 @@ LOAD CSV WITH HEADERS
 FROM 'file:///content.csv' AS line
 FIELDTERMINATOR ','
 MATCH (p:Page { url: line.url })
-SET p.text = apoc.text.clean(line.text)
+SET p.text = line.text
 ;
 
 // coalesce() handles a handful of links that have malformed URLs, or empty link


### PR DESCRIPTION
This reverts commit 6b87d0ff52131d9604520618cf33f335e51ea418, reversing
changes made to e1e9222d327e2c26713de3955ff5df0e605fcaa9.

It turns out that apoc.text.clean() doesn't normalize as we expected.
Instead, it simply discards non-alphanumeric characters, and converts to
lowercase.  We had hoped that it would normalize similarly to BigQuery,
so instead we'll have to hack our own way of converting known dodgy
characters to something more expected, e.g. non-breaking spaces to
ordinary spaces.
