### PR TITLE
Use TRUNCATE instead of CREATE OR REPLACE

### DIFF
--- a/src/mongodb/bigquery/abbreviations.sql
+++ b/src/mongodb/bigquery/abbreviations.sql
@@ -1,45 +1,6 @@
 -- Concatenate tables of embedded links from various document types into one
-CREATE OR REPLACE TABLE `content.abbreviations`AS
-SELECT * FROM `content.body_abbreviations`
-UNION ALL
-SELECT * FROM `content.body_content_abbreviations`
-UNION ALL
-SELECT
-  * EXCEPT(base_path, part_index)
-FROM `content.parts_abbreviations`
-UNION ALL
-SELECT
-  count,
-  base_path as url,
-  * EXCEPT(count, url, base_path, part_index)
-FROM `content.parts_abbreviations`
-WHERE part_index = 1
-UNION ALL
-SELECT * FROM `content.place_abbreviations`
-UNION ALL
-SELECT * FROM `content.step_by_step_abbreviations`
-UNION ALL
-SELECT * FROM `content.step_by_step_abbreviations`
-UNION ALL
-SELECT * FROM `content.transaction_abbreviations`
--- role_content is derived from the publishing API database, which isn't updated
--- until after this query is run, because the database backup file isn't
--- available until too late in the day, so this is always a day behind the other
--- tables.
-UNION ALL
-SELECT * FROM `content.role_abbreviations`
-;
-
-EXPORT DATA OPTIONS(
-  uri='gs://$PROJECT_ID-data-processed/bigquery/abbreviations_*.csv.gz',
-  format='CSV',
-  compression='GZIP',
-  overwrite=true
-  ) AS
-SELECT * FROM content.abbreviations
-;
-
-CREATE OR REPLACE TABLE `content.abbreviations`AS
+TRUNCATE TABLE `content.abbreviations`;
+INSERT INTO `content.abbreviations`
 SELECT * FROM `content.body_abbreviations`
 UNION ALL
 SELECT * FROM `content.body_content_abbreviations`

--- a/src/mongodb/bigquery/content.sql
+++ b/src/mongodb/bigquery/content.sql
@@ -1,5 +1,6 @@
 -- Concatenate tables of content from various document types into one
-CREATE OR REPLACE TABLE `content.content` AS
+TRUNCATE TABLE `content.content`;
+INSERT INTO `content.content`
 SELECT * FROM `content.body_content`
 UNION ALL
 SELECT * FROM `content.body`

--- a/src/mongodb/bigquery/embedded_links.sql
+++ b/src/mongodb/bigquery/embedded_links.sql
@@ -1,45 +1,6 @@
 -- Concatenate tables of embedded links from various document types into one
-CREATE OR REPLACE TABLE `content.embedded_links`AS
-SELECT * FROM `content.body_embedded_links`
-UNION ALL
-SELECT * FROM `content.body_content_embedded_links`
-UNION ALL
-SELECT
-  * EXCEPT(base_path, part_index)
-FROM `content.parts_embedded_links`
-UNION ALL
-SELECT
-  count,
-  base_path as url,
-  * EXCEPT(count, url, base_path, part_index)
-FROM `content.parts_embedded_links`
-WHERE part_index = 1
-UNION ALL
-SELECT * FROM `content.place_embedded_links`
-UNION ALL
-SELECT * FROM `content.step_by_step_embedded_links`
-UNION ALL
-SELECT * FROM `content.step_by_step_embedded_links`
-UNION ALL
-SELECT * FROM `content.transaction_embedded_links`
--- role_content is derived from the publishing API database, which isn't updated
--- until after this query is run, because the database backup file isn't
--- available until too late in the day, so this is always a day behind the other
--- tables.
-UNION ALL
-SELECT * FROM `content.role_embedded_links`
-;
-
-EXPORT DATA OPTIONS(
-  uri='gs://$PROJECT_ID-data-processed/bigquery/embedded_links_*.csv.gz',
-  format='CSV',
-  compression='GZIP',
-  overwrite=true
-  ) AS
-SELECT * FROM content.embedded_links
-;
-
-CREATE OR REPLACE TABLE `content.embedded_links`AS
+TRUNCATE TABLE `content.embedded_links`;
+INSERT INTO `content.embedded_links`
 SELECT * FROM `content.body_embedded_links`
 UNION ALL
 SELECT * FROM `content.body_content_embedded_links`


### PR DESCRIPTION
Fixes #430 and corrects remaining problems left by #494 which were that,
although the table was being terraformed, it was also being deleted
nightly, so that `terraform apply` always offered to reset the table
metadata.
