### PR TITLE
grant bigquery.DataViewer role to the service account for llm-question-answering project

### DIFF
--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -32,6 +32,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -36,6 +36,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
     ]
   }
 }

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -32,6 +32,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -36,6 +36,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
     ]
   }
 }

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -32,6 +32,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "projectReaders",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
+      "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "group:data-engineering@digital.cabinet-office.gov.uk",

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -36,6 +36,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
     ]
   }
 }


### PR DESCRIPTION
Purpose of this PR is to grant BigQuery read permissions in all the environments to a new service account from the GCP question-answering with large-language-models.

Specifically, these permissions enable the service account to read from bigquery search and graph datasets.