### PR TITLE
Add content of some schemas

### DIFF
--- a/src/mongodb/Makefile
+++ b/src/mongodb/Makefile
@@ -56,7 +56,7 @@ clean.mongodb:
 clean.gz:
 	rm data/*
 
-# Create an index on the document_type field.  The query doesn't create a file,
+# Create indexes on certain fields.  The query doesn't create a file,
 # so a dummy target file is created by the `touch` command, so that subsequent
 # steps know that this step has been executed.  A similar trick is used in many
 # places in this Makefile.
@@ -93,6 +93,9 @@ data/acronym.csv.gz: temp/define_url.mongodb
 
 data/document_type.csv.gz: temp/define_url.mongodb
 	source functions.sh; source sh/document_type.sh
+
+data/schema_name.csv.gz: temp/define_url.mongodb
+	source functions.sh; source sh/schema_name.sh
 
 data/locale.csv.gz: temp/define_url.mongodb
 	source functions.sh; source sh/locale.sh
@@ -350,6 +353,7 @@ data/organisation_govuk_status.csv.gz: temp/organisation_govuk_status.mongodb
 temp/page.bigquery: \
 	data/url.csv.gz \
 	data/document_type.csv.gz \
+	data/schema_name.csv.gz \
 	data/phase.csv.gz \
 	data/content_id.csv.gz \
 	data/analytics_identifier.csv.gz \

--- a/src/mongodb/bigquery/page.sql
+++ b/src/mongodb/bigquery/page.sql
@@ -4,6 +4,7 @@ INSERT INTO graph.page
 SELECT
   u.url,
   document_type.document_type,
+  schema_name.schema_name,
   phase.phase,
   content_id.content_id,
   analytics_identifier.analytics_identifier,
@@ -25,6 +26,7 @@ SELECT
   page_views.number_of_views AS page_views
 FROM content.url AS u
 LEFT JOIN content.document_type USING (url)
+LEFT JOIN content.schema_name USING (url)
 LEFT JOIN content.phase USING (url)
 LEFT JOIN content.content_id USING (url)
 LEFT JOIN content.analytics_identifier USING (url)

--- a/src/mongodb/js/body.js
+++ b/src/mongodb/js/body.js
@@ -19,8 +19,11 @@ db.content_items.aggregate([
     "speech",
     "statistical_data_set",
     "take_part",
+    "topical_event",
     "topical_event_about_page",
-    "working_group"
+    "working_group",
+    "worldwide_corporate_information_page",
+    "worldwide_organisation",
   ] } } },
   { $project: { url: true, html: "$details.body" } },
   { $match: { "html": { "$exists": true, $ne: null } } },

--- a/src/mongodb/js/index.js
+++ b/src/mongodb/js/index.js
@@ -1,1 +1,2 @@
 db.content_items.createIndex({ "document_type": 1 })
+db.content_items.createIndex({ "schema_name": 1 })

--- a/src/mongodb/js/parts_content.js
+++ b/src/mongodb/js/parts_content.js
@@ -1,6 +1,9 @@
 // html content of parts of "guide" and "travel_advice"
 db.content_items.aggregate([
-  { $match: { "details.parts": { $exists: true } } },
+  { $match: { "schema_name": { $in: [
+    "guide",
+    "travel_advice"
+  ] } } },
   { $project: {
     "_id": false,
     "base_path": "$url",

--- a/src/mongodb/js/place_content.js
+++ b/src/mongodb/js/place_content.js
@@ -1,7 +1,9 @@
 // HTML content of "place", following the schema:
 // https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/place/frontend/schema.json
 db.content_items.aggregate([
-  { $match: { "document_type": "place" } },
+  { $match: { "schema_name": { $in: [
+    "place"
+  ] } } },
   { $project: {
     "url": true,
     "details.introduction": true,

--- a/src/mongodb/js/step_by_step_content.js
+++ b/src/mongodb/js/step_by_step_content.js
@@ -1,7 +1,9 @@
 // All step-by-step content as a string, following the schema:
 // https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/step_by_step_nav/frontend/schema.json
 db.content_items.aggregate([
-  { $match: { "document_type": "step_by_step_nav" } },
+  { $match: { "schema_name": { $in: [
+    "step_by_step_nav"
+  ] } } },
   { $project: {
     url: true,
     introduction: { $filter: { // only the govspeak version

--- a/src/mongodb/js/transaction_content.js
+++ b/src/mongodb/js/transaction_content.js
@@ -1,7 +1,9 @@
 // HTML content of "transaction", following the schema:
 // https://github.com/alphagov/govuk-content-schemas/blob/main/dist/formats/transaction/frontend/schema.json
 db.content_items.aggregate([
-  { $match: { "document_type": "transaction" } },
+  { $match: { "schema_name": { $in: [
+    "transaction"
+  ] } } },
   { $project: {
     "url": true,
     "details.introductory_paragraph": true,

--- a/src/mongodb/sh/schema_name.sh
+++ b/src/mongodb/sh/schema_name.sh
@@ -1,0 +1,8 @@
+FILE_NAME=schema_name
+
+query_mongo \
+  fields=url,schema_name \
+  query='{ "schema_name": { "$exists": true } }' \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/postgres/Makefile
+++ b/src/postgres/Makefile
@@ -80,6 +80,10 @@ data/role_document_type.csv.gz: temp/roles.postgres
 	source functions.sh; source sh/document_type.sh
 	touch $@
 
+data/role_schema_name.csv.gz: temp/roles.postgres
+	source functions.sh; source sh/schema_name.sh
+	touch $@
+
 data/role_publishing_app.csv.gz: temp/roles.postgres
 	source functions.sh; source sh/publishing_app.sh
 	touch $@
@@ -192,6 +196,7 @@ data/role_role_organisation.csv.gz: temp/roles.postgres
 temp/role.bigquery: \
 data/role_role_url.csv.gz \
 data/role_document_type.csv.gz \
+data/role_schema_name.csv.gz \
 data/role_phase.csv.gz \
 data/role_content_id.csv.gz \
 data/role_locale.csv.gz \

--- a/src/postgres/bigquery/role.sql
+++ b/src/postgres/bigquery/role.sql
@@ -4,6 +4,7 @@ INSERT INTO graph.role
 SELECT
   role_url.url,
   role_document_type.document_type,
+  role_schema_name.schema_name,
   role_phase.phase,
   role_content_id.content_id,
   role_locale.locale,
@@ -16,6 +17,7 @@ SELECT
   role_content.text
 FROM content.role_url
 LEFT JOIN content.role_document_type USING (url)
+LEFT JOIN content.role_schema_name USING (url)
 LEFT JOIN content.role_phase USING (url)
 LEFT JOIN content.role_content_id USING (url)
 LEFT JOIN content.role_locale USING (url)

--- a/src/postgres/sh/schema_name.sh
+++ b/src/postgres/sh/schema_name.sh
@@ -1,0 +1,8 @@
+FILE_NAME=role_schema_name
+
+# The document_type of every role and role appointment
+query_postgres \
+  file=sql/schema_name.sql \
+| upload file_name=$FILE_NAME
+
+send_to_bigquery file_name=$FILE_NAME

--- a/src/postgres/sql/schema_name.sql
+++ b/src/postgres/sql/schema_name.sql
@@ -1,0 +1,6 @@
+SELECT
+  url,
+  schema_name
+FROM roles
+WHERE schema_name IS NOT NULL
+;

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -100,6 +100,14 @@ resource "google_bigquery_table" "document_type" {
   schema        = file("schemas/content/document-type.json")
 }
 
+resource "google_bigquery_table" "schema_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "schema_name"
+  friendly_name = "Schema name"
+  description   = "How the data of a content item is arranged"
+  schema        = file("schemas/content/schema-name.json")
+}
+
 resource "google_bigquery_table" "locale" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "locale"
@@ -474,6 +482,14 @@ resource "google_bigquery_table" "role_document_type" {
   friendly_name = "Role document type"
   description   = "Document type of a role on GOV.UK"
   schema        = file("schemas/content/role-document-type.json")
+}
+
+resource "google_bigquery_table" "role_schema_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "role_schema_name"
+  friendly_name = "Role document type"
+  description   = "How the data of a role is arranged"
+  schema        = file("schemas/content/role-schema-name.json")
 }
 
 resource "google_bigquery_table" "role_attends_cabinet_type" {

--- a/terraform-dev/schemas/content/role-schema-name.json
+++ b/terraform-dev/schemas/content/role-schema-name.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a role on GOV.UK"
+  },
+  {
+    "name": "schema_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "How the data of a content item is arranged"
+  }
+]

--- a/terraform-dev/schemas/content/schema-name.json
+++ b/terraform-dev/schemas/content/schema-name.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "schema_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "How the data of a content item is arranged"
+  }
+]

--- a/terraform-dev/schemas/graph/page.json
+++ b/terraform-dev/schemas/graph/page.json
@@ -13,6 +13,12 @@
     },
     {
         "mode": "NULLABLE",
+        "name": "schema_name",
+        "type": "STRING",
+        "description": "How the data of a content item is arranged"
+    },
+    {
+        "mode": "NULLABLE",
         "name": "phase",
         "type": "STRING",
         "description": "The service design phase of a page - https://www.gov.uk/service-manual/phases"

--- a/terraform-dev/schemas/graph/part.json
+++ b/terraform-dev/schemas/graph/part.json
@@ -13,6 +13,12 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING",
+    "description": "How the data of a content item is arranged"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "phase",
     "type": "STRING",
     "description": "The service design phase of a page - https://www.gov.uk/service-manual/phases"

--- a/terraform-dev/schemas/graph/role.json
+++ b/terraform-dev/schemas/graph/role.json
@@ -12,6 +12,12 @@
     "description": "The kind of role"
   },
   {
+      "mode": "NULLABLE",
+      "name": "schema_name",
+      "type": "STRING",
+      "description": "How the data of a content item is arranged"
+  },
+  {
     "name": "phase",
     "type": "STRING",
     "mode": "NULLABLE",

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -100,6 +100,14 @@ resource "google_bigquery_table" "document_type" {
   schema        = file("schemas/content/document-type.json")
 }
 
+resource "google_bigquery_table" "schema_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "schema_name"
+  friendly_name = "Schema name"
+  description   = "How the data of a content item is arranged"
+  schema        = file("schemas/content/schema-name.json")
+}
+
 resource "google_bigquery_table" "locale" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "locale"
@@ -474,6 +482,14 @@ resource "google_bigquery_table" "role_document_type" {
   friendly_name = "Role document type"
   description   = "Document type of a role on GOV.UK"
   schema        = file("schemas/content/role-document-type.json")
+}
+
+resource "google_bigquery_table" "role_schema_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "role_schema_name"
+  friendly_name = "Role document type"
+  description   = "How the data of a role is arranged"
+  schema        = file("schemas/content/role-schema-name.json")
 }
 
 resource "google_bigquery_table" "role_attends_cabinet_type" {

--- a/terraform-staging/schemas/content/role-schema-name.json
+++ b/terraform-staging/schemas/content/role-schema-name.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a role on GOV.UK"
+  },
+  {
+    "name": "schema_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "How the data of a content item is arranged"
+  }
+]

--- a/terraform-staging/schemas/content/schema-name.json
+++ b/terraform-staging/schemas/content/schema-name.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "schema_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "How the data of a content item is arranged"
+  }
+]

--- a/terraform-staging/schemas/graph/page.json
+++ b/terraform-staging/schemas/graph/page.json
@@ -13,6 +13,12 @@
     },
     {
         "mode": "NULLABLE",
+        "name": "schema_name",
+        "type": "STRING",
+        "description": "How the data of a content item is arranged"
+    },
+    {
+        "mode": "NULLABLE",
         "name": "phase",
         "type": "STRING",
         "description": "The service design phase of a page - https://www.gov.uk/service-manual/phases"

--- a/terraform-staging/schemas/graph/part.json
+++ b/terraform-staging/schemas/graph/part.json
@@ -13,6 +13,12 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING",
+    "description": "How the data of a content item is arranged"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "phase",
     "type": "STRING",
     "description": "The service design phase of a page - https://www.gov.uk/service-manual/phases"

--- a/terraform-staging/schemas/graph/role.json
+++ b/terraform-staging/schemas/graph/role.json
@@ -12,6 +12,12 @@
     "description": "The kind of role"
   },
   {
+      "mode": "NULLABLE",
+      "name": "schema_name",
+      "type": "STRING",
+      "description": "How the data of a content item is arranged"
+  },
+  {
     "name": "phase",
     "type": "STRING",
     "mode": "NULLABLE",

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -100,6 +100,14 @@ resource "google_bigquery_table" "document_type" {
   schema        = file("schemas/content/document-type.json")
 }
 
+resource "google_bigquery_table" "schema_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "schema_name"
+  friendly_name = "Schema name"
+  description   = "How the data of a content item is arranged"
+  schema        = file("schemas/content/schema-name.json")
+}
+
 resource "google_bigquery_table" "locale" {
   dataset_id    = google_bigquery_dataset.content.dataset_id
   table_id      = "locale"
@@ -474,6 +482,14 @@ resource "google_bigquery_table" "role_document_type" {
   friendly_name = "Role document type"
   description   = "Document type of a role on GOV.UK"
   schema        = file("schemas/content/role-document-type.json")
+}
+
+resource "google_bigquery_table" "role_schema_name" {
+  dataset_id    = google_bigquery_dataset.content.dataset_id
+  table_id      = "role_schema_name"
+  friendly_name = "Role document type"
+  description   = "How the data of a role is arranged"
+  schema        = file("schemas/content/role-schema-name.json")
 }
 
 resource "google_bigquery_table" "role_attends_cabinet_type" {

--- a/terraform/schemas/content/role-schema-name.json
+++ b/terraform/schemas/content/role-schema-name.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a role on GOV.UK"
+  },
+  {
+    "name": "schema_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "How the data of a content item is arranged"
+  }
+]

--- a/terraform/schemas/content/schema-name.json
+++ b/terraform/schemas/content/schema-name.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a piece of static content on the www.gov.uk domain"
+  },
+  {
+    "name": "schema_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "How the data of a content item is arranged"
+  }
+]

--- a/terraform/schemas/graph/page.json
+++ b/terraform/schemas/graph/page.json
@@ -13,6 +13,12 @@
     },
     {
         "mode": "NULLABLE",
+        "name": "schema_name",
+        "type": "STRING",
+        "description": "How the data of a content item is arranged"
+    },
+    {
+        "mode": "NULLABLE",
         "name": "phase",
         "type": "STRING",
         "description": "The service design phase of a page - https://www.gov.uk/service-manual/phases"

--- a/terraform/schemas/graph/part.json
+++ b/terraform/schemas/graph/part.json
@@ -13,6 +13,12 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING",
+    "description": "How the data of a content item is arranged"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "phase",
     "type": "STRING",
     "description": "The service design phase of a page - https://www.gov.uk/service-manual/phases"

--- a/terraform/schemas/graph/role.json
+++ b/terraform/schemas/graph/role.json
@@ -12,6 +12,12 @@
     "description": "The kind of role"
   },
   {
+      "mode": "NULLABLE",
+      "name": "schema_name",
+      "type": "STRING",
+      "description": "How the data of a content item is arranged"
+  },
+  {
     "name": "phase",
     "type": "STRING",
     "mode": "NULLABLE",


### PR DESCRIPTION
This adds the content of some schemas that either didn't previously exist in the
Content Store, or we had missed them.

In order to know which schemas we are missing, this PR also extracts the schema
name from the Content Store and Publishing API databases.

Queries that had been specified by `document_type` are now specified by
`schema_name`, because it's the schema, not the document type, that determines
where in the JSON the content is.

- Extract `schema_name` from Mongo and Postgres
- Extract body content by schema not document type
- Extract the content of some easy schemas

This is the first part of #528.  Doing this part separately means that we can
deploy it soon, while we work out how to do the harder parts.

## How to review

This has been deployed in the `dev` environment, so the data can be checked to ensure that:

- Documents of schemas that were previously supported still have content.  
- Documents of schemas that are introduced by this PR have content.
- The new tables `content.schema_name` and `content.role_schema_name` exist and contain data.
- The tables `graph.role`, `graph.part` and `graph.page` each have a column `schema_name`, containing data.