### PR TITLE
Extract abbreviations from page content

### DIFF
--- a/src/mongodb/Makefile
+++ b/src/mongodb/Makefile
@@ -151,6 +151,10 @@ data/step_by_step_embedded_links.csv.gz: temp/step_by_step_content.mongodb
 	source functions.sh; source sh/step_by_step_embedded_links.sh
 	touch data/step_by_step_embedded_links.csv.gz
 
+data/step_by_step_abbreviations.csv.gz: temp/step_by_step_content.mongodb
+	source functions.sh; source sh/step_by_step_abbreviations.sh
+	touch data/step_by_step_abbreviations.csv.gz
+
 data/department_analytics_profile.csv.gz: temp/define_url.mongodb temp/index.mongodb
 	source functions.sh; source sh/department_analytics_profile.sh
 
@@ -193,6 +197,10 @@ data/parts_embedded_links.csv.gz: temp/parts_content.mongodb
 	source functions.sh; source sh/parts_embedded_links.sh
 	touch data/parts_embedded_links.csv.gz
 
+data/parts_abbreviations.csv.gz: temp/parts_content.mongodb
+	source functions.sh; source sh/parts_abbreviations.sh
+	touch data/parts_abbreviations.csv.gz
+
 temp/transaction_content.mongodb: temp/define_url.mongodb temp/index.mongodb
 	mongo content_store js/transaction_content.js
 	touch temp/transaction_content.mongodb
@@ -205,6 +213,10 @@ data/transaction_embedded_links.csv.gz: temp/transaction_content.mongodb
 	source functions.sh; source sh/transaction_embedded_links.sh
 	touch data/transaction_embedded_links.csv.gz
 
+data/transaction_abbreviations.csv.gz: temp/transaction_content.mongodb
+	source functions.sh; source sh/transaction_abbreviations.sh
+	touch data/transaction_abbreviations.csv.gz
+
 temp/place_content.mongodb: temp/define_url.mongodb temp/index.mongodb
 	mongo content_store js/place_content.js
 	touch temp/place_content.mongodb
@@ -216,6 +228,10 @@ data/place_content.csv.gz: temp/place_content.mongodb
 data/place_embedded_links.csv.gz: temp/place_content.mongodb
 	source functions.sh; source sh/place_embedded_links.sh
 	touch data/place_embedded_links.csv.gz
+
+data/place_abbreviations.csv.gz: temp/place_content.mongodb
+	source functions.sh; source sh/place_abbreviations.sh
+	touch data/place_abbreviations.csv.gz
 
 # Some document types have the body text in the 'body' field (not 'body.content')
 temp/body.mongodb: temp/define_url.mongodb temp/index.mongodb
@@ -230,6 +246,10 @@ data/body_embedded_links.csv.gz: temp/body.mongodb
 	source functions.sh; source sh/body_embedded_links.sh
 	touch data/body_embedded_links.csv.gz
 
+data/body_abbreviations.csv.gz: temp/body.mongodb
+	source functions.sh; source sh/body_abbreviations.sh
+	touch data/body_abbreviations.csv.gz
+
 # Some document types have the body text in the 'body.content' field (not 'body')
 temp/body_content.mongodb: temp/define_url.mongodb temp/index.mongodb
 	mongo content_store js/body_content.js
@@ -242,6 +262,10 @@ data/body_content.csv.gz: temp/body_content.mongodb
 data/body_content_embedded_links.csv.gz: temp/body_content.mongodb
 	source functions.sh; source sh/body_content_embedded_links.sh
 	touch data/body_content_embedded_links.csv.gz
+
+data/body_content_abbreviations.csv.gz: temp/body_content.mongodb
+	source functions.sh; source sh/body_content_abbreviations.sh
+	touch data/body_content_abbreviations.csv.gz
 
 # Combine the tables of content of each document type, export back into a
 # storage bucket as many files, and concatenate those files into a single file.
@@ -271,6 +295,17 @@ temp/embedded_links.bigquery: data/step_by_step_embedded_links.csv.gz data/parts
 		"gs://${PROJECT_ID}-data-processed/bigquery/embedded_links_[0-9]*.csv.gz" \
     --continue-on-error
 	envsubst < ./bigquery/embedded_links.sql \
