### PR TITLE
Don't return nulls in roles that were never filled

### DIFF
--- a/terraform-dev/bigquery/role.sql
+++ b/terraform-dev/bigquery/role.sql
@@ -11,8 +11,10 @@ persons AS (
       has_role.ended_on AS endDate
   )) AS personNames
   FROM graph.role
-  LEFT JOIN graph.has_role ON has_role.role_url = role.url
-  LEFT JOIN graph.person ON person.url = has_role.person_url
+  -- If nobody has ever been appointed to the role, we don't want any null
+  -- results here, therefore use INNER JOIN.
+  INNER JOIN graph.has_role ON has_role.role_url = role.url
+  INNER JOIN graph.person ON person.url = has_role.person_url
   LEFT JOIN graph.has_homepage ON has_homepage.url = person.url
   GROUP BY role.url
 ),

--- a/terraform-staging/bigquery/role.sql
+++ b/terraform-staging/bigquery/role.sql
@@ -11,8 +11,10 @@ persons AS (
       has_role.ended_on AS endDate
   )) AS personNames
   FROM graph.role
-  LEFT JOIN graph.has_role ON has_role.role_url = role.url
-  LEFT JOIN graph.person ON person.url = has_role.person_url
+  -- If nobody has ever been appointed to the role, we don't want any null
+  -- results here, therefore use INNER JOIN.
+  INNER JOIN graph.has_role ON has_role.role_url = role.url
+  INNER JOIN graph.person ON person.url = has_role.person_url
   LEFT JOIN graph.has_homepage ON has_homepage.url = person.url
   GROUP BY role.url
 ),

--- a/terraform/bigquery/role.sql
+++ b/terraform/bigquery/role.sql
@@ -11,8 +11,10 @@ persons AS (
       has_role.ended_on AS endDate
   )) AS personNames
   FROM graph.role
-  LEFT JOIN graph.has_role ON has_role.role_url = role.url
-  LEFT JOIN graph.person ON person.url = has_role.person_url
+  -- If nobody has ever been appointed to the role, we don't want any null
+  -- results here, therefore use INNER JOIN.
+  INNER JOIN graph.has_role ON has_role.role_url = role.url
+  INNER JOIN graph.person ON person.url = has_role.person_url
   LEFT JOIN graph.has_homepage ON has_homepage.url = person.url
   GROUP BY role.url
 ),


### PR DESCRIPTION
GovSearch hangs when a role is returned from BigQuery that has null
values for the persons who have filled the role.  This happens when a
role has never been filled.  The fix is to use an inner join, so that an
empty array is returned instead.

Before:

```json
{
    "type": "Role",
    "name": "Acting Permanent Secretary, DIT",
    "homepage": null,
    "description": "The Permanent Secretary is responsible for leading the Department for International Trade.",
    "personNames": [
        {
            "name": null,
            "homepage": null,
            "startDate": null,
            "endDate": null
        }
    ],
    "orgNames": [
        "Department for International Trade"
    ]
}
```

After:

```json
{
    "type": "Role",
    "name": "Acting Permanent Secretary, DIT",
    "homepage": null,
    "description": "The Permanent Secretary is responsible for leading the Department for International Trade.",
    "personNames": [],
    "orgNames": [
        "Department for International Trade"
    ]
}
```
