### PR TITLE
Tolerate tables being briefly empty during updates

### DIFF
--- a/terraform-dev/bigquery/check-tables-metadata.sql
+++ b/terraform-dev/bigquery/check-tables-metadata.sql
@@ -7,7 +7,11 @@ SELECT
   CASE
     -- Raise an alert for tables that have zero rows
     WHEN row_count = 0
-      -- But ignore tables that are expected to have zero rows
+      -- And that aren't likely to be still being refreshed.
+      -- Annoyingly, it isn't possible to TRUNCATE in the same transaction, so
+      -- tables will briefly be empty until they are repopulated.
+      AND last_modified < TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL - 10 MINUTE)
+      -- Ignore tables that are expected to have zero rows
       AND CONCAT(dataset_id, ".", table_id) NOT IN
       (
         'content.place_abbreviations',

--- a/terraform-staging/bigquery/check-tables-metadata.sql
+++ b/terraform-staging/bigquery/check-tables-metadata.sql
@@ -7,7 +7,11 @@ SELECT
   CASE
     -- Raise an alert for tables that have zero rows
     WHEN row_count = 0
-      -- But ignore tables that are expected to have zero rows
+      -- And that aren't likely to be still being refreshed.
+      -- Annoyingly, it isn't possible to TRUNCATE in the same transaction, so
+      -- tables will briefly be empty until they are repopulated.
+      AND last_modified < TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL - 10 MINUTE)
+      -- Ignore tables that are expected to have zero rows
       AND CONCAT(dataset_id, ".", table_id) NOT IN
       (
         'content.place_abbreviations',

--- a/terraform/bigquery/check-tables-metadata.sql
+++ b/terraform/bigquery/check-tables-metadata.sql
@@ -7,7 +7,11 @@ SELECT
   CASE
     -- Raise an alert for tables that have zero rows
     WHEN row_count = 0
-      -- But ignore tables that are expected to have zero rows
+      -- And that aren't likely to be still being refreshed.
+      -- Annoyingly, it isn't possible to TRUNCATE in the same transaction, so
+      -- tables will briefly be empty until they are repopulated.
+      AND last_modified < TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL - 10 MINUTE)
+      -- Ignore tables that are expected to have zero rows
       AND CONCAT(dataset_id, ".", table_id) NOT IN
       (
         'content.place_abbreviations',


### PR DESCRIPTION
We create alerts when a table unexpectedly has zero rows. We also update
tables by first truncating them (removing all rows), and then loading
new data into them. Alerts can be raised between those two events
occurring.

Unfortunately, there isn't a way to truncate and load in the same
transaction, so that the table always has rows, and if the load fails
then the original rows remain.

- The `WRITE_TRUNCATE` disposition of `bq load` unfortunately scrubs the
  schema of the table as well as the data.
- The `TRUNCATE` statement in SQL isn't allowed as part of a
  multi-statement transaction.

So this commit introduces a hard-coded tolerance.  Alerts will only be
raised for an empty tables if more than 10 minutes have passed since
they were last updated.

Closes #491
