### PR TITLE
Allow a test google account through IAP

### DIFF
--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -13,4 +13,5 @@ oauth_callback_url                  = "https://govgraphsearch.dev/auth/gds/callb
 enable_redis_session_store_instance = false
 govgraphsearch_iap_members = [
   "group:data-products@digital.cabinet-office.gov.uk",
+  "user:govsearchtest@gmail.com",
 ]


### PR DESCRIPTION
This allows a Google account that we created for user research
participants to access the app in the staging environment.
