### PR TITLE
Terraform abbreviations table and things query

### DIFF
--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -2276,3 +2276,30 @@ resource "google_bigquery_table" "organisation_govuk_status" {
     ]
   )
 }
+
+resource "google_bigquery_table" "abbreviations" {
+  dataset_id    = "content"
+  table_id      = "abbreviations"
+  friendly_name = "Abbreviations"
+  description   = "Abbreviations defined on GOV.UK pages"
+  schema = jsonencode(
+    [
+      {
+        name = "count"
+        type = "INTEGER"
+      },
+      {
+        name = "url"
+        type = "STRING"
+      },
+      {
+        name = "abbreviation_title"
+        type = "STRING"
+      },
+      {
+        name = "abbreviation_text"
+        type = "STRING"
+      },
+    ]
+  )
+}

--- a/terraform-dev/bigquery/thing.sql
+++ b/terraform-dev/bigquery/thing.sql
@@ -28,3 +28,9 @@ UNION ALL
 SELECT 'Transaction' AS type, title AS name
 FROM graph.page
 WHERE document_type = 'transaction'
+UNION ALL
+SELECT DISTINCT 'AbbreviationText' AS type, abbreviation_text AS name
+FROM content.abbreviations
+UNION ALL
+SELECT DISTINCT 'AbbreviationTitle' AS type, abbreviation_title AS name
+FROM content.abbreviations

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -2276,3 +2276,30 @@ resource "google_bigquery_table" "organisation_govuk_status" {
     ]
   )
 }
+
+resource "google_bigquery_table" "abbreviations" {
+  dataset_id    = "content"
+  table_id      = "abbreviations"
+  friendly_name = "Abbreviations"
+  description   = "Abbreviations defined on GOV.UK pages"
+  schema = jsonencode(
+    [
+      {
+        name = "count"
+        type = "INTEGER"
+      },
+      {
+        name = "url"
+        type = "STRING"
+      },
+      {
+        name = "abbreviation_title"
+        type = "STRING"
+      },
+      {
+        name = "abbreviation_text"
+        type = "STRING"
+      },
+    ]
+  )
+}

--- a/terraform-staging/bigquery/thing.sql
+++ b/terraform-staging/bigquery/thing.sql
@@ -28,3 +28,9 @@ UNION ALL
 SELECT 'Transaction' AS type, title AS name
 FROM graph.page
 WHERE document_type = 'transaction'
+UNION ALL
+SELECT DISTINCT 'AbbreviationText' AS type, abbreviation_text AS name
+FROM content.abbreviations
+UNION ALL
+SELECT DISTINCT 'AbbreviationTitle' AS type, abbreviation_title AS name
+FROM content.abbreviations

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -2276,3 +2276,30 @@ resource "google_bigquery_table" "organisation_govuk_status" {
     ]
   )
 }
+
+resource "google_bigquery_table" "abbreviations" {
+  dataset_id    = "content"
+  table_id      = "abbreviations"
+  friendly_name = "Abbreviations"
+  description   = "Abbreviations defined on GOV.UK pages"
+  schema = jsonencode(
+    [
+      {
+        name = "count"
+        type = "INTEGER"
+      },
+      {
+        name = "url"
+        type = "STRING"
+      },
+      {
+        name = "abbreviation_title"
+        type = "STRING"
+      },
+      {
+        name = "abbreviation_text"
+        type = "STRING"
+      },
+    ]
+  )
+}


### PR DESCRIPTION
Abbreviations were added in #437 and #440 but by accident those changes
weren't made consistently in all environments (prod, staging, dev).
This commit makes it consistent.

The table `content.abbreviations` also wasn't terraformed by those pull
requests, as noted in #494.

Closes #494
