### PR TITLE
Include expanded links

### DIFF
--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -41,19 +41,12 @@ all_links AS (
   FROM
     content.embedded_links
 ), 
-unique_links AS (
-  SELECT DISTINCT 
-    url, 
-    link_url
-  FROM 
-    all_links
-), 
 links AS (
   SELECT
     url, 
-    ARRAY_AGG(link_url) as link_url
+    ARRAY_AGG(DISTINCT link_url) as link_url
   FROM 
-    unique_links
+    all_links
   GROUP BY
     url
 ),

--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -41,12 +41,21 @@ all_links AS (
   FROM
     content.embedded_links
 ), 
-links AS (
+unique_links AS (
   SELECT DISTINCT 
     url, 
-    link_url 
+    link_url
   FROM 
     all_links
+), 
+links AS (
+  SELECT
+    url, 
+    ARRAY_AGG(link_url) as link_url
+  FROM 
+    unique_links
+  GROUP BY
+    url
 ),
 entities AS (
   WITH page_type_count AS (

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -41,19 +41,12 @@ all_links AS (
   FROM
     content.embedded_links
 ), 
-unique_links AS (
-  SELECT DISTINCT 
-    url, 
-    link_url
-  FROM 
-    all_links
-), 
 links AS (
   SELECT
     url, 
-    ARRAY_AGG(link_url) as link_url
+    ARRAY_AGG(DISTINCT link_url) as link_url
   FROM 
-    unique_links
+    all_links
   GROUP BY
     url
 ),

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -41,12 +41,21 @@ all_links AS (
   FROM
     content.embedded_links
 ), 
-links AS (
+unique_links AS (
   SELECT DISTINCT 
     url, 
-    link_url 
+    link_url
   FROM 
     all_links
+), 
+links AS (
+  SELECT
+    url, 
+    ARRAY_AGG(link_url) as link_url
+  FROM 
+    unique_links
+  GROUP BY
+    url
 ),
 entities AS (
   WITH page_type_count AS (

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -41,19 +41,12 @@ all_links AS (
   FROM
     content.embedded_links
 ), 
-unique_links AS (
-  SELECT DISTINCT 
-    url, 
-    link_url
-  FROM 
-    all_links
-), 
 links AS (
   SELECT
     url, 
-    ARRAY_AGG(link_url) as link_url
+    ARRAY_AGG(DISTINCT link_url) as link_url
   FROM 
-    unique_links
+    all_links
   GROUP BY
     url
 ),

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -41,12 +41,21 @@ all_links AS (
   FROM
     content.embedded_links
 ), 
-links AS (
+unique_links AS (
   SELECT DISTINCT 
     url, 
-    link_url 
+    link_url
   FROM 
     all_links
+), 
+links AS (
+  SELECT
+    url, 
+    ARRAY_AGG(link_url) as link_url
+  FROM 
+    unique_links
+  GROUP BY
+    url
 ),
 entities AS (
   WITH page_type_count AS (


### PR DESCRIPTION
Include both embedded and expanded links in search.

This is achieved by:

1. Fetching both embedded and expanded links into a single table;
2. Deduplicating the table, and
3. Aggregating the link target values into a list, grouped by source url