### PR TITLE
Fix wrong content for guide pages without slug

### DIFF
--- a/src/mongodb/bigquery/content.sql
+++ b/src/mongodb/bigquery/content.sql
@@ -16,7 +16,7 @@ SELECT
   base_path as url,
   * EXCEPT(url, base_path, part_index)
 FROM `content.parts_content`
-WHERE part_index = 1
+WHERE part_index = 0
 UNION ALL
 SELECT * FROM `content.place_content`
 UNION ALL


### PR DESCRIPTION
Guide pages have several parts, each with their own slug.  A URL without
any slug uses the content of the first part.  We were inferring the
wrong content because of an off-by-one error.

You can confirm that parts are zero-indexed by the following query.

```sql
SELECT
  base_path,
  MIN(part_index) AS first_index
FROM
  content.parts_content
GROUP BY
  base_path
HAVING
  first_index > 0;
```
