### PR TITLE
Grant access to additional metadata project service account

### DIFF
--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -32,6 +32,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -32,7 +32,9 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:data-products@digital.cabinet-office.gov.uk",
+      "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com"
     ]
   }
 }

--- a/terraform-dev/bigquery-publishing.tf
+++ b/terraform-dev/bigquery-publishing.tf
@@ -43,7 +43,7 @@ resource "google_bigquery_table" "publishing_actions" {
   table_id      = "actions"
   friendly_name = "Actions"
   description   = "Actions table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -104,7 +104,7 @@ resource "google_bigquery_table" "publishing_change_notes" {
   table_id      = "change_notes"
   friendly_name = "Change notes"
   description   = "Change notes table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -145,7 +145,7 @@ resource "google_bigquery_table" "publishing_documents" {
   table_id      = "documents"
   friendly_name = "Documents"
   description   = "Documents table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -191,7 +191,7 @@ resource "google_bigquery_table" "publishing_editions" {
   table_id      = "editions"
   friendly_name = "Editions"
   description   = "Editions table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -347,7 +347,7 @@ resource "google_bigquery_table" "publishing_events" {
   table_id      = "events"
   friendly_name = "Events"
   description   = "Events table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -398,7 +398,7 @@ resource "google_bigquery_table" "publishing_expanded_links" {
   table_id      = "expanded_links"
   friendly_name = "Expanded links"
   description   = "Expanded links table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -449,7 +449,7 @@ resource "google_bigquery_table" "publishing_link_changes" {
   table_id      = "link_changes"
   friendly_name = "Link changes"
   description   = "Link changes table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -500,7 +500,7 @@ resource "google_bigquery_table" "publishing_link_sets" {
   table_id      = "link_sets"
   friendly_name = "Link sets"
   description   = "Link sets table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -536,7 +536,7 @@ resource "google_bigquery_table" "publishing_links" {
   table_id      = "links"
   friendly_name = "Links"
   description   = "Links table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -587,7 +587,7 @@ resource "google_bigquery_table" "publishing_path_reservations" {
   table_id      = "path_reservations"
   friendly_name = "Path reservations"
   description   = "Path reservations table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -623,7 +623,7 @@ resource "google_bigquery_table" "publishing_role_appointments" {
   table_id      = "role_appointments"
   friendly_name = "Role appointments"
   description   = "Role appointments table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"
@@ -649,80 +649,80 @@ resource "google_bigquery_table" "publishing_roles" {
   table_id      = "roles"
   friendly_name = "Roles"
   description   = "Roles table from the GOV.UK Publishing API PostgreSQL database"
-    schema              = jsonencode(
-        [
-            {
-                mode = "NULLABLE"
-                name = "url"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "schema_name"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "document_type"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "publishing_app"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "phase"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "content_id"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "locale"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "updated_at"
-                type = "TIMESTAMP"
-            },
-            {
-                mode = "NULLABLE"
-                name = "public_updated_at"
-                type = "TIMESTAMP"
-            },
-            {
-                mode = "NULLABLE"
-                name = "first_published_at"
-                type = "TIMESTAMP"
-            },
-            {
-                mode = "NULLABLE"
-                name = "base_path"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "title"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "description"
-                type = "STRING"
-            },
-            {
-                mode = "NULLABLE"
-                name = "details"
-                type = "JSON"
-            },
-        ]
-    )
+  schema = jsonencode(
+    [
+      {
+        mode = "NULLABLE"
+        name = "url"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "schema_name"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "document_type"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "publishing_app"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "phase"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "content_id"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "locale"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "public_updated_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "first_published_at"
+        type = "TIMESTAMP"
+      },
+      {
+        mode = "NULLABLE"
+        name = "base_path"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "title"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "description"
+        type = "STRING"
+      },
+      {
+        mode = "NULLABLE"
+        name = "details"
+        type = "JSON"
+      },
+    ]
+  )
 }
 
 resource "google_bigquery_table" "publishing_unpublishings" {
@@ -730,7 +730,7 @@ resource "google_bigquery_table" "publishing_unpublishings" {
   table_id      = "unpublishings"
   friendly_name = "Unpublishings"
   description   = "Unpublishings table from the GOV.UK Publishing API PostgreSQL database"
-  schema              = jsonencode(
+  schema = jsonencode(
     [
       {
         mode = "NULLABLE"

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -58,9 +58,9 @@ EOF
 }
 
 resource "google_bigquery_routine" "page_views" {
-  dataset_id = google_bigquery_dataset.content.dataset_id
-  routine_id     = "page_views"
-  routine_type = "PROCEDURE"
-  language = "SQL"
+  dataset_id      = google_bigquery_dataset.content.dataset_id
+  routine_id      = "page_views"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
   definition_body = file("bigquery/page-views.sql")
 }

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -32,6 +32,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -32,7 +32,9 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:data-products@digital.cabinet-office.gov.uk",
+      "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com"
     ]
   }
 }

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -32,6 +32,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",
       "group:data-analysis@digital.cabinet-office.gov.uk",

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -34,6 +34,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "group:data-analysis@digital.cabinet-office.gov.uk",
       "group:data-products@digital.cabinet-office.gov.uk",
       "serviceAccount:cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com"
     ]
   }
 }


### PR DESCRIPTION
Purpose of this commit is to grant BigQuery read permissions in the development environment to an additional service account from the metadata project. 

The intent is to grant the same permissions to: 
 - 'wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com' 

as have been granted to:  

 - 'cpto-content-metadata-sa@cpto-content-metadata.iam.gserviceaccount.com'. 

Specifically, these permissions enable the service account to read from bigquery content and graph datasets.

Additionally, some formatting changes have been made to files `bigquery-publishing.tf` and `bigquery.tf` courtesy of `terraform fmt`.