### PR TITLE
Make terraform consistent in all environments

### DIFF
--- a/diff-terraform.sh
+++ b/diff-terraform.sh
@@ -14,4 +14,5 @@ echo "$diffs"
 
 # If there are any differences then exit with an error.
 # https://stackoverflow.com/a/35165216/937932
-if [[ $(echo $diffs | head -c1 | wc -c) -ne 0 ]]; then exit 1; fi
+# Leading whitespace of an empty diff is trimmed with the tr command.
+if [[ $(echo $diffs | tr -d "[:space:]" | head -c1 | wc -c) -ne 0 ]]; then exit 1; else exit 0; fi

--- a/terraform-dev/terraform.tfvars
+++ b/terraform-dev/terraform.tfvars
@@ -21,6 +21,7 @@ services = [
   "sourcerepo.googleapis.com",
   "vpcaccess.googleapis.com",
   "workflows.googleapis.com",
+  "iap.googleapis.com",
   "secretmanager.googleapis.com",
 ]
 


### PR DESCRIPTION
This adds one line to one file in one environment.  It enables an API
that is already enabled anyway, because terraform doesn't disable APIs
when they are removed from the configuration as this line was.  So there
will be nothing to deploy, and no actual real-world change except that
the `diff-terraform` GitHub Action should now pass.

This PR also includes a bugfix for the `diff-terraform.sh` tool, which was exiting with an error even when diffs were blank, because blank diffs included whitespace.