+	  | bq query --use_legacy_sql=false \
+	  < /dev/stdin
+	touch $@
+
+# Combine the tables of abbreviations of each document type, export back into a
+# storage bucket as many files, and concatenate those files into a single file.
+temp/abbreviations.bigquery: data/step_by_step_abbreviations.csv.gz data/parts_abbreviations.csv.gz data/transaction_abbreviations.csv.gz data/place_abbreviations.csv.gz data/body_abbreviations.csv.gz data/body_content_abbreviations.csv.gz
+	-gcloud storage rm \
+		"gs://${PROJECT_ID}-data-processed/bigquery/abbreviations_[0-9]*.csv.gz" \
+    --continue-on-error
+	envsubst < ./bigquery/abbreviations.sql \
 	  | bq query --use_legacy_sql=false \
 	  < /dev/stdin
 	touch $@

--- a/src/mongodb/bigquery/abbreviations.sql
+++ b/src/mongodb/bigquery/abbreviations.sql
@@ -1,0 +1,79 @@
+-- Concatenate tables of embedded links from various document types into one
+CREATE OR REPLACE TABLE `content.abbreviations`AS
+SELECT * FROM `content.body_abbreviations`
+UNION ALL
+SELECT * FROM `content.body_content_abbreviations`
+UNION ALL
+SELECT
+  * EXCEPT(base_path, part_index)
+FROM `content.parts_abbreviations`
+UNION ALL
+SELECT
+  count,
+  base_path as url,
+  * EXCEPT(count, url, base_path, part_index)
+FROM `content.parts_abbreviations`
+WHERE part_index = 1
+UNION ALL
+SELECT * FROM `content.place_abbreviations`
+UNION ALL
+SELECT * FROM `content.step_by_step_abbreviations`
+UNION ALL
+SELECT * FROM `content.step_by_step_abbreviations`
+UNION ALL
+SELECT * FROM `content.transaction_abbreviations`
+-- role_content is derived from the publishing API database, which isn't updated
+-- until after this query is run, because the database backup file isn't
+-- available until too late in the day, so this is always a day behind the other
+-- tables.
+UNION ALL
+SELECT * FROM `content.role_abbreviations`
+;
+
+EXPORT DATA OPTIONS(
+  uri='gs://$PROJECT_ID-data-processed/bigquery/abbreviations_*.csv.gz',
+  format='CSV',
+  compression='GZIP',
+  overwrite=true
+  ) AS
+SELECT * FROM content.abbreviations
+;
+
+CREATE OR REPLACE TABLE `content.abbreviations`AS
+SELECT * FROM `content.body_abbreviations`
+UNION ALL
+SELECT * FROM `content.body_content_abbreviations`
+UNION ALL
+SELECT
+  * EXCEPT(base_path, part_index)
+FROM `content.parts_abbreviations`
+UNION ALL
+SELECT
+  count,
+  base_path as url,
+  * EXCEPT(count, url, base_path, part_index)
+FROM `content.parts_abbreviations`
+WHERE part_index = 1
+UNION ALL
+SELECT * FROM `content.place_abbreviations`
+UNION ALL
+SELECT * FROM `content.step_by_step_abbreviations`
+UNION ALL
+SELECT * FROM `content.step_by_step_abbreviations`
+UNION ALL
+SELECT * FROM `content.transaction_abbreviations`
+-- role_content is derived from the publishing API database, which isn't updated
+-- until after this query is run, because the database backup file isn't
+-- available until too late in the day, so this is always a day behind the other
+-- tables.
+UNION ALL
+SELECT * FROM `content.role_abbreviations`
+;
+
+EXPORT DATA OPTIONS(
+  uri='gs://$PROJECT_ID-data-processed/bigquery/abbreviations_*.csv.gz',
+  format='CSV',
+  compression='GZIP',
+  overwrite=true
+  ) AS
+SELECT * FROM content.abbreviations;

--- a/src/mongodb/functions.sh
+++ b/src/mongodb/functions.sh
@@ -121,6 +121,10 @@ query_mongo () {
 # extract_hyperlinks_from_html \
 #   input_col=html \
 #   id_cols=url \
+#
+# extract_abbreviations_from_html \
+#   input_col=html \
+#   id_cols=url \
 extract_text_from_html () {
   local input_col id_cols # reset in case they are defined globally
   local "${@}"
@@ -145,6 +149,20 @@ extract_hyperlinks_from_html () {
       --line-buffer \
       --keep-order \
       python3 ../../src/utils/extract_hyperlinks_from_html.py \
+      --input_col=${input_col} \
+      --id_cols=${id_cols} \
+  ;}
+}
+extract_abbreviations_from_html () {
+  local input_col id_cols # reset in case they are defined globally
+  local "${@}"
+  { echo $id_cols,abbreviation_title,abbreviation_text & \
+    parallel \
+      --pipe \
+      --round-robin \
+      --line-buffer \
+      --keep-order \
+      python3 ../../src/utils/extract_abbreviations_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
   ;}

--- a/src/mongodb/sh/body_abbreviations.sh
+++ b/src/mongodb/sh/body_abbreviations.sh
@@ -1,0 +1,13 @@
+FILE_NAME=body_abbreviations
+
+query_mongo \
+  type=json \
+  collection=body \
+  fields=url,html \
+| extract_abbreviations_from_html \
+  input_col=html \
+  id_cols=url \
+| count_distinct escape_cols=abbreviation_title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/mongodb/sh/body_content_abbreviations.sh
+++ b/src/mongodb/sh/body_content_abbreviations.sh
@@ -1,0 +1,13 @@
+FILE_NAME=body_content_abbreviations
+
+query_mongo \
+  type=json \
+  collection=body_content \
+  fields=url,html \
+| extract_abbreviations_from_html \
+  input_col=html \
+  id_cols=url \
+| count_distinct escape_cols=abbreviation_title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/mongodb/sh/parts_abbreviations.sh
+++ b/src/mongodb/sh/parts_abbreviations.sh
@@ -1,0 +1,13 @@
+FILE_NAME=parts_abbreviations
+
+query_mongo \
+  type=json \
+  collection=parts \
+  fields=url,base_path,part_index,html \
+| extract_abbreviations_from_html \
+  input_col=html \
+  id_cols=url,base_path,part_index \
+| count_distinct escape_cols=abbreviation_title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/mongodb/sh/place_abbreviations.sh
+++ b/src/mongodb/sh/place_abbreviations.sh
@@ -1,0 +1,13 @@
+FILE_NAME=place_abbreviations
+
+query_mongo \
+  type=json \
+  collection=place \
+  fields=url,html \
+| extract_abbreviations_from_html \
+  input_col=html \
+  id_cols=url \
+| count_distinct escape_cols=abbreviation_title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/mongodb/sh/step_by_step_abbreviations.sh
+++ b/src/mongodb/sh/step_by_step_abbreviations.sh
@@ -1,0 +1,13 @@
+FILE_NAME=step_by_step_abbreviations
+
+query_mongo \
+  type=json \
+  collection=step_by_step \
+  fields=url,html \
+| extract_abbreviations_from_html \
+  input_col=html \
+  id_cols=url \
+| count_distinct escape_cols=abbreviation_title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/mongodb/sh/transaction_abbreviations.sh
+++ b/src/mongodb/sh/transaction_abbreviations.sh
@@ -1,0 +1,13 @@
+FILE_NAME=transaction_abbreviations
+
+query_mongo \
+  type=json \
+  collection=transaction \
+  fields=url,html \
+| extract_abbreviations_from_html \
+  input_col=html \
+  id_cols=url \
+| count_distinct escape_cols=abbreviation_title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/postgres/Makefile
+++ b/src/postgres/Makefile
@@ -136,6 +136,9 @@ data/role_content_text.csv.gz: data/role_content.csv.gz
 data/role_embedded_links.csv.gz: data/role_content.csv.gz
 	source functions.sh; source sh/embedded_links.sh
 
+data/role_abbreviations.csv.gz: data/role_content.csv.gz
+	source functions.sh; source sh/abbreviations.sh
+
 data/role_redirects.csv.gz:
 	source functions.sh; source sh/redirects.sh
 

--- a/src/postgres/functions.sh
+++ b/src/postgres/functions.sh
@@ -143,6 +143,10 @@ convert_govspeak_to_html () {
 # extract_hyperlinks_from_html \
 #   input_col=html \
 #   id_cols=url \
+#
+# extract_abbreviations_from_html \
+#   input_col=html \
+#   id_cols=url \
 extract_text_from_html () {
   local input_col id_cols # reset in case they are defined globally
   local "${@}"
@@ -167,6 +171,20 @@ extract_hyperlinks_from_html () {
       --line-buffer \
       --keep-order \
       python3 ../../src/utils/extract_hyperlinks_from_html.py \
+      --input_col=${input_col} \
+      --id_cols=${id_cols} \
+  ;}
+}
+extract_abbreviations_from_html () {
+  local input_col id_cols # reset in case they are defined globally
+  local "${@}"
+  { echo $id_cols,abbreviation_title,abbreviation_text & \
+    parallel \
+      --pipe \
+      --round-robin \
+      --line-buffer \
+      --keep-order \
+      python3 ../../src/utils/extract_abbreviations_from_html.py \
       --input_col=${input_col} \
       --id_cols=${id_cols} \
   ;}

--- a/src/postgres/sh/abbreviations.sh
+++ b/src/postgres/sh/abbreviations.sh
@@ -1,0 +1,10 @@
+FILE_NAME=role_abbreviations
+
+zcat data/role_content.csv.gz \
+| extract_abbreviations_from_html \
+  input_col=html \
+  id_cols=url \
+| count_distinct escape_cols=abbreviation_title \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/utils/extract_abbreviations_from_html.py
+++ b/src/utils/extract_abbreviations_from_html.py
@@ -1,0 +1,117 @@
+# Extract hyperlinks from an html column of a CSV file.  See the argparse
+# description below for more explanation.
+
+import argparse
+import sys
+import csv
+import json
+import re
+
+from typing import NamedTuple
+from bs4 import BeautifulSoup
+
+
+class Abbreviation(NamedTuple):
+    """An abbreviation with elements `title` and `text`."""
+
+    title: str
+    text: str
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="""Extract abbreviations from an html field of single-line JSON documents, via stdin, to stdout.
+
+Example usage:
+    cat myfile.json | \\
+      parallel \
+        --pipe \
+        --round-robin \
+        --line-buffer \
+        python src/data/extract_abbreviations.py \\
+            --input_col=col_containing_html \\
+            --id_cols=base_path,slug
+
+That example will take a file of one JSON document per line, with items:
+  - base_path
+  - slug
+  - col_containing_html
+
+It will emit a CSV file without headers, but columns for:
+  - base_path
+  - slug
+  - abbreviation_title
+  - abbreviation_text
+
+One row will be emitted per URL found.  If no URL is found in an input row, then
+no output row will be emitted.
+
+New output columns:
+  - abbreviation_title: the text, such as His Majesty's Revenue and Customs
+  - abbreviation_text: the acronym, such as HMRC
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--input_col",
+        type=str,
+        required=True,
+        help="The name of the field to search for abbreviations",
+    )
+
+    parser.add_argument(
+        "--id_cols",
+        type=str,
+        required=False,
+        help="Names of columns to be preserved in the output, separated by commas, e.g. --id_cols=url slug",
+    )
+
+    args = parser.parse_args()
+
+    input_col = args.input_col
+    id_cols = [] if args.id_cols is None else args.id_cols.split(",")
+
+    fieldnames = [*id_cols, "abbreviation_title", "abbreviation_text"]
+
+    # Allow the largest field size possible.
+    # https://stackoverflow.com/a/15063941
+    maxInt = sys.maxsize
+    while True:
+        # decrease the maxInt value by factor 10
+        # as long as the OverflowError occurs.
+        try:
+            csv.field_size_limit(maxInt)
+            break
+        except OverflowError:
+            maxInt = int(maxInt / 10)
+    csv.field_size_limit(maxInt)
+
+    # Allow the largest field size possible.
+    # https://stackoverflow.com/a/15063941
+    maxInt = sys.maxsize
+    while True:
+        # decrease the maxInt value by factor 10
+        # as long as the OverflowError occurs.
+        try:
+            csv.field_size_limit(maxInt)
+            break
+        except OverflowError:
+            maxInt = int(maxInt / 10)
+    csv.field_size_limit(maxInt)
+
+    writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+
+    for line in sys.stdin:
+        row = json.loads(line.rstrip('\n'))
+        row_dict = {col_name: row[col_name] for col_name in id_cols}
+        soup = BeautifulSoup(row[input_col], "lxml")
+        abbrs = [
+            Abbreviation(title=abbr.get("title"), text=abbr.get_text())
+            for abbr in soup.find_all("abbr")
+        ]
+        for abbr in abbrs:
+            row_dict["abbreviation_title"] = abbr.title
+            row_dict["abbreviation_text"] = abbr.text
+            writer.writerow(row_dict)

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -1079,6 +1079,228 @@ resource "google_bigquery_table" "body_content_embedded_links" {
 EOF
 }
 
+resource "google_bigquery_table" "step_by_step_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "step_by_step_abbreviations"
+  friendly_name = "Step-by-step abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of step-by-step pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "parts_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "parts_abbreviations"
+  friendly_name = "Parts abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of parts of 'guide' and 'travel_advice' documents"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "base_path",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of the parent document of the part"
+  },
+  {
+    "name": "part_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "The order of the part among other parts in the same document, counting from 0"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "transaction_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "transaction_abbreviations"
+  friendly_name = "Transaction abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'transaction' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "place_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "place_abbreviations"
+  friendly_name = "Place abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'place' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "body_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "body_abbreviations"
+  friendly_name = "Body abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of several types of pages, others are in tables with the suffix '_abbreviations'"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "body_content_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "body_content_abbreviations"
+  friendly_name = "Body content abbreviations"
+  description   = "Text and acronyms from the text of several types of pages, others are in tables with the suffix '_abbreviations'"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym  of an abbreviation"
+  }
+]
+EOF
+}
+
 resource "google_bigquery_table" "url_override" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "url_override"
@@ -1501,6 +1723,41 @@ resource "google_bigquery_table" "role_embedded_links" {
     "type": "STRING",
     "mode": "NULLABLE",
     "description": "Plain text that is displayed in place of the URL"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "role_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "role_abbreviations"
+  friendly_name = "Role abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'role' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym  of an abbreviation"
   }
 ]
 EOF

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -1079,6 +1079,228 @@ resource "google_bigquery_table" "body_content_embedded_links" {
 EOF
 }
 
+resource "google_bigquery_table" "step_by_step_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "step_by_step_abbreviations"
+  friendly_name = "Step-by-step abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of step-by-step pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "parts_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "parts_abbreviations"
+  friendly_name = "Parts abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of parts of 'guide' and 'travel_advice' documents"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "base_path",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of the parent document of the part"
+  },
+  {
+    "name": "part_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "The order of the part among other parts in the same document, counting from 0"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "transaction_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "transaction_abbreviations"
+  friendly_name = "Transaction abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'transaction' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "place_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "place_abbreviations"
+  friendly_name = "Place abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'place' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "body_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "body_abbreviations"
+  friendly_name = "Body abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of several types of pages, others are in tables with the suffix '_abbreviations'"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "body_content_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "body_content_abbreviations"
+  friendly_name = "Body content abbreviations"
+  description   = "Text and acronyms from the text of several types of pages, others are in tables with the suffix '_abbreviations'"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym  of an abbreviation"
+  }
+]
+EOF
+}
+
 resource "google_bigquery_table" "url_override" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "url_override"
@@ -1501,6 +1723,41 @@ resource "google_bigquery_table" "role_embedded_links" {
     "type": "STRING",
     "mode": "NULLABLE",
     "description": "Plain text that is displayed in place of the URL"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "role_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "role_abbreviations"
+  friendly_name = "Role abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'role' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym  of an abbreviation"
   }
 ]
 EOF

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -1079,6 +1079,228 @@ resource "google_bigquery_table" "body_content_embedded_links" {
 EOF
 }
 
+resource "google_bigquery_table" "step_by_step_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "step_by_step_abbreviations"
+  friendly_name = "Step-by-step abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of step-by-step pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "parts_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "parts_abbreviations"
+  friendly_name = "Parts abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of parts of 'guide' and 'travel_advice' documents"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "base_path",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of the parent document of the part"
+  },
+  {
+    "name": "part_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "The order of the part among other parts in the same document, counting from 0"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "transaction_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "transaction_abbreviations"
+  friendly_name = "Transaction abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'transaction' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "place_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "place_abbreviations"
+  friendly_name = "Place abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'place' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "body_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "body_abbreviations"
+  friendly_name = "Body abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of several types of pages, others are in tables with the suffix '_abbreviations'"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym of an abbreviation"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "body_content_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "body_content_abbreviations"
+  friendly_name = "Body content abbreviations"
+  description   = "Text and acronyms from the text of several types of pages, others are in tables with the suffix '_abbreviations'"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym  of an abbreviation"
+  }
+]
+EOF
+}
+
 resource "google_bigquery_table" "url_override" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "url_override"
@@ -1501,6 +1723,41 @@ resource "google_bigquery_table" "role_embedded_links" {
     "type": "STRING",
     "mode": "NULLABLE",
     "description": "Plain text that is displayed in place of the URL"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_table" "role_abbreviations" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "role_abbreviations"
+  friendly_name = "Role abbreviations"
+  description   = "Text and acronyms of abbreviations from the text of 'role' pages"
+  schema        = <<EOF
+[
+  {
+    "name": "count",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Number of occurrences of a link with the same URL and link-text in the same document"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "abbreviation_title",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Title of an abbreviation"
+  },
+  {
+    "name": "abbreviation_text",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Acronym  of an abbreviation"
   }
 ]
 EOF


### PR DESCRIPTION
GovSpeak supports a markup for acronyms, to create hover text.

```html
<abbr title="Foreign, Commonwealth and Development Office">FCDO</abbr>
```

This commit extracts the counts of appearances of each acronym in each
page.
