### PR TITLE
Export all of mongodb to BigQuery

### DIFF
--- a/src/mongodb/Makefile
+++ b/src/mongodb/Makefile
@@ -333,6 +333,9 @@ temp/taxon_levels.mongodb: temp/define_url.mongodb temp/index.mongodb
 data/taxon_levels.csv.gz: temp/taxon_levels.mongodb
 	source functions.sh; source sh/taxon_levels.sh
 
+data/content_items.csv.gz: temp/define_url.mongodb
+	source functions.sh; source sh/content_items.sh
+
 # Assume that the content.pagerank table has been refreshed by another process
 temp/page.bigquery: \
 	data/url.csv.gz \

--- a/src/mongodb/sh/content_items.sh
+++ b/src/mongodb/sh/content_items.sh
@@ -1,0 +1,22 @@
+FILE_NAME=content_items
+
+# The awk command wraps each line in {"item":<line>} to trick BigQuery into
+# importing the whole line of JSON into a single JSON column, called "item".
+mongoexport \
+  --quiet \
+  --db=content_store \
+  --type=json \
+  --collection=content_items \
+| awk '{print "{\"item\":" $0 "}"}' \
+| gzip -c \
+| gcloud storage cp \
+  - \
+  "gs://${PROJECT_ID}-data-processed/content-store/content_items.json.gz" \
+  --quiet
+
+bq load \
+  --nosynchronous_mode \
+  --noreplace \
+  --source_format="NEWLINE_DELIMITED_JSON" \
+  "content.content_items" \
+  "gs://${PROJECT_ID}-data-processed/content-store/content_items.json.gz"

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -2222,3 +2222,20 @@ resource "google_bigquery_table" "page_views" {
     ]
   )
 }
+
+resource "google_bigquery_table" "content_items" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "content_items"
+  friendly_name = "Content items"
+  description   = "The raw JSON from the MongoDB Content Store database"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "item"
+        type        = "JSON"
+        description = "JSON representation of a content item"
+      }
+    ]
+  )
+}

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -2222,3 +2222,20 @@ resource "google_bigquery_table" "page_views" {
     ]
   )
 }
+
+resource "google_bigquery_table" "content_items" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "content_items"
+  friendly_name = "Content items"
+  description   = "The raw JSON from the MongoDB Content Store database"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "item"
+        type        = "JSON"
+        description = "JSON representation of a content item"
+      }
+    ]
+  )
+}

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -2222,3 +2222,20 @@ resource "google_bigquery_table" "page_views" {
     ]
   )
 }
+
+resource "google_bigquery_table" "content_items" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "content_items"
+  friendly_name = "Content items"
+  description   = "The raw JSON from the MongoDB Content Store database"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "item"
+        type        = "JSON"
+        description = "JSON representation of a content item"
+      }
+    ]
+  )
+}


### PR DESCRIPTION
This will make the data available without having to wait for the
database to restore, and without having to pay for an always-on mongodb
database.
