### PR TITLE
Use details.internal_name instead to disambiguate taxon titles

### DIFF
--- a/src/mongodb/Makefile
+++ b/src/mongodb/Makefile
@@ -97,6 +97,9 @@ data/document_type.csv.gz: temp/define_url.mongodb
 data/locale.csv.gz: temp/define_url.mongodb
 	source functions.sh; source sh/locale.sh
 
+data/internal_name.csv.gz: temp/define_url.mongodb
+	source functions.sh; source sh/internal_name.sh
+
 data/publishing_app.csv.gz: temp/define_url.mongodb
 	source functions.sh; source sh/publishing_app.sh
 

--- a/src/mongodb/bigquery/page.sql
+++ b/src/mongodb/bigquery/page.sql
@@ -16,6 +16,7 @@ SELECT
   withdrawn_at.withdrawn_at,
   withdrawn_explanation.text AS withdrawn_explanation,
   title.title,
+  internal_name.internal_name,
   description.description,
   department_analytics_profile.department_analytics_profile,
   c.text,
@@ -35,6 +36,7 @@ LEFT JOIN content.public_updated_at USING (url)
 LEFT JOIN content.first_published_at USING (url)
 LEFT JOIN content.withdrawn_at USING (url)
 LEFT JOIN content.withdrawn_explanation USING (url)
+LEFT JOIN content.internal_name USING (url)
 LEFT JOIN content.title USING (url)
 LEFT JOIN content.description USING (url)
 LEFT JOIN content.department_analytics_profile USING (url)

--- a/src/mongodb/bigquery/taxon.sql
+++ b/src/mongodb/bigquery/taxon.sql
@@ -3,6 +3,7 @@ INSERT INTO graph.taxon
 SELECT
   taxon_levels.url,
   page.title,
+  page.internal_name,
   page.description,
   page.content_id,
   taxon_levels.level

--- a/src/mongodb/sh/internal_name.sh
+++ b/src/mongodb/sh/internal_name.sh
@@ -1,0 +1,8 @@
+FILE_NAME=internal_name
+
+query_mongo \
+  fields=url,details.internal_name \
+  query='{ "details.internal_name": { "$exists": true } }' \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -87,6 +87,29 @@ resource "google_bigquery_table" "phase" {
 EOF
 }
 
+resource "google_bigquery_table" "internal_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "internal_name"
+  friendly_name = "GOV.UK content ID"
+  description   = "Internal name of a taxon"
+  schema        = <<EOF
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a taxon"
+  },
+  {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "Internal name of a taxon"
+  }
+]
+EOF
+}
+
 resource "google_bigquery_table" "content_id" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "content_id"

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -138,6 +138,12 @@ resource "google_bigquery_table" "page" {
     "description": "The title of a page"
   },
   {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The internal name of a taxon"
+  },
+  {
     "mode": "NULLABLE",
     "name": "description",
     "type": "STRING",
@@ -267,6 +273,12 @@ resource "google_bigquery_table" "part" {
     "name": "part_title",
     "type": "STRING",
     "description": "The title of a part"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "internal_name",
+    "type": "STRING",
+    "description": "The internal name of a taxon"
   },
   {
     "mode": "NULLABLE",
@@ -425,6 +437,12 @@ resource "google_bigquery_table" "taxon" {
     "type": "STRING",
     "mode": "NULLABLE",
     "description": "The name of a taxon"
+  },
+  {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The internal name of a taxon"
   },
   {
     "name": "description",

--- a/terraform-dev/bigquery-search.tf
+++ b/terraform-dev/bigquery-search.tf
@@ -376,7 +376,7 @@ resource "google_bigquery_table" "search_taxon" {
       {
         name        = "name"
         type        = "STRING"
-        description = "Name of the taxon"
+        description = "Internal name of a taxon"
       },
       {
         name        = "homepage"
@@ -398,7 +398,7 @@ resource "google_bigquery_table" "search_taxon" {
           {
             name        = "name"
             type        = "STRING"
-            description = "Name of the taxon"
+            description = "Internal name of a taxon"
           },
           {
             name        = "level"
@@ -421,7 +421,7 @@ resource "google_bigquery_table" "search_taxon" {
           {
             name        = "name"
             type        = "STRING"
-            description = "Name of the taxon"
+            description = "Internal name of a taxon"
           },
           {
             name        = "level"

--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -65,7 +65,14 @@ SELECT
   withdrawn_at,
   withdrawn_explanation,
   page_views,
-  title,
+  /*
+  Title is preferred to internal name because it is typically of better quality;
+  internal name should be used if title is not unique / repeated.
+  */
+  CASE WHEN
+    COUNT(page.title) OVER (PARTITION BY page.title) = 1 THEN page.title
+    ELSE page.internal_name
+  END AS name,
   description,
   text,
   tagged_taxons.ancestor_titles AS taxons,

--- a/terraform-dev/bigquery/taxon.sql
+++ b/terraform-dev/bigquery/taxon.sql
@@ -4,7 +4,14 @@ WITH
 taxons AS (
   SELECT
   taxon.url AS taxon_url,
-  taxon.title AS name,
+  /*
+  Title is preferred to internal name because it is typically of better quality;
+  internal name should be used if title is not unique / repeated.
+  */
+  CASE WHEN
+    COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
+    ELSE taxon.internal_name
+  END AS name,
   taxon.description,
   taxon.level,
   has_homepage.homepage_url AS url
@@ -39,19 +46,3 @@ SELECT
 FROM taxons
 LEFT JOIN ancestor_taxons USING (taxon_url)
 LEFT JOIN child_taxons USING (taxon_url)
-
--- name: string,
--- homepage: string,
--- description: string,
--- level: number,
--- ancestorTaxons: {
---   url: string,
---   name: string,
---   level: number,
--- }[],
--- childTaxons: {
---   url: string,
---   name: string,
---   level: number
--- }[]
---

--- a/terraform-dev/bigquery/thing.sql
+++ b/terraform-dev/bigquery/thing.sql
@@ -13,7 +13,16 @@ UNION ALL
 SELECT 'BankHoliday' AS type, title AS name
 FROM content.bank_holiday_title
 UNION ALL
-SELECT 'Taxon' AS type, title AS name
+SELECT
+    'Taxon' AS type,
+    /*
+    Title is preferred to internal name because it is typically of better
+    quality; internal name should be used if title is not unique / repeated.
+    */
+    CASE WHEN
+        COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
+        ELSE taxon.internal_name
+    END AS name
 FROM graph.taxon
 UNION ALL
 SELECT 'Transaction' AS type, title AS name

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -87,6 +87,29 @@ resource "google_bigquery_table" "phase" {
 EOF
 }
 
+resource "google_bigquery_table" "internal_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "internal_name"
+  friendly_name = "GOV.UK content ID"
+  description   = "Internal name of a taxon"
+  schema        = <<EOF
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a taxon"
+  },
+  {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "Internal name of a taxon"
+  }
+]
+EOF
+}
+
 resource "google_bigquery_table" "content_id" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "content_id"

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -138,6 +138,12 @@ resource "google_bigquery_table" "page" {
     "description": "The title of a page"
   },
   {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The internal name of a taxon"
+  },
+  {
     "mode": "NULLABLE",
     "name": "description",
     "type": "STRING",
@@ -267,6 +273,12 @@ resource "google_bigquery_table" "part" {
     "name": "part_title",
     "type": "STRING",
     "description": "The title of a part"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "internal_name",
+    "type": "STRING",
+    "description": "The internal name of a taxon"
   },
   {
     "mode": "NULLABLE",
@@ -425,6 +437,12 @@ resource "google_bigquery_table" "taxon" {
     "type": "STRING",
     "mode": "NULLABLE",
     "description": "The name of a taxon"
+  },
+  {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The internal name of a taxon"
   },
   {
     "name": "description",

--- a/terraform-staging/bigquery-search.tf
+++ b/terraform-staging/bigquery-search.tf
@@ -376,7 +376,7 @@ resource "google_bigquery_table" "search_taxon" {
       {
         name        = "name"
         type        = "STRING"
-        description = "Name of the taxon"
+        description = "Internal name of a taxon"
       },
       {
         name        = "homepage"
@@ -398,7 +398,7 @@ resource "google_bigquery_table" "search_taxon" {
           {
             name        = "name"
             type        = "STRING"
-            description = "Name of the taxon"
+            description = "Internal name of a taxon"
           },
           {
             name        = "level"
@@ -421,7 +421,7 @@ resource "google_bigquery_table" "search_taxon" {
           {
             name        = "name"
             type        = "STRING"
-            description = "Name of the taxon"
+            description = "Internal name of a taxon"
           },
           {
             name        = "level"

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -65,7 +65,14 @@ SELECT
   withdrawn_at,
   withdrawn_explanation,
   page_views,
-  title,
+  /*
+  Title is preferred to internal name because it is typically of better quality;
+  internal name should be used if title is not unique / repeated.
+  */
+  CASE WHEN
+    COUNT(page.title) OVER (PARTITION BY page.title) = 1 THEN page.title
+    ELSE page.internal_name
+  END AS name,
   description,
   text,
   tagged_taxons.ancestor_titles AS taxons,

--- a/terraform-staging/bigquery/taxon.sql
+++ b/terraform-staging/bigquery/taxon.sql
@@ -4,7 +4,14 @@ WITH
 taxons AS (
   SELECT
   taxon.url AS taxon_url,
-  taxon.title AS name,
+  /*
+  Title is preferred to internal name because it is typically of better quality;
+  internal name should be used if title is not unique / repeated.
+  */
+  CASE WHEN
+    COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
+    ELSE taxon.internal_name
+  END AS name,
   taxon.description,
   taxon.level,
   has_homepage.homepage_url AS url
@@ -39,19 +46,3 @@ SELECT
 FROM taxons
 LEFT JOIN ancestor_taxons USING (taxon_url)
 LEFT JOIN child_taxons USING (taxon_url)
-
--- name: string,
--- homepage: string,
--- description: string,
--- level: number,
--- ancestorTaxons: {
---   url: string,
---   name: string,
---   level: number,
--- }[],
--- childTaxons: {
---   url: string,
---   name: string,
---   level: number
--- }[]
---

--- a/terraform-staging/bigquery/thing.sql
+++ b/terraform-staging/bigquery/thing.sql
@@ -13,7 +13,16 @@ UNION ALL
 SELECT 'BankHoliday' AS type, title AS name
 FROM content.bank_holiday_title
 UNION ALL
-SELECT 'Taxon' AS type, title AS name
+SELECT
+    'Taxon' AS type,
+    /*
+    Title is preferred to internal name because it is typically of better
+    quality; internal name should be used if title is not unique / repeated.
+    */
+    CASE WHEN
+        COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
+        ELSE taxon.internal_name
+    END AS name
 FROM graph.taxon
 UNION ALL
 SELECT 'Transaction' AS type, title AS name

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -87,6 +87,29 @@ resource "google_bigquery_table" "phase" {
 EOF
 }
 
+resource "google_bigquery_table" "internal_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "internal_name"
+  friendly_name = "GOV.UK content ID"
+  description   = "Internal name of a taxon"
+  schema        = <<EOF
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a taxon"
+  },
+  {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "Internal name of a taxon"
+  }
+]
+EOF
+}
+
 resource "google_bigquery_table" "content_id" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "content_id"

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -138,6 +138,12 @@ resource "google_bigquery_table" "page" {
     "description": "The title of a page"
   },
   {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The internal name of a taxon"
+  },
+  {
     "mode": "NULLABLE",
     "name": "description",
     "type": "STRING",
@@ -267,6 +273,12 @@ resource "google_bigquery_table" "part" {
     "name": "part_title",
     "type": "STRING",
     "description": "The title of a part"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "internal_name",
+    "type": "STRING",
+    "description": "The internal name of a taxon"
   },
   {
     "mode": "NULLABLE",
@@ -425,6 +437,12 @@ resource "google_bigquery_table" "taxon" {
     "type": "STRING",
     "mode": "NULLABLE",
     "description": "The name of a taxon"
+  },
+  {
+    "name": "internal_name",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The internal name of a taxon"
   },
   {
     "name": "description",

--- a/terraform/bigquery-search.tf
+++ b/terraform/bigquery-search.tf
@@ -376,7 +376,7 @@ resource "google_bigquery_table" "search_taxon" {
       {
         name        = "name"
         type        = "STRING"
-        description = "Name of the taxon"
+        description = "Internal name of a taxon"
       },
       {
         name        = "homepage"
@@ -398,7 +398,7 @@ resource "google_bigquery_table" "search_taxon" {
           {
             name        = "name"
             type        = "STRING"
-            description = "Name of the taxon"
+            description = "Internal name of a taxon"
           },
           {
             name        = "level"
@@ -421,7 +421,7 @@ resource "google_bigquery_table" "search_taxon" {
           {
             name        = "name"
             type        = "STRING"
-            description = "Name of the taxon"
+            description = "Internal name of a taxon"
           },
           {
             name        = "level"

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -65,7 +65,14 @@ SELECT
   withdrawn_at,
   withdrawn_explanation,
   page_views,
-  title,
+  /*
+  Title is preferred to internal name because it is typically of better quality;
+  internal name should be used if title is not unique / repeated.
+  */
+  CASE WHEN
+    COUNT(page.title) OVER (PARTITION BY page.title) = 1 THEN page.title
+    ELSE page.internal_name
+  END AS name,
   description,
   text,
   tagged_taxons.ancestor_titles AS taxons,

--- a/terraform/bigquery/taxon.sql
+++ b/terraform/bigquery/taxon.sql
@@ -4,7 +4,14 @@ WITH
 taxons AS (
   SELECT
   taxon.url AS taxon_url,
-  taxon.title AS name,
+  /*
+  Title is preferred to internal name because it is typically of better quality;
+  internal name should be used if title is not unique / repeated.
+  */
+  CASE WHEN
+    COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
+    ELSE taxon.internal_name
+  END AS name,
   taxon.description,
   taxon.level,
   has_homepage.homepage_url AS url
@@ -39,19 +46,3 @@ SELECT
 FROM taxons
 LEFT JOIN ancestor_taxons USING (taxon_url)
 LEFT JOIN child_taxons USING (taxon_url)
-
--- name: string,
--- homepage: string,
--- description: string,
--- level: number,
--- ancestorTaxons: {
---   url: string,
---   name: string,
---   level: number,
--- }[],
--- childTaxons: {
---   url: string,
---   name: string,
---   level: number
--- }[]
---

--- a/terraform/bigquery/thing.sql
+++ b/terraform/bigquery/thing.sql
@@ -13,7 +13,16 @@ UNION ALL
 SELECT 'BankHoliday' AS type, title AS name
 FROM content.bank_holiday_title
 UNION ALL
-SELECT 'Taxon' AS type, title AS name
+SELECT
+    'Taxon' AS type,
+    /*
+    Title is preferred to internal name because it is typically of better
+    quality; internal name should be used if title is not unique / repeated.
+    */
+    CASE WHEN
+        COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
+        ELSE taxon.internal_name
+    END AS name
 FROM graph.taxon
 UNION ALL
 SELECT 'Transaction' AS type, title AS name


### PR DESCRIPTION
The PR consists of steps to add a new data (internal_name) field to search.taxon table to be available for UI search.