### PR TITLE
Remove IAP from staging and prod

### DIFF
--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -120,6 +120,18 @@ resource "google_cloud_run_service" "govgraphsearch" {
           value = var.project_id
         }
         env {
+          name  = "OAUTH_AUTH_URL"
+          value = "https://signon.integration.publishing.service.gov.uk/oauth/authorize"
+        }
+        env {
+          name  = "OAUTH_TOKEN_URL"
+          value = "https://signon.integration.publishing.service.gov.uk/oauth/access_token"
+        }
+        env {
+          name  = "OAUTH_CALLBACK_URL"
+          value = "https://govgraphsearchdev.dev/auth/gds/callback"
+        }
+        env {
           name = "OAUTH_ID"
           value_from {
             secret_key_ref {

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -5,8 +5,3 @@ govgraph_domain       = "govgraphstaging.dev"
 govgraphsearch_domain = "govgraphsearchstaging.dev"
 govsearch_domain      = "NOT_IN_USE"
 application_title     = "GovGraph Search (staging)"
-govgraphsearch_iap_members = [
-  "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
-  "user:max.froumentin@digital.cabinet-office.gov.uk",
-  "user:james.marvin@digital.cabinet-office.gov.uk",
-]

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -1,29 +1,15 @@
-# Create this first, on its own: The IAP OAuth consent screen (Identity-Aware
-# Proxy)
-resource "google_iap_brand" "project_brand" {
-  # The support_email must be your own email address, or a Google Group that you
-  # manage.
-  support_email     = "duncan.garmonsway@digital.cabinet-office.gov.uk"
-  application_title = var.application_title
-}
-
-# Then manually create OAUTH credentials:
-# https://console.cloud.google.com/apis/credentials/oauthclient
-
-# Add a redirect URI of the form
-# https://iap.googleapis.com/v1/oauth/clientIds/CLIENT_ID:handleRedirect
-
 # Then create the secrets in Secret Manager
 # https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#bebe
-resource "google_secret_manager_secret" "iap_oauth_client_id" {
-  secret_id = "iap-oauth-client-id"
+
+resource "google_secret_manager_secret" "sso_oauth_client_id" {
+  secret_id = "OAUTH_ID"
   replication {
     automatic = true
   }
 }
 
-resource "google_secret_manager_secret" "iap_oauth_client_secret" {
-  secret_id = "iap-oauth-client-secret"
+resource "google_secret_manager_secret" "sso_oauth_client_secret" {
+  secret_id = "OAUTH_SECRET"
   replication {
     automatic = true
   }
@@ -53,12 +39,12 @@ resource "google_dns_managed_zone" "govgraphsearch" {
 # Then create everything else below.
 
 # Retrieve the value of the secret
-data "google_secret_manager_secret_version" "iap_oauth_client_id" {
-  secret = "iap-oauth-client-id"
+data "google_secret_manager_secret_version" "sso_oauth_client_id" {
+  secret = "OAUTH_ID"
 }
 
-data "google_secret_manager_secret_version" "iap_oauth_client_secret" {
-  secret = "iap-oauth-client-secret"
+data "google_secret_manager_secret_version" "sso_oauth_client_secret" {
+  secret = "OAUTH_SECRET"
 }
 
 # Boilerplate
@@ -70,34 +56,21 @@ resource "google_compute_region_network_endpoint_group" "govgraphsearch_eg" {
   }
 }
 
-# Connect to the same VPC where Neo4j is
-resource "google_vpc_access_connector" "cloudrun_connector" {
-  name = "cloudrun-connector"
-  subnet {
-    name = "cloudrun-subnet"
-  }
-}
-
-# Allow access the app via IAP (Identity-Aware Proxy)
-data "google_iam_policy" "govgraphsearch_iap" {
-  binding {
-    role    = "roles/iap.httpsResourceAccessor"
-    members = var.govgraphsearch_iap_members
-  }
-}
-
-resource "google_iap_web_backend_service_iam_policy" "govgraphsearch" {
-  web_backend_service = google_compute_backend_service.govgraphsearch.name
-  policy_data         = data.google_iam_policy.govgraphsearch_iap.policy_data
-}
-
-# Allow anyone who has already been through IAP to load the app
+# Allow anyone who has already been through SSO to load the app
 data "google_iam_policy" "govgraphsearch" {
   binding {
     role = "roles/run.invoker"
     members = [
       "allUsers",
     ]
+  }
+}
+
+# Connect to the same VPC where Neo4j is
+resource "google_vpc_access_connector" "cloudrun_connector" {
+  name = "cloudrun-connector"
+  subnet {
+    name = "cloudrun-subnet"
   }
 }
 
@@ -146,6 +119,36 @@ resource "google_cloud_run_service" "govgraphsearch" {
           name  = "PROJECT_ID"
           value = var.project_id
         }
+        env {
+          name  = "OAUTH_AUTH_URL"
+          value = "https://signon.staging.publishing.service.gov.uk/oauth/authorize"
+        }
+        env {
+          name  = "OAUTH_TOKEN_URL"
+          value = "https://signon.staging.publishing.service.gov.uk/oauth/access_token"
+        }
+        env {
+          name  = "OAUTH_CALLBACK_URL"
+          value = "https://govgraphsearchstaging.dev/auth/gds/callback"
+        }
+        env {
+          name = "OAUTH_ID"
+          value_from {
+            secret_key_ref {
+              key  = "latest"
+              name = "OAUTH_ID"
+            }
+          }
+        }
+        env {
+          name = "OAUTH_SECRET"
+          value_from {
+            secret_key_ref {
+              key  = "latest"
+              name = "OAUTH_SECRET"
+            }
+          }
+        }
       }
     }
   }
@@ -163,10 +166,6 @@ resource "google_compute_backend_service" "govgraphsearch" {
   protocol  = "HTTP"
   backend {
     group = google_compute_region_network_endpoint_group.govgraphsearch_eg.self_link
-  }
-  iap {
-    oauth2_client_id     = data.google_secret_manager_secret_version.iap_oauth_client_id.secret_data
-    oauth2_client_secret = data.google_secret_manager_secret_version.iap_oauth_client_secret.secret_data
   }
 }
 

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -68,10 +68,6 @@ variable "application_title" {
   type = string
 }
 
-variable "govgraphsearch_iap_members" {
-  type = set(string)
-}
-
 variable "services" {
   type = list(any)
 }

--- a/terraform-staging/terraform.tfvars
+++ b/terraform-staging/terraform.tfvars
@@ -21,7 +21,6 @@ services = [
   "sourcerepo.googleapis.com",
   "vpcaccess.googleapis.com",
   "workflows.googleapis.com",
-  "iap.googleapis.com",
   "secretmanager.googleapis.com",
 ]
 

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -5,21 +5,3 @@ govgraph_domain       = "govgraph.dev"
 govgraphsearch_domain = "govgraphsearch.dev"
 govsearch_domain      = "gov-search.service.gov.uk"
 application_title     = "GovGraph Search"
-
-govgraphsearch_iap_members = [
-  "domain:digital.cabinet-office.gov.uk",
-
-  # We want to allow trade.gov.uk, and when we do, Google silently respells it as
-  # bis.gov.uk, presumably because of some DNS registration by BEIS as part of a
-  # machinery of government change.
-  "domain:bis.gov.uk",
-
-  # Users at DIT (Department for International Trade) use a different domain to
-  # access Google services, so we allow this as well.
-  "domain:digital.bis.gov.uk",
-
-  # Users at MoJ (Ministry of Justice) use two different domains, and we don't
-  # know which one is a Google domain, so we allow both.
-  "domain:justice.gov.uk",
-  "domain:digital.justice.gov.uk"
-]

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -1,29 +1,15 @@
-# Create this first, on its own: The IAP OAuth consent screen (Identity-Aware
-# Proxy)
-resource "google_iap_brand" "project_brand" {
-  # The support_email must be your own email address, or a Google Group that you
-  # manage.
-  support_email     = "duncan.garmonsway@digital.cabinet-office.gov.uk"
-  application_title = var.application_title
-}
-
-# Then manually create OAUTH credentials:
-# https://console.cloud.google.com/apis/credentials/oauthclient
-
-# Add a redirect URI of the form
-# https://iap.googleapis.com/v1/oauth/clientIds/CLIENT_ID:handleRedirect
-
 # Then create the secrets in Secret Manager
 # https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#bebe
-resource "google_secret_manager_secret" "iap_oauth_client_id" {
-  secret_id = "iap-oauth-client-id"
+
+resource "google_secret_manager_secret" "sso_oauth_client_id" {
+  secret_id = "OAUTH_ID"
   replication {
     automatic = true
   }
 }
 
-resource "google_secret_manager_secret" "iap_oauth_client_secret" {
-  secret_id = "iap-oauth-client-secret"
+resource "google_secret_manager_secret" "sso_oauth_client_secret" {
+  secret_id = "OAUTH_SECRET"
   replication {
     automatic = true
   }
@@ -53,12 +39,12 @@ resource "google_dns_managed_zone" "govgraphsearch" {
 # Then create everything else below.
 
 # Retrieve the value of the secret
-data "google_secret_manager_secret_version" "iap_oauth_client_id" {
-  secret = "iap-oauth-client-id"
+data "google_secret_manager_secret_version" "sso_oauth_client_id" {
+  secret = "OAUTH_ID"
 }
 
-data "google_secret_manager_secret_version" "iap_oauth_client_secret" {
-  secret = "iap-oauth-client-secret"
+data "google_secret_manager_secret_version" "sso_oauth_client_secret" {
+  secret = "OAUTH_SECRET"
 }
 
 # Boilerplate
@@ -70,34 +56,21 @@ resource "google_compute_region_network_endpoint_group" "govgraphsearch_eg" {
   }
 }
 
-# Connect to the same VPC where Neo4j is
-resource "google_vpc_access_connector" "cloudrun_connector" {
-  name = "cloudrun-connector"
-  subnet {
-    name = "cloudrun-subnet"
-  }
-}
-
-# Allow access the app via IAP (Identity-Aware Proxy)
-data "google_iam_policy" "govgraphsearch_iap" {
-  binding {
-    role    = "roles/iap.httpsResourceAccessor"
-    members = var.govgraphsearch_iap_members
-  }
-}
-
-resource "google_iap_web_backend_service_iam_policy" "govgraphsearch" {
-  web_backend_service = google_compute_backend_service.govgraphsearch.name
-  policy_data         = data.google_iam_policy.govgraphsearch_iap.policy_data
-}
-
-# Allow anyone who has already been through IAP to load the app
+# Allow anyone who has already been through SSO to load the app
 data "google_iam_policy" "govgraphsearch" {
   binding {
     role = "roles/run.invoker"
     members = [
       "allUsers",
     ]
+  }
+}
+
+# Connect to the same VPC where Neo4j is
+resource "google_vpc_access_connector" "cloudrun_connector" {
+  name = "cloudrun-connector"
+  subnet {
+    name = "cloudrun-subnet"
   }
 }
 
@@ -146,6 +119,36 @@ resource "google_cloud_run_service" "govgraphsearch" {
           name  = "PROJECT_ID"
           value = var.project_id
         }
+        env {
+          name  = "OAUTH_AUTH_URL"
+          value = "https://signon.publishing.service.gov.uk/oauth/authorize"
+        }
+        env {
+          name  = "OAUTH_TOKEN_URL"
+          value = "https://signon.publishing.service.gov.uk/oauth/access_token"
+        }
+        env {
+          name  = "OAUTH_CALLBACK_URL"
+          value = "https://gov-search.service.gov.uk/auth/gds/callback"
+        }
+        env {
+          name = "OAUTH_ID"
+          value_from {
+            secret_key_ref {
+              key  = "latest"
+              name = "OAUTH_ID"
+            }
+          }
+        }
+        env {
+          name = "OAUTH_SECRET"
+          value_from {
+            secret_key_ref {
+              key  = "latest"
+              name = "OAUTH_SECRET"
+            }
+          }
+        }
       }
     }
   }
@@ -163,10 +166,6 @@ resource "google_compute_backend_service" "govgraphsearch" {
   protocol  = "HTTP"
   backend {
     group = google_compute_region_network_endpoint_group.govgraphsearch_eg.self_link
-  }
-  iap {
-    oauth2_client_id     = data.google_secret_manager_secret_version.iap_oauth_client_id.secret_data
-    oauth2_client_secret = data.google_secret_manager_secret_version.iap_oauth_client_secret.secret_data
   }
 }
 

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -68,10 +68,6 @@ variable "application_title" {
   type = string
 }
 
-variable "govgraphsearch_iap_members" {
-  type = set(string)
-}
-
 variable "services" {
   type = list(any)
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -21,7 +21,6 @@ services = [
   "sourcerepo.googleapis.com",
   "vpcaccess.googleapis.com",
   "workflows.googleapis.com",
-  "iap.googleapis.com",
   "secretmanager.googleapis.com",
 ]
 


### PR DESCRIPTION
Similar to the previous change on dev, we're removing the IAP code and adding new OAuth variables in order to enable moving to Signon