### PR TITLE
Export all publishing database tables to BigQuery

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -26,6 +26,11 @@ RUN \
   gcc \
   ruby-full \
   && gem install govspeak -v 7.0.0 \
+  # Install duckdb
+  && curl -L -o duckdb.zip https://github.com/duckdb/duckdb/releases/download/v0.7.1/duckdb_cli-linux-amd64.zip \
+  && unzip duckdb.zip \
+  && rm duckdb.zip \
+  && mv duckdb /usr/bin \
   # Clean up
   && apt-get remove -y gcc \
   && apt-get autoremove -y \

--- a/src/postgres/Makefile
+++ b/src/postgres/Makefile
@@ -25,11 +25,15 @@ BIGQUERY.SQL = $(wildcard bigquery/*.sql)
 # to trigger subsequent targets.
 BIGQUERY = $(patsubst bigquery/%.sql, temp/%.bigquery, $(BIGQUERY.SQL))
 
+# Names of tables in the postgres database to export to Cloud Storage
+# and BigQuery
+EXPORT = actions change_notes documents editions events expanded_links link_changes link_sets links path_reservations role_appointments roles unpublishings
+
 # A step to create all the targets described in the CSV.GZ and BIGQUERY
 # variables, which means that all the .sh and .sql scripts in the SH and
 # BIGQUERY variables will be executed.
 .PHONY: all
-all: $(CSV.GZ) $(BIGQUERY)
+all: $(CSV.GZ) $(BIGQUERY) $(EXPORT)
 
 # A step to print the names of all the targets that were derived from the names
 # of .sh scripts.  This is for debugging only.
@@ -38,6 +42,8 @@ check:
 	@echo "${CSV.GZ}" | tr -s ' ' '\n'
 	@echo -e "\nBIGQUERY:"
 	@echo "${BIGQUERY}" | tr -s ' ' '\n'
+	@echo -e "\nEXPORT:"
+	@echo "${EXPORT}" | tr -s ' ' '\n'
 
 # A step to delete any intermediate files that have been created.  This is for
 # development only.
@@ -213,3 +219,42 @@ data/role_appointment_role.csv.gz
 
 temp/belongs_to.bigquery: data/role_role_organisation.csv.gz
 	source functions.sh; query_bigquery file_name=bigquery/belongs_to.sql
+
+actions:
+	source functions.sh; export_to_bigquery table_name=$@
+
+change_notes:
+	source functions.sh; export_to_bigquery table_name=$@
+
+documents:
+	source functions.sh; export_to_bigquery table_name=$@
+
+editions:
+	source functions.sh; export_to_bigquery table_name=$@
+
+events:
+	source functions.sh; export_to_bigquery table_name=$@
+
+expanded_links:
+	source functions.sh; export_to_bigquery table_name=$@
+
+link_changes:
+	source functions.sh; export_to_bigquery table_name=$@
+
+link_sets:
+	source functions.sh; export_to_bigquery table_name=$@
+
+links:
+	source functions.sh; export_to_bigquery table_name=$@
+
+path_reservations:
+	source functions.sh; export_to_bigquery table_name=$@
+
+role_appointments:
+	source functions.sh; export_to_bigquery table_name=$@
+
+roles:
+	source functions.sh; export_to_bigquery table_name=$@
+
+unpublishings:
+	source functions.sh; export_to_bigquery table_name=$@

--- a/src/postgres/functions.sh
+++ b/src/postgres/functions.sh
@@ -37,7 +37,7 @@ count_distinct () {
 # Extract datasets of nodes, attributes and edges from the PostgreSQL Publishing
 # API database.
 
-# Wrapper around psql.
+# Wrapper around psql to export the results of a query to CSV
 #
 # Usage:
 #
@@ -53,7 +53,7 @@ query_postgres () {
     --file="${file}"
 }
 
-# Wrapper around psql, for when emitting json
+# Wrapper around psql to export the results of a query to JSON
 #
 # Usage:
 #
@@ -67,6 +67,21 @@ query_postgres_json () {
 		--dbname=publishing_api_production \
 		--tuples-only \
     --file="${file}"
+}
+
+# Wrapper around psql to export a whole table to CSV
+#
+# Usage:
+#
+# dump_table \
+#   name=table_name
+dump_table () {
+  local name # reset in case they are defined globally
+  local "${@}"
+  psql \
+		--username=postgres \
+		--dbname=publishing_api_production \
+    --command="\copy ${name} TO STDOUT WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',');"
 }
 
 # Wrapper around sed to replace single backslash with double backslashes,
@@ -200,4 +215,54 @@ query_bigquery () {
   bq query \
     --use_legacy_sql=false \
     < "${file_name}"
+}
+
+# Export a table, upload to storage and import into BigQuery
+#
+# Usage:
+# query_bigquery table_name=name_of_table_in_postgres
+export_to_bigquery () {
+  local table_name # reset in case they are defined globally
+  local "${@}"
+
+  file_name="table_${table_name}"
+  dataset_name="publishing"
+
+  # We have to use uncompressed CSV for the largest table, so we might as well
+  # use it for the others too.
+  # BigQuery can't deal with compressed CSVs larger than 4GB.  The largest table
+  # is 19GB when compressed.
+  # Alternatively we could use Parquet (via DuckDB) but BigQuery can't cope with
+  # values larger than 10MiB in any particular column, and the largest page has
+  # 11302027 bytes (>10MiB) in the `details` column.
+  # /hmrc-internal-manuals/customs-authorisation-and-approval/caa08030
+  # https://webarchive.nationalarchives.gov.uk/ukgwa/20211120003440/https://www.gov.uk/hmrc-internal-manuals/customs-authorisation-and-approval/caa08030
+  # The DuckDB max_line_size parameter defaults to 2 MiB, which would eliminate
+  # those rows before they break BigQuery, but DuckDB stops with an error
+  # instead of ignoring those lines.
+  # The command gcloud bq load has options for ignoring bad lines, but they
+  # don't work for parquet.
+  # Finally, BigQuery does in fact seem to allow values larger than 10MiB, as
+  # long as they come from uncompressed CSV files.  So that's what we use.
+  # What a palaver.  "Big" Query, huh.
+  dump_table \
+    name=$table_name \
+  | gcloud storage cp \
+    - \
+    "gs://${PROJECT_ID}-data-processed/publishing-api/${file_name}.csv" \
+    --gzip-in-flight-all
+
+  # Empty the table
+  bq query --use_legacy_sql=false "TRUNCATE TABLE ${dataset_name}.${table_name}"
+
+  # Use nosynchronous_mode to avoid waiting for BQ to complete one job before
+  # initiating another.
+  bq load \
+    --source_format="CSV" \
+    --allow_quoted_newlines \
+    --skip_leading_rows=1 \
+    --noreplace \
+    --nosynchronous_mode \
+    "${dataset_name}.${table_name}" \
+    "gs://${PROJECT_ID}-data-processed/publishing-api/${file_name}.csv"
 }

--- a/terraform-dev/bigquery-publishing.tf
+++ b/terraform-dev/bigquery-publishing.tf
@@ -1,0 +1,782 @@
+# A dataset of tables from the Publishing API postgres database
+
+resource "google_bigquery_dataset" "publishing" {
+  dataset_id            = "publishing"
+  friendly_name         = "publishing"
+  description           = "Data from the GOV.UK Publishing API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_publishing" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      "serviceAccount:${google_service_account.gce_postgres.email}",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = [
+      "projectReaders",
+      "group:data-engineering@digital.cabinet-office.gov.uk",
+      "group:data-analysis@digital.cabinet-office.gov.uk",
+      "group:data-products@digital.cabinet-office.gov.uk",
+    ]
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "publishing" {
+  dataset_id  = google_bigquery_dataset.publishing.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_publishing.policy_data
+}
+
+resource "google_bigquery_table" "publishing_actions" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "actions"
+  friendly_name = "Actions"
+  description   = "Actions table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_uid"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_set_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "event_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_change_notes" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "change_notes"
+  friendly_name = "Change notes"
+  description   = "Change notes table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "note"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "public_timestamp"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_documents" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "documents"
+  friendly_name = "Documents"
+  description   = "Documents table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "stale_lock_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "owning_document_id"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_editions" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "title"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "public_updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "rendering_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "update_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "phase"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "analytics_identifier"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "document_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "schema_name"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "first_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "last_edited_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "state"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_facing_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "base_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_store"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "document_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "description"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_request_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "major_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_api_first_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_api_last_edited_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "auth_bypass_ids"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "details"
+        type = "JSON"
+      },
+      {
+        mode = "NULLABLE"
+        name = "routes"
+        type = "JSON"
+      },
+      {
+        mode = "NULLABLE"
+        name = "redirects"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_events" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "events"
+  friendly_name = "Events"
+  description   = "Events table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_uid"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "request_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "payload"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_expanded_links" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "expanded_links"
+  friendly_name = "Expanded links"
+  description   = "Expanded links table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "with_drafts"
+        type = "BOOLEAN"
+      },
+      {
+        mode = "NULLABLE"
+        name = "payload_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "expanded_links"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_link_changes" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "link_changes"
+  friendly_name = "Link changes"
+  description   = "Link changes table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "source_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "target_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "change"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_link_sets" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "link_sets"
+  friendly_name = "Link sets"
+  description   = "Link sets table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "stale_lock_version"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_links" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "links"
+  friendly_name = "Links"
+  description   = "Links table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_set_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "target_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "position"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_path_reservations" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "path_reservations"
+  friendly_name = "Path reservations"
+  description   = "Path reservations table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "base_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_role_appointments" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "role_appointments"
+  friendly_name = "Role appointments"
+  description   = "Role appointments table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "url"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "details"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_roles" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "roles"
+  friendly_name = "Roles"
+  description   = "Roles table from the GOV.UK Publishing API PostgreSQL database"
+    schema              = jsonencode(
+        [
+            {
+                mode = "NULLABLE"
+                name = "url"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "schema_name"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "document_type"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "publishing_app"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "phase"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "content_id"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "locale"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "updated_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "public_updated_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "first_published_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "base_path"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "title"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "description"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "details"
+                type = "JSON"
+            },
+        ]
+    )
+}
+
+resource "google_bigquery_table" "publishing_unpublishings" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "unpublishings"
+  friendly_name = "Unpublishings"
+  description   = "Unpublishings table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "explanation"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "alternative_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "unpublished_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "redirects"
+        type = "JSON"
+      },
+    ]
+  )
+}

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -39,6 +39,8 @@ WITH tables AS (
   UNION ALL
   SELECT * FROM graph.__TABLES__
   UNION ALL
+  SELECT * FROM publishing.__TABLES__
+  UNION ALL
   SELECT * FROM search.__TABLES__
 )
 SELECT

--- a/terraform-staging/bigquery-publishing.tf
+++ b/terraform-staging/bigquery-publishing.tf
@@ -1,0 +1,782 @@
+# A dataset of tables from the Publishing API postgres database
+
+resource "google_bigquery_dataset" "publishing" {
+  dataset_id            = "publishing"
+  friendly_name         = "publishing"
+  description           = "Data from the GOV.UK Publishing API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_publishing" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      "serviceAccount:${google_service_account.gce_postgres.email}",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = [
+      "projectReaders",
+      "group:data-engineering@digital.cabinet-office.gov.uk",
+      "group:data-analysis@digital.cabinet-office.gov.uk",
+      "group:data-products@digital.cabinet-office.gov.uk",
+    ]
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "publishing" {
+  dataset_id  = google_bigquery_dataset.publishing.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_publishing.policy_data
+}
+
+resource "google_bigquery_table" "publishing_actions" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "actions"
+  friendly_name = "Actions"
+  description   = "Actions table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_uid"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_set_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "event_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_change_notes" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "change_notes"
+  friendly_name = "Change notes"
+  description   = "Change notes table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "note"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "public_timestamp"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_documents" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "documents"
+  friendly_name = "Documents"
+  description   = "Documents table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "stale_lock_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "owning_document_id"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_editions" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "title"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "public_updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "rendering_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "update_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "phase"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "analytics_identifier"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "document_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "schema_name"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "first_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "last_edited_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "state"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_facing_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "base_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_store"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "document_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "description"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_request_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "major_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_api_first_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_api_last_edited_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "auth_bypass_ids"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "details"
+        type = "JSON"
+      },
+      {
+        mode = "NULLABLE"
+        name = "routes"
+        type = "JSON"
+      },
+      {
+        mode = "NULLABLE"
+        name = "redirects"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_events" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "events"
+  friendly_name = "Events"
+  description   = "Events table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_uid"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "request_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "payload"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_expanded_links" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "expanded_links"
+  friendly_name = "Expanded links"
+  description   = "Expanded links table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "with_drafts"
+        type = "BOOLEAN"
+      },
+      {
+        mode = "NULLABLE"
+        name = "payload_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "expanded_links"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_link_changes" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "link_changes"
+  friendly_name = "Link changes"
+  description   = "Link changes table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "source_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "target_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "change"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_link_sets" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "link_sets"
+  friendly_name = "Link sets"
+  description   = "Link sets table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "stale_lock_version"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_links" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "links"
+  friendly_name = "Links"
+  description   = "Links table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_set_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "target_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "position"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_path_reservations" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "path_reservations"
+  friendly_name = "Path reservations"
+  description   = "Path reservations table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "base_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_role_appointments" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "role_appointments"
+  friendly_name = "Role appointments"
+  description   = "Role appointments table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "url"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "details"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_roles" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "roles"
+  friendly_name = "Roles"
+  description   = "Roles table from the GOV.UK Publishing API PostgreSQL database"
+    schema              = jsonencode(
+        [
+            {
+                mode = "NULLABLE"
+                name = "url"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "schema_name"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "document_type"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "publishing_app"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "phase"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "content_id"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "locale"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "updated_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "public_updated_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "first_published_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "base_path"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "title"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "description"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "details"
+                type = "JSON"
+            },
+        ]
+    )
+}
+
+resource "google_bigquery_table" "publishing_unpublishings" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "unpublishings"
+  friendly_name = "Unpublishings"
+  description   = "Unpublishings table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "explanation"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "alternative_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "unpublished_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "redirects"
+        type = "JSON"
+      },
+    ]
+  )
+}

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -39,6 +39,8 @@ WITH tables AS (
   UNION ALL
   SELECT * FROM graph.__TABLES__
   UNION ALL
+  SELECT * FROM publishing.__TABLES__
+  UNION ALL
   SELECT * FROM search.__TABLES__
 )
 SELECT

--- a/terraform/bigquery-publishing.tf
+++ b/terraform/bigquery-publishing.tf
@@ -1,0 +1,782 @@
+# A dataset of tables from the Publishing API postgres database
+
+resource "google_bigquery_dataset" "publishing" {
+  dataset_id            = "publishing"
+  friendly_name         = "publishing"
+  description           = "Data from the GOV.UK Publishing API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_publishing" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      "serviceAccount:${google_service_account.gce_postgres.email}",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = [
+      "projectReaders",
+      "group:data-engineering@digital.cabinet-office.gov.uk",
+      "group:data-analysis@digital.cabinet-office.gov.uk",
+      "group:data-products@digital.cabinet-office.gov.uk",
+    ]
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "publishing" {
+  dataset_id  = google_bigquery_dataset.publishing.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_publishing.policy_data
+}
+
+resource "google_bigquery_table" "publishing_actions" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "actions"
+  friendly_name = "Actions"
+  description   = "Actions table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_uid"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_set_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "event_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_change_notes" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "change_notes"
+  friendly_name = "Change notes"
+  description   = "Change notes table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "note"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "public_timestamp"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_documents" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "documents"
+  friendly_name = "Documents"
+  description   = "Documents table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "stale_lock_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "owning_document_id"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_editions" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "title"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "public_updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "rendering_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "update_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "phase"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "analytics_identifier"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "document_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "schema_name"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "first_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "last_edited_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "state"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_facing_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "base_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_store"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "document_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "description"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_request_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "major_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_api_first_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_api_last_edited_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "auth_bypass_ids"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "details"
+        type = "JSON"
+      },
+      {
+        mode = "NULLABLE"
+        name = "routes"
+        type = "JSON"
+      },
+      {
+        mode = "NULLABLE"
+        name = "redirects"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_events" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "events"
+  friendly_name = "Events"
+  description   = "Events table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "user_uid"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "request_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "payload"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_expanded_links" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "expanded_links"
+  friendly_name = "Expanded links"
+  description   = "Expanded links table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "with_drafts"
+        type = "BOOLEAN"
+      },
+      {
+        mode = "NULLABLE"
+        name = "payload_version"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "expanded_links"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_link_changes" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "link_changes"
+  friendly_name = "Link changes"
+  description   = "Link changes table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "source_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "target_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "change"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "action_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_link_sets" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "link_sets"
+  friendly_name = "Link sets"
+  description   = "Link sets table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "stale_lock_version"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_links" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "links"
+  friendly_name = "Links"
+  description   = "Links table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_set_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "target_content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "link_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "position"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_path_reservations" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "path_reservations"
+  friendly_name = "Path reservations"
+  description   = "Path reservations table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "base_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_role_appointments" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "role_appointments"
+  friendly_name = "Role appointments"
+  description   = "Role appointments table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "url"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "details"
+        type = "JSON"
+      },
+    ]
+  )
+}
+
+resource "google_bigquery_table" "publishing_roles" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "roles"
+  friendly_name = "Roles"
+  description   = "Roles table from the GOV.UK Publishing API PostgreSQL database"
+    schema              = jsonencode(
+        [
+            {
+                mode = "NULLABLE"
+                name = "url"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "schema_name"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "document_type"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "publishing_app"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "phase"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "content_id"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "locale"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "updated_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "public_updated_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "first_published_at"
+                type = "TIMESTAMP"
+            },
+            {
+                mode = "NULLABLE"
+                name = "base_path"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "title"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "description"
+                type = "STRING"
+            },
+            {
+                mode = "NULLABLE"
+                name = "details"
+                type = "JSON"
+            },
+        ]
+    )
+}
+
+resource "google_bigquery_table" "publishing_unpublishings" {
+  dataset_id    = google_bigquery_dataset.publishing.dataset_id
+  table_id      = "unpublishings"
+  friendly_name = "Unpublishings"
+  description   = "Unpublishings table from the GOV.UK Publishing API PostgreSQL database"
+  schema              = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "edition_id"
+        type = "INTEGER"
+      },
+      {
+        mode = "NULLABLE"
+        name = "type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "explanation"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "alternative_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "created_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "unpublished_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "redirects"
+        type = "JSON"
+      },
+    ]
+  )
+}

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -39,6 +39,8 @@ WITH tables AS (
   UNION ALL
   SELECT * FROM graph.__TABLES__
   UNION ALL
+  SELECT * FROM publishing.__TABLES__
+  UNION ALL
   SELECT * FROM search.__TABLES__
 )
 SELECT


### PR DESCRIPTION
This will make the data available without having to wait an hour for the
database to restore, and without having to pay for an always-on postgres
database.

- [x] Functions
- [x] Makefile
- [x] Terraform of BigQuery dataset and tables
- [x] Omit tables that aren't useful
- [x] Remove `--autodetect` from `bq load`
- [x] Mitigate the CSV file size limit for `bq load` for the `editions` table, ~perhaps by converting to parquet via duckdb~ by using uncompressed CSV files.