### PR TITLE
Omit deprecated taxons

### DIFF
--- a/src/mongodb/bigquery/taxon.sql
+++ b/src/mongodb/bigquery/taxon.sql
@@ -9,4 +9,6 @@ SELECT
   taxon_levels.level
 FROM content.taxon_levels
 INNER JOIN graph.page AS page ON taxon_levels.homepage_url = page.url
+/* Exclude "alpha" (depcrecated) taxons */
+WHERE page.phase != "alpha"
 ;

--- a/terraform-dev/bigquery/thing.sql
+++ b/terraform-dev/bigquery/thing.sql
@@ -27,7 +27,9 @@ FROM graph.taxon
 UNION ALL
 SELECT 'Transaction' AS type, title AS name
 FROM graph.page
-WHERE document_type = 'transaction'
+WHERE document_type = 'transaction' AND
+/* Exclude "alpha" (depcrecated) taxons */
+phase != "alpha"
 UNION ALL
 SELECT DISTINCT 'AbbreviationText' AS type, abbreviation_text AS name
 FROM content.abbreviations

--- a/terraform-staging/bigquery/thing.sql
+++ b/terraform-staging/bigquery/thing.sql
@@ -27,7 +27,9 @@ FROM graph.taxon
 UNION ALL
 SELECT 'Transaction' AS type, title AS name
 FROM graph.page
-WHERE document_type = 'transaction'
+WHERE document_type = 'transaction' AND
+/* Exclude "alpha" (depcrecated) taxons */
+phase != "alpha"
 UNION ALL
 SELECT DISTINCT 'AbbreviationText' AS type, abbreviation_text AS name
 FROM content.abbreviations

--- a/terraform/bigquery/thing.sql
+++ b/terraform/bigquery/thing.sql
@@ -27,7 +27,9 @@ FROM graph.taxon
 UNION ALL
 SELECT 'Transaction' AS type, title AS name
 FROM graph.page
-WHERE document_type = 'transaction'
+WHERE document_type = 'transaction' AND
+/* Exclude "alpha" (depcrecated) taxons */
+phase != "alpha"
 UNION ALL
 SELECT DISTINCT 'AbbreviationText' AS type, abbreviation_text AS name
 FROM content.abbreviations


### PR DESCRIPTION
Deprecated taxons are identified with a `phase` value of `alpha` in graph.page.

The purpose of the proposed changes is to ensure that deprecated taxons are not displayed to end users.

This is achieved by:

 - Using a `WHERE` filter to prevent deprecated taxons from being included in the creation of `graph.taxon` (`taxon.sql`)
 - Using a `WHERE` filter to prevent deprecated taxons from being included in the population of `search.thing` (`thing.sql`)