### PR TITLE
Fix bank holiday workflow

### DIFF
--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -333,7 +333,7 @@ main:
             body:
                 useLegacySql: false
                 query: $${
-                    "TRUNCATE content.bank_holiday_url; " +
+                    "TRUNCATE TABLE content.bank_holiday_url; " +
                     "INSERT INTO content.bank_holiday_url " +
                     "SELECT DISTINCT " +
                     "  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '+', '-'), '/', '_') AS url " +


### PR DESCRIPTION
Fix a syntax error introduced in https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/451.  The error is only in the production environment.

The [Tables metadata](https://console.cloud.google.com/monitoring/alerting/policies/7462025334159841691?project=govuk-knowledge-graph) check is raising an alert because the table `content.bank_holiday_url` hasn't been updated for more than 24 hours, because of the syntax error in the
[workflow](https://console.cloud.google.com/workflows/workflow/europe-west2/bank-holidays/logs?project=govuk-knowledge-graph-dev).

The workflow doesn't report any errors. Perhaps it is only concerned with the success of the API call to BigQuery, not the success of the query itself.
