### PR TITLE
Alert GovSearch Devs instead of Data Products

### DIFF
--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -135,11 +135,11 @@ resource "google_bigquery_data_transfer_config" "check_tables_metadata" {
   service_account_name = google_service_account.bigquery_scheduled_queries_search.email
 }
 
-resource "google_monitoring_notification_channel" "data_products" {
-  display_name = "Data Products"
+resource "google_monitoring_notification_channel" "govsearch_developers" {
+  display_name = "GovSearch Developers"
   type         = "email"
   labels = {
-    email_address = "data-products@digital.cabinet-office.gov.uk"
+    email_address = "govsearch-developers@digital.cabinet-office.gov.uk"
   }
 }
 
@@ -153,7 +153,7 @@ resource "google_monitoring_alert_policy" "tables_metadata" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.data_products.name]
+  notification_channels = [google_monitoring_notification_channel.govsearch_developers.name]
   alert_strategy {
     notification_rate_limit {
       // One day

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -135,11 +135,11 @@ resource "google_bigquery_data_transfer_config" "check_tables_metadata" {
   service_account_name = google_service_account.bigquery_scheduled_queries_search.email
 }
 
-resource "google_monitoring_notification_channel" "data_products" {
-  display_name = "Data Products"
+resource "google_monitoring_notification_channel" "govsearch_developers" {
+  display_name = "GovSearch Developers"
   type         = "email"
   labels = {
-    email_address = "data-products@digital.cabinet-office.gov.uk"
+    email_address = "govsearch-developers@digital.cabinet-office.gov.uk"
   }
 }
 
@@ -153,7 +153,7 @@ resource "google_monitoring_alert_policy" "tables_metadata" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.data_products.name]
+  notification_channels = [google_monitoring_notification_channel.govsearch_developers.name]
   alert_strategy {
     notification_rate_limit {
       // One day

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -135,11 +135,11 @@ resource "google_bigquery_data_transfer_config" "check_tables_metadata" {
   service_account_name = google_service_account.bigquery_scheduled_queries_search.email
 }
 
-resource "google_monitoring_notification_channel" "data_products" {
-  display_name = "Data Products"
+resource "google_monitoring_notification_channel" "govsearch_developers" {
+  display_name = "GovSearch Developers"
   type         = "email"
   labels = {
-    email_address = "data-products@digital.cabinet-office.gov.uk"
+    email_address = "govsearch-developers@digital.cabinet-office.gov.uk"
   }
 }
 
@@ -153,7 +153,7 @@ resource "google_monitoring_alert_policy" "tables_metadata" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.data_products.name]
+  notification_channels = [google_monitoring_notification_channel.govsearch_developers.name]
   alert_strategy {
     notification_rate_limit {
       // One day


### PR DESCRIPTION
We now have a Google Group of the developers who work on the GovSearch.
It would be more appropriate to send alerts to that group than to the
whole Data Products team.
