### PR TITLE
Add abbreviations to 'thing' table for govsearch

### DIFF
--- a/terraform/bigquery/thing.sql
+++ b/terraform/bigquery/thing.sql
@@ -19,3 +19,9 @@ UNION ALL
 SELECT 'Transaction' AS type, title AS name
 FROM graph.page
 WHERE document_type = 'transaction'
+UNION ALL
+SELECT DISTINCT 'AbbreviationText' AS type, abbreviation_text AS name
+FROM content.abbreviations
+UNION ALL
+SELECT DISTINCT 'AbbreviationTitle' AS type, abbreviation_title AS name
+FROM content.abbreviations


### PR DESCRIPTION
To support searches that match either the abbreviated or the expanded
form.
