### PR TITLE
Consolidate some bigquery dataViewer roles

### DIFF
--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -35,9 +35,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 }

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -30,9 +30,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     members = [
       "projectReaders",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",

--- a/terraform-dev/bigquery-publishing.tf
+++ b/terraform-dev/bigquery-publishing.tf
@@ -26,9 +26,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
     ]
   }

--- a/terraform-dev/bigquery-search.tf
+++ b/terraform-dev/bigquery-search.tf
@@ -32,9 +32,7 @@ data "google_iam_policy" "bigquery_dataset_search" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
     ]

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -44,9 +44,7 @@ data "google_iam_policy" "bigquery_dataset_test" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 }

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -234,9 +234,7 @@ data "google_iam_policy" "project" {
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -35,9 +35,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 }

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -30,9 +30,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     members = [
       "projectReaders",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",

--- a/terraform-staging/bigquery-publishing.tf
+++ b/terraform-staging/bigquery-publishing.tf
@@ -26,9 +26,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
     ]
   }

--- a/terraform-staging/bigquery-search.tf
+++ b/terraform-staging/bigquery-search.tf
@@ -32,9 +32,7 @@ data "google_iam_policy" "bigquery_dataset_search" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
     ]

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -44,9 +44,7 @@ data "google_iam_policy" "bigquery_dataset_test" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 }

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -234,9 +234,7 @@ data "google_iam_policy" "project" {
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -35,9 +35,7 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 }

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -30,9 +30,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     members = [
       "projectReaders",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",

--- a/terraform/bigquery-publishing.tf
+++ b/terraform/bigquery-publishing.tf
@@ -26,9 +26,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
     ]
   }

--- a/terraform/bigquery-search.tf
+++ b/terraform/bigquery-search.tf
@@ -32,9 +32,7 @@ data "google_iam_policy" "bigquery_dataset_search" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
     ]

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -44,9 +44,7 @@ data "google_iam_policy" "bigquery_dataset_test" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk",
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -234,9 +234,7 @@ data "google_iam_policy" "project" {
       "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
       "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
       "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "group:data-engineering@digital.cabinet-office.gov.uk",
-      "group:data-analysis@digital.cabinet-office.gov.uk",
-      "group:data-products@digital.cabinet-office.gov.uk"
+      "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
 


### PR DESCRIPTION
Currently we assign the bigquery.dataViewer to three different Google
Groups, each of which is managed independently of GovSearch.  It would
be better to create a single Google Group called govsearch-data-viewers,
and make those other groups members of govsearch-data-viewers.  Such a
group has been created, and this commit reconfigures terraform to use
it.
