### PR TITLE
Define node env

### DIFF
--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -198,6 +198,10 @@ resource "google_cloud_run_service" "govgraphsearch" {
           value = try(google_redis_instance.session_store[0].port, "")
         }
         env {
+          name  = "NODE_ENV"
+          value = var.environment
+        }
+        env {
           name  = "NEO4J_URL"
           value = "http://${google_compute_address.neo4j_internal.address}:7474/db/neo4j/tx"
         }

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -198,6 +198,10 @@ resource "google_cloud_run_service" "govgraphsearch" {
           value = try(google_redis_instance.session_store[0].port, "")
         }
         env {
+          name  = "NODE_ENV"
+          value = var.environment
+        }
+        env {
           name  = "NEO4J_URL"
           value = "http://${google_compute_address.neo4j_internal.address}:7474/db/neo4j/tx"
         }

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -198,6 +198,10 @@ resource "google_cloud_run_service" "govgraphsearch" {
           value = try(google_redis_instance.session_store[0].port, "")
         }
         env {
+          name  = "NODE_ENV"
+          value = var.environment
+        }
+        env {
           name  = "NEO4J_URL"
           value = "http://${google_compute_address.neo4j_internal.address}:7474/db/neo4j/tx"
         }


### PR DESCRIPTION
This PR introduces the `NODE_ENV` environment variable to the Cloud Run instance.

It is used for the frontend to know which environment it is being served from. See [this PR](https://github.com/alphagov/govuk-knowledge-graph-search/pull/73).