### PR TITLE
Update environment variables to reflect auth status

### DIFF
--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -120,6 +120,18 @@ resource "google_cloud_run_service" "govgraphsearch" {
           value = var.project_id
         }
         env {
+          name  = "OAUTH_AUTH_URL"
+          value = "https://signon.integration.publishing.service.gov.uk/oauth/authorize"
+        }
+        env {
+          name  = "OAUTH_TOKEN_URL"
+          value = "https://signon.integration.publishing.service.gov.uk/oauth/access_token"
+        }
+        env {
+          name  = "OAUTH_CALLBACK_URL"
+          value = "https://govgraphsearchdev.dev/auth/gds/callback"
+        }
+        env {
           name = "OAUTH_ID"
           value_from {
             secret_key_ref {

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -146,6 +146,10 @@ resource "google_cloud_run_service" "govgraphsearch" {
           name  = "PROJECT_ID"
           value = var.project_id
         }
+        env {
+          name  = "DISABLE_AUTH"
+          value = "true"
+        }
       }
     }
   }

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -146,6 +146,10 @@ resource "google_cloud_run_service" "govgraphsearch" {
           name  = "PROJECT_ID"
           value = var.project_id
         }
+        env {
+          name  = "DISABLE_AUTH"
+          value = "true"
+        }
       }
     }
   }


### PR DESCRIPTION
This change updates the cloud run environment variables of each environment to reflect the current decisions on auth:
- dev is behind integration signon, which means we need to define extra variables to make signon authentication work

- staging and prod are on Google Auth, which means we don't need to manage authentication ourselves (since it's taken care of by GCP's Identity-aware proxy). Therefore we set the DISABLE_AUTH value so that GovGraphSearch doesn't do any of the auth stuff.