### PR TITLE
Allow slug column to be null in graph.page

### DIFF
--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -168,7 +168,7 @@ resource "google_bigquery_table" "page" {
     "description": "The order of the part among other parts in the same document, counting from 0"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path to get the url"

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -168,7 +168,7 @@ resource "google_bigquery_table" "page" {
     "description": "The order of the part among other parts in the same document, counting from 0"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path to get the url"

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -168,7 +168,7 @@ resource "google_bigquery_table" "page" {
     "description": "The order of the part among other parts in the same document, counting from 0"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path to get the url"


### PR DESCRIPTION
We mistakenly required the "slug" column to have a value in the
graph.page table, to be consistent with the content.parts table.  In
fact, the graph.page table includes rows of pages that aren't a "part"
of a guide document, and therefore don't have a slug.  Disallowing nulls
caused the query that populates the table to fail.
