### PR TITLE
Allow data products team to access app in staging

### DIFF
--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -6,7 +6,5 @@ govgraphsearch_domain = "govgraphsearchstaging.dev"
 govsearch_domain      = "NOT_IN_USE"
 application_title     = "GovGraph Search (staging)"
 govgraphsearch_iap_members = [
-  "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
-  "user:max.froumentin@digital.cabinet-office.gov.uk",
-  "user:james.marvin@digital.cabinet-office.gov.uk",
+  "group:data-products@digital.cabinet-office.gov.uk",
 ]


### PR DESCRIPTION
Access to the govsearch app is currently restricted to named users.
This commit removes their access, and instead allows all members of the
Data Products google group.
