### PR TITLE
Fix titles sql

### DIFF
--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -71,7 +71,7 @@ SELECT
   */
   CASE WHEN
     COUNT(page.title) OVER (PARTITION BY page.title) = 1 THEN page.title
-    ELSE page.internal_name
+    ELSE COALESCE(page.internal_name, page.title)
   END AS name,
   description,
   text,

--- a/terraform-dev/bigquery/taxon.sql
+++ b/terraform-dev/bigquery/taxon.sql
@@ -10,7 +10,7 @@ taxons AS (
   */
   CASE WHEN
     COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
-    ELSE taxon.internal_name
+    ELSE COALESCE(taxon.internal_name, taxon.title)
   END AS name,
   taxon.description,
   taxon.level,

--- a/terraform-dev/bigquery/thing.sql
+++ b/terraform-dev/bigquery/thing.sql
@@ -21,7 +21,7 @@ SELECT
     */
     CASE WHEN
         COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
-        ELSE taxon.internal_name
+        ELSE COALESCE(taxon.internal_name, taxon.title)
     END AS name
 FROM graph.taxon
 UNION ALL

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -71,7 +71,7 @@ SELECT
   */
   CASE WHEN
     COUNT(page.title) OVER (PARTITION BY page.title) = 1 THEN page.title
-    ELSE page.internal_name
+    ELSE COALESCE(page.internal_name, page.title)
   END AS name,
   description,
   text,

--- a/terraform-staging/bigquery/taxon.sql
+++ b/terraform-staging/bigquery/taxon.sql
@@ -10,7 +10,7 @@ taxons AS (
   */
   CASE WHEN
     COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
-    ELSE taxon.internal_name
+    ELSE COALESCE(taxon.internal_name, taxon.title)
   END AS name,
   taxon.description,
   taxon.level,

--- a/terraform-staging/bigquery/thing.sql
+++ b/terraform-staging/bigquery/thing.sql
@@ -21,7 +21,7 @@ SELECT
     */
     CASE WHEN
         COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
-        ELSE taxon.internal_name
+        ELSE COALESCE(taxon.internal_name, taxon.title)
     END AS name
 FROM graph.taxon
 UNION ALL

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -71,7 +71,7 @@ SELECT
   */
   CASE WHEN
     COUNT(page.title) OVER (PARTITION BY page.title) = 1 THEN page.title
-    ELSE page.internal_name
+    ELSE COALESCE(page.internal_name, page.title)
   END AS name,
   description,
   text,

--- a/terraform/bigquery/taxon.sql
+++ b/terraform/bigquery/taxon.sql
@@ -10,7 +10,7 @@ taxons AS (
   */
   CASE WHEN
     COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
-    ELSE taxon.internal_name
+    ELSE COALESCE(taxon.internal_name, taxon.title)
   END AS name,
   taxon.description,
   taxon.level,

--- a/terraform/bigquery/thing.sql
+++ b/terraform/bigquery/thing.sql
@@ -21,7 +21,7 @@ SELECT
     */
     CASE WHEN
         COUNT(taxon.title) OVER (PARTITION BY taxon.title) = 1 THEN taxon.title
-        ELSE taxon.internal_name
+        ELSE COALESCE(taxon.internal_name, taxon.title)
     END AS name
 FROM graph.taxon
 UNION ALL


### PR DESCRIPTION
The purpose of this PR is to fix relevant SQL used to populate a page name.

The SQL has been updated to ensure that the page title is used where it is unique **OR** where the page internal name is not available.