### PR TITLE
Replace IAP with GOV.UK Signon on dev

### DIFF
--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -5,9 +5,3 @@ govgraph_domain       = "govgraphdev.dev"
 govgraphsearch_domain = "govgraphsearchdev.dev"
 govsearch_domain      = "NOT_IN_USE"
 application_title     = "GovGraph Search (development)"
-govgraphsearch_iap_members = [
-  "domain:digital.cabinet-office.gov.uk",
-  "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
-  "user:max.froumentin@digital.cabinet-office.gov.uk",
-  "user:james.marvin@digital.cabinet-office.gov.uk",
-]

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -68,10 +68,6 @@ variable "application_title" {
   type = string
 }
 
-variable "govgraphsearch_iap_members" {
-  type = set(string)
-}
-
 variable "services" {
   type = list(any)
 }

--- a/terraform-dev/terraform.tfvars
+++ b/terraform-dev/terraform.tfvars
@@ -21,7 +21,6 @@ services = [
   "sourcerepo.googleapis.com",
   "vpcaccess.googleapis.com",
   "workflows.googleapis.com",
-  "iap.googleapis.com",
   "secretmanager.googleapis.com",
 ]
 


### PR DESCRIPTION
We're moving GovSearch behind Signon, so we don't need IAP anymore.