### PR TITLE
Fix SQL bank holiday queries

### DIFF
--- a/terraform-dev/queries/load_bank_holiday_titles.sql
+++ b/terraform-dev/queries/load_bank_holiday_titles.sql
@@ -1,7 +1,7 @@
 TRUNCATE TABLE content.bank_holiday_title;  
 INSERT INTO content.bank_holiday_title  
 SELECT DISTINCT  
-  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '', '-'), '/', '_') AS url,  
+  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '+', '-'), '/', '_') AS url,  
   events.title  
 FROM content.bank_holiday_raw,  
   UNNEST(body) AS body,  

--- a/terraform-dev/queries/load_bank_holiday_url.sql
+++ b/terraform-dev/queries/load_bank_holiday_url.sql
@@ -1,7 +1,7 @@
 TRUNCATE TABLE content.bank_holiday_url;  
 INSERT INTO content.bank_holiday_url  
 SELECT DISTINCT  
-  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '', '-'), '/', '_') AS url  
+  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '+', '-'), '/', '_') AS url  
 FROM content.bank_holiday_raw,  
   UNNEST(body) AS body,  
   UNNEST(events) AS events  

--- a/terraform-staging/queries/load_bank_holiday_titles.sql
+++ b/terraform-staging/queries/load_bank_holiday_titles.sql
@@ -1,7 +1,7 @@
 TRUNCATE TABLE content.bank_holiday_title;  
 INSERT INTO content.bank_holiday_title  
 SELECT DISTINCT  
-  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '', '-'), '/', '_') AS url,  
+  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '+', '-'), '/', '_') AS url,  
   events.title  
 FROM content.bank_holiday_raw,  
   UNNEST(body) AS body,  

--- a/terraform-staging/queries/load_bank_holiday_url.sql
+++ b/terraform-staging/queries/load_bank_holiday_url.sql
@@ -1,7 +1,7 @@
 TRUNCATE TABLE content.bank_holiday_url;  
 INSERT INTO content.bank_holiday_url  
 SELECT DISTINCT  
-  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '', '-'), '/', '_') AS url  
+  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '+', '-'), '/', '_') AS url  
 FROM content.bank_holiday_raw,  
   UNNEST(body) AS body,  
   UNNEST(events) AS events  

--- a/terraform/queries/load_bank_holiday_titles.sql
+++ b/terraform/queries/load_bank_holiday_titles.sql
@@ -1,7 +1,7 @@
 TRUNCATE TABLE content.bank_holiday_title;  
 INSERT INTO content.bank_holiday_title  
 SELECT DISTINCT  
-  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '', '-'), '/', '_') AS url,  
+  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '+', '-'), '/', '_') AS url,  
   events.title  
 FROM content.bank_holiday_raw,  
   UNNEST(body) AS body,  

--- a/terraform/queries/load_bank_holiday_url.sql
+++ b/terraform/queries/load_bank_holiday_url.sql
@@ -1,7 +1,7 @@
 TRUNCATE TABLE content.bank_holiday_url;  
 INSERT INTO content.bank_holiday_url  
 SELECT DISTINCT  
-  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '', '-'), '/', '_') AS url  
+  'https://www.gov.uk/' || REPLACE(REPLACE(TO_BASE64(SHA256(events.title)), '+', '-'), '/', '_') AS url  
 FROM content.bank_holiday_raw,  
   UNNEST(body) AS body,  
   UNNEST(events) AS events  


### PR DESCRIPTION
SQL was missing a "+" sign in replace statements due to a lazy "find/replace" operation on a previous PR.

The "+" symbol has been reinstated.