### PR TITLE
Add GTM variables to the govsearch environment

### DIFF
--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -10,6 +10,8 @@ signon_url            = "https://signon.integration.publishing.service.gov.uk"
 oauth_auth_url        = "https://signon.integration.publishing.service.gov.uk/oauth/authorize"
 oauth_token_url       = "https://signon.integration.publishing.service.gov.uk/oauth/access_token"
 oauth_callback_url    = "https://govgraphsearchdev.dev/auth/gds/callback"
+GTM_AUTH              = "PLACEHOLDER"
+GTM_ID                = "PLACEHOLDER"
 govgraphsearch_iap_members = [
   "allUsers"
 ]

--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -216,6 +216,14 @@ resource "google_cloud_run_service" "govgraphsearch" {
       containers {
         image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {
+          name  = "GTM_ID"
+          value = var.gtm_id
+        }
+        env {
+          name  = "GTM_AUTH"
+          value = var.gtm_auth
+        }
+        env {
           name  = "REDIS_HOST"
           value = try(google_redis_instance.session_store[0].host, "")
         }

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -112,6 +112,14 @@ variable "enable_redis_session_store_instance" {
   type = string
 }
 
+variable "gtm_id" {
+  type = string
+}
+
+variable "gtm_auth" {
+  type = string
+}
+
 terraform {
   required_providers {
     google = {

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -11,6 +11,8 @@ oauth_auth_url                      = "https://signon.publishing.service.gov.uk/
 oauth_token_url                     = "https://signon.publishing.service.gov.uk/oauth/access_token"
 oauth_callback_url                  = "https://govgraphsearch.dev/auth/gds/callback"
 enable_redis_session_store_instance = false
+GTM_AUTH                            = "PLACEHOLDER"
+GTM_ID                              = "PLACEHOLDER"
 govgraphsearch_iap_members = [
   "group:data-products@digital.cabinet-office.gov.uk",
 ]

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -216,6 +216,14 @@ resource "google_cloud_run_service" "govgraphsearch" {
       containers {
         image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {
+          name  = "GTM_ID"
+          value = var.gtm_id
+        }
+        env {
+          name  = "GTM_AUTH"
+          value = var.gtm_auth
+        }
+        env {
           name  = "REDIS_HOST"
           value = try(google_redis_instance.session_store[0].host, "")
         }

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -112,6 +112,14 @@ variable "enable_redis_session_store_instance" {
   type = string
 }
 
+variable "gtm_id" {
+  type = string
+}
+
+variable "gtm_auth" {
+  type = string
+}
+
 terraform {
   required_providers {
     google = {

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -11,6 +11,8 @@ oauth_auth_url                      = "https://signon.publishing.service.gov.uk/
 oauth_token_url                     = "https://signon.publishing.service.gov.uk/oauth/access_token"
 oauth_callback_url                  = "https://govgraphsearch.dev/auth/gds/callback"
 enable_redis_session_store_instance = false
+GTM_ID                              = "GTM-5LTHPJZ"
+GTM_AUTH                            = "aWEg5ABBTyIPcsSg1cJWxg"
 govgraphsearch_iap_members = [
   "domain:digital.cabinet-office.gov.uk",
 

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -216,6 +216,14 @@ resource "google_cloud_run_service" "govgraphsearch" {
       containers {
         image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {
+          name  = "GTM_ID"
+          value = var.gtm_id
+        }
+        env {
+          name  = "GTM_AUTH"
+          value = var.gtm_auth
+        }
+        env {
           name  = "REDIS_HOST"
           value = try(google_redis_instance.session_store[0].host, "")
         }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -112,6 +112,14 @@ variable "enable_redis_session_store_instance" {
   type = string
 }
 
+variable "gtm_id" {
+  type = string
+}
+
+variable "gtm_auth" {
+  type = string
+}
+
 terraform {
   required_providers {
     google = {


### PR DESCRIPTION
For GA4 Google Analytics

These aren't secret.  They're shown in plain text in the browser "view
source".
