### PR TITLE
Assign owner and support emails to groups

### DIFF
--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -10,7 +10,7 @@ resource "google_service_account" "govgraphsearch" {
 resource "google_iap_brand" "project_brand" {
   # The support_email must be your own email address, or a Google Group that you
   # manage.
-  support_email     = "duncan.garmonsway@digital.cabinet-office.gov.uk"
+  support_email     = "govsearch-developers@digital.cabinet-office.gov.uk"
   application_title = var.application_title
 }
 

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -194,10 +194,7 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/owner"
     members = [
-      "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
-      "user:james.marvin@digital.cabinet-office.gov.uk",
-      "user:guilhem.forey@digital.cabinet-office.gov.uk",
-      "user:somme.sakounthong@digital.cabinet-office.gov.uk",
+      "group:govsearch-developers@digital.cabinet-office.gov.uk",
     ]
   }
 

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -10,7 +10,7 @@ resource "google_service_account" "govgraphsearch" {
 resource "google_iap_brand" "project_brand" {
   # The support_email must be your own email address, or a Google Group that you
   # manage.
-  support_email     = "duncan.garmonsway@digital.cabinet-office.gov.uk"
+  support_email     = "govsearch-developers@digital.cabinet-office.gov.uk"
   application_title = var.application_title
 }
 

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -194,10 +194,7 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/owner"
     members = [
-      "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
-      "user:james.marvin@digital.cabinet-office.gov.uk",
-      "user:guilhem.forey@digital.cabinet-office.gov.uk",
-      "user:somme.sakounthong@digital.cabinet-office.gov.uk",
+      "group:govsearch-developers@digital.cabinet-office.gov.uk",
     ]
   }
 

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -10,7 +10,7 @@ resource "google_service_account" "govgraphsearch" {
 resource "google_iap_brand" "project_brand" {
   # The support_email must be your own email address, or a Google Group that you
   # manage.
-  support_email     = "duncan.garmonsway@digital.cabinet-office.gov.uk"
+  support_email     = "govsearch-developers@digital.cabinet-office.gov.uk"
   application_title = var.application_title
 }
 

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -194,10 +194,7 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/owner"
     members = [
-      "user:duncan.garmonsway@digital.cabinet-office.gov.uk",
-      "user:james.marvin@digital.cabinet-office.gov.uk",
-      "user:guilhem.forey@digital.cabinet-office.gov.uk",
-      "user:somme.sakounthong@digital.cabinet-office.gov.uk",
+      "group:govsearch-developers@digital.cabinet-office.gov.uk",
     ]
   }
 


### PR DESCRIPTION
- Assign projectOwner role to group not individuals
- Set support email of GovSearch app to a group

This avoids revealing owners in the public GitHub repository, and makes it
easier to change people's permissions, by avoiding terraform.
