### PR TITLE
Filter deprecated taxons

### DIFF
--- a/src/mongodb/bigquery/taxon.sql
+++ b/src/mongodb/bigquery/taxon.sql
@@ -9,6 +9,4 @@ SELECT
   taxon_levels.level
 FROM content.taxon_levels
 INNER JOIN graph.page AS page ON taxon_levels.homepage_url = page.url
-/* Exclude "alpha" (depcrecated) taxons */
-WHERE page.phase != "alpha"
 ;

--- a/terraform-dev/bigquery/taxon.sql
+++ b/terraform-dev/bigquery/taxon.sql
@@ -46,3 +46,6 @@ SELECT
 FROM taxons
 LEFT JOIN ancestor_taxons USING (taxon_url)
 LEFT JOIN child_taxons USING (taxon_url)
+/* Use content.phase to filter "alpha" (deprecated) taxons */
+LEFT JOIN content.phase ON phase.url = taxons.url
+WHERE phase.phase != "alpha"

--- a/terraform-staging/bigquery/taxon.sql
+++ b/terraform-staging/bigquery/taxon.sql
@@ -46,3 +46,6 @@ SELECT
 FROM taxons
 LEFT JOIN ancestor_taxons USING (taxon_url)
 LEFT JOIN child_taxons USING (taxon_url)
+/* Use content.phase to filter "alpha" (deprecated) taxons */
+LEFT JOIN content.phase ON phase.url = taxons.url
+WHERE phase.phase != "alpha"

--- a/terraform/bigquery/taxon.sql
+++ b/terraform/bigquery/taxon.sql
@@ -46,3 +46,6 @@ SELECT
 FROM taxons
 LEFT JOIN ancestor_taxons USING (taxon_url)
 LEFT JOIN child_taxons USING (taxon_url)
+/* Use content.phase to filter "alpha" (deprecated) taxons */
+LEFT JOIN content.phase ON phase.url = taxons.url
+WHERE phase.phase != "alpha"


### PR DESCRIPTION
Purpose of this change is to revoke previous changes to mongodb sql intended to filter deprecated taxons.

These changes are made in terraform sql (taxon.sql) instead.