### PR TITLE
Export organisation-govuk-status from mongo to BQ

### DIFF
--- a/src/mongodb/Makefile
+++ b/src/mongodb/Makefile
@@ -336,6 +336,14 @@ data/taxon_levels.csv.gz: temp/taxon_levels.mongodb
 data/content_items.csv.gz: temp/define_url.mongodb
 	source functions.sh; source sh/content_items.sh
 
+# Status of a government organisation
+temp/organisation_govuk_status.mongodb: temp/define_url.mongodb
+	mongo content_store js/organisation_govuk_status.js
+	touch temp/organisation_govuk_status.mongodb
+
+data/organisation_govuk_status.csv.gz: temp/organisation_govuk_status.mongodb
+	source functions.sh; source sh/organisation_govuk_status.sh
+
 # Assume that the content.pagerank table has been refreshed by another process
 temp/page.bigquery: \
 	data/url.csv.gz \

--- a/src/mongodb/js/organisation_govuk_status.js
+++ b/src/mongodb/js/organisation_govuk_status.js
@@ -1,0 +1,13 @@
+db.content_items.aggregate([
+  { $match: { $and: [
+    { "details.organisation_govuk_status": { $exists: true } },
+    { "details.organisation_govuk_status.status": { $ne: "live" } },
+  ] } },
+  { $project: {
+    url: true,
+    status: "$details.organisation_govuk_status.status",
+    updated_at: "$details.organisation_govuk_status.updated_at",
+    organisation_url: "$details.organisation_govuk_status.url",
+  } },
+  { $out: "organisation_govuk_status" }
+])

--- a/src/mongodb/sh/organisation_govuk_status.sh
+++ b/src/mongodb/sh/organisation_govuk_status.sh
@@ -1,0 +1,8 @@
+FILE_NAME=organisation_govuk_status
+
+query_mongo \
+  collection=organisation_govuk_status \
+  fields=url,status,updated_at,organisation_url \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -2239,3 +2239,38 @@ resource "google_bigquery_table" "content_items" {
     ]
   )
 }
+
+resource "google_bigquery_table" "organisation_govuk_status" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "organisation_govuk_status"
+  friendly_name = "Organisation GOV.UK status"
+  description   = "The status of the organisation in GOV.UK"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "url"
+        type        = "STRING"
+        description = "URL of an organisation on the GOV.UK website"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "status"
+        type        = "STRING"
+        description = "Status of an organisation on the GOV.UK website"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "updated_at"
+        type        = "TIMESTAMP"
+        description = "Date and time that an organisation's status was last updated"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "organisation_url"
+        type        = "STRING"
+        description = "URL of an organisation, not necessarily on GOV.UK"
+      }
+    ]
+  )
+}

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -2239,3 +2239,38 @@ resource "google_bigquery_table" "content_items" {
     ]
   )
 }
+
+resource "google_bigquery_table" "organisation_govuk_status" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "organisation_govuk_status"
+  friendly_name = "Organisation GOV.UK status"
+  description   = "The status of the organisation in GOV.UK"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "url"
+        type        = "STRING"
+        description = "URL of an organisation on the GOV.UK website"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "status"
+        type        = "STRING"
+        description = "Status of an organisation on the GOV.UK website"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "updated_at"
+        type        = "TIMESTAMP"
+        description = "Date and time that an organisation's status was last updated"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "organisation_url"
+        type        = "STRING"
+        description = "URL of an organisation, not necessarily on GOV.UK"
+      }
+    ]
+  )
+}

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -2239,3 +2239,38 @@ resource "google_bigquery_table" "content_items" {
     ]
   )
 }
+
+resource "google_bigquery_table" "organisation_govuk_status" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "organisation_govuk_status"
+  friendly_name = "Organisation GOV.UK status"
+  description   = "The status of the organisation in GOV.UK"
+  schema = jsonencode(
+    [
+      {
+        mode        = "REQUIRED"
+        name        = "url"
+        type        = "STRING"
+        description = "URL of an organisation on the GOV.UK website"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "status"
+        type        = "STRING"
+        description = "Status of an organisation on the GOV.UK website"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "updated_at"
+        type        = "TIMESTAMP"
+        description = "Date and time that an organisation's status was last updated"
+      },
+      {
+        mode        = "NULLABLE"
+        name        = "organisation_url"
+        type        = "STRING"
+        description = "URL of an organisation, not necessarily on GOV.UK"
+      }
+    ]
+  )
+}


### PR DESCRIPTION
Close #326

This doesn't incorporate the status into any of the derived tables in
the `graph` or `search` tables.  That can wait.
