### PR TITLE
[DO NOT MERGE YET] Make search.organisation distinct on name

### DIFF
--- a/terraform-dev/bigquery/organisation.sql
+++ b/terraform-dev/bigquery/organisation.sql
@@ -4,7 +4,7 @@ WITH
 parent_organisation AS (
   SELECT
     has_child_organisation.child_organisation_url AS url,
-    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentName,
+    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentOrgNames,
   FROM graph.has_child_organisation
   LEFT JOIN graph.organisation AS parent_organisation ON parent_organisation.url = has_child_organisation.url
   GROUP BY has_child_organisation.child_organisation_url
@@ -53,7 +53,7 @@ supersedes AS (
 SELECT
   organisation.title AS name,
   has_homepage.homepage_url AS homepage,
-  parent_organisation.parentName,
+  parent_organisation.parentOrgNames,
   child_organisations.childOrgNames,
   organisation_roles.personRoleNames,
   superseded_by.supersededBy,

--- a/terraform-dev/bigquery/organisation.sql
+++ b/terraform-dev/bigquery/organisation.sql
@@ -4,9 +4,10 @@ WITH
 parent_organisation AS (
   SELECT
     has_child_organisation.child_organisation_url AS url,
-    parent_organisation.title AS parentName,
+    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentName,
   FROM graph.has_child_organisation
   LEFT JOIN graph.organisation AS parent_organisation ON parent_organisation.url = has_child_organisation.url
+  GROUP BY has_child_organisation.child_organisation_url
 ),
 child_organisations AS (
   SELECT

--- a/terraform-dev/schemas/search/organisation.json
+++ b/terraform-dev/schemas/search/organisation.json
@@ -10,7 +10,8 @@
         "description": "URL of a page on GOV.UK about the organisation"
     },
     {
-        "name": "parentName",
+        "mode": "REPEATED",
+        "name": "parentOrgNames",
         "type": "STRING",
         "description": "Name of the parent organisation of this organisation"
     },

--- a/terraform-staging/bigquery/organisation.sql
+++ b/terraform-staging/bigquery/organisation.sql
@@ -4,7 +4,7 @@ WITH
 parent_organisation AS (
   SELECT
     has_child_organisation.child_organisation_url AS url,
-    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentName,
+    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentOrgNames,
   FROM graph.has_child_organisation
   LEFT JOIN graph.organisation AS parent_organisation ON parent_organisation.url = has_child_organisation.url
   GROUP BY has_child_organisation.child_organisation_url
@@ -53,7 +53,7 @@ supersedes AS (
 SELECT
   organisation.title AS name,
   has_homepage.homepage_url AS homepage,
-  parent_organisation.parentName,
+  parent_organisation.parentOrgNames,
   child_organisations.childOrgNames,
   organisation_roles.personRoleNames,
   superseded_by.supersededBy,

--- a/terraform-staging/bigquery/organisation.sql
+++ b/terraform-staging/bigquery/organisation.sql
@@ -4,9 +4,10 @@ WITH
 parent_organisation AS (
   SELECT
     has_child_organisation.child_organisation_url AS url,
-    parent_organisation.title AS parentName,
+    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentName,
   FROM graph.has_child_organisation
   LEFT JOIN graph.organisation AS parent_organisation ON parent_organisation.url = has_child_organisation.url
+  GROUP BY has_child_organisation.child_organisation_url
 ),
 child_organisations AS (
   SELECT

--- a/terraform-staging/schemas/search/organisation.json
+++ b/terraform-staging/schemas/search/organisation.json
@@ -10,7 +10,8 @@
         "description": "URL of a page on GOV.UK about the organisation"
     },
     {
-        "name": "parentName",
+        "mode": "REPEATED",
+        "name": "parentOrgNames",
         "type": "STRING",
         "description": "Name of the parent organisation of this organisation"
     },

--- a/terraform/bigquery/organisation.sql
+++ b/terraform/bigquery/organisation.sql
@@ -4,7 +4,7 @@ WITH
 parent_organisation AS (
   SELECT
     has_child_organisation.child_organisation_url AS url,
-    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentName,
+    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentOrgNames,
   FROM graph.has_child_organisation
   LEFT JOIN graph.organisation AS parent_organisation ON parent_organisation.url = has_child_organisation.url
   GROUP BY has_child_organisation.child_organisation_url
@@ -53,7 +53,7 @@ supersedes AS (
 SELECT
   organisation.title AS name,
   has_homepage.homepage_url AS homepage,
-  parent_organisation.parentName,
+  parent_organisation.parentOrgNames,
   child_organisations.childOrgNames,
   organisation_roles.personRoleNames,
   superseded_by.supersededBy,

--- a/terraform/bigquery/organisation.sql
+++ b/terraform/bigquery/organisation.sql
@@ -4,9 +4,10 @@ WITH
 parent_organisation AS (
   SELECT
     has_child_organisation.child_organisation_url AS url,
-    parent_organisation.title AS parentName,
+    ARRAY_AGG(DISTINCT parent_organisation.title) AS parentName,
   FROM graph.has_child_organisation
   LEFT JOIN graph.organisation AS parent_organisation ON parent_organisation.url = has_child_organisation.url
+  GROUP BY has_child_organisation.child_organisation_url
 ),
 child_organisations AS (
   SELECT

--- a/terraform/schemas/search/organisation.json
+++ b/terraform/schemas/search/organisation.json
@@ -10,7 +10,9 @@
         "description": "URL of a page on GOV.UK about the organisation"
     },
     {
-        "name": "parentName",
+
+        "mode": "REPEATED",
+        "name": "parentOrgNames",
         "type": "STRING",
         "description": "Name of the parent organisation of this organisation"
     },

--- a/terraform/schemas/search/organisation.json
+++ b/terraform/schemas/search/organisation.json
@@ -10,7 +10,6 @@
         "description": "URL of a page on GOV.UK about the organisation"
     },
     {
-
         "mode": "REPEATED",
         "name": "parentOrgNames",
         "type": "STRING",


### PR DESCRIPTION
This PR addresses an issue whereby some records are duplicated in the `search.organisations` table because a single organisation may have multiple parents.

The PR implements a fix which consolidates parent names into a list to ensure that each organisation record remains distinct in the table.

Specifically, the following changes have been made:

 - SQL statements used to populate the `parentName` column has been amended to consolidate multiple values into a list
 - Name of parent column has been changed from `parentName` to `parentNames` (in both the SQL and the `search.organisations` schema).

**Note** that this change will have the following impact on the application front-end: 

 - `Organisation` type as described in [search-api-types](https://github.com/alphagov/govuk-knowledge-graph-search/blob/555aebbc7cd3b21d19378292e8f30a237570850f/src/common/types/search-api-types.ts#L72) will need to be updated to reflect: 
     - Change of column name from `parentName` to `parentNames`;
     - Change of type from `string` to a list of strings (`string[]`)
 - The [front-end viewbox](https://github.com/alphagov/govuk-knowledge-graph-search/blob/555aebbc7cd3b21d19378292e8f30a237570850f/src/frontend/view/view-metabox.ts#L215) code should be updated to allow multiple parent name values to be displayed.

Note that the front-end viewbox change would align it with [similar logic](https://github.com/alphagov/govuk-knowledge-graph-search/blob/555aebbc7cd3b21d19378292e8f30a237570850f/src/frontend/view/view-metabox.ts#L233) used to display org. children.