### PR TITLE
[DO NOT MERGE YET] Links by type

### DIFF
--- a/terraform-dev/schemas/search/page.json
+++ b/terraform-dev/schemas/search/page.json
@@ -98,8 +98,20 @@
   {
     "mode": "REPEATED",
     "name": "hyperlinks",
-    "type": "STRING",
-    "description": "Array of hyperlinks from the body of the page"
+    "type": "RECORD",
+    "description": "Array of hyperlinks from the body of the page", 
+    "fields": [
+      {
+        "name": "link_url", 
+        "type": "STRING", 
+        "description": "Link URL"
+      }, 
+      {
+        "name": "link_type", 
+        "type": "STRING", 
+        "description": "Type of link"
+      }
+    ]
   },
   {
     "mode": "REPEATED",

--- a/terraform-staging/schemas/search/page.json
+++ b/terraform-staging/schemas/search/page.json
@@ -98,8 +98,20 @@
   {
     "mode": "REPEATED",
     "name": "hyperlinks",
-    "type": "STRING",
-    "description": "Array of hyperlinks from the body of the page"
+    "type": "RECORD",
+    "description": "Array of hyperlinks from the body of the page", 
+    "fields": [
+      {
+        "name": "link_url", 
+        "type": "STRING", 
+        "description": "Link URL"
+      }, 
+      {
+        "name": "link_type", 
+        "type": "STRING", 
+        "description": "Type of link"
+      }
+    ]
   },
   {
     "mode": "REPEATED",

--- a/terraform/schemas/search/page.json
+++ b/terraform/schemas/search/page.json
@@ -98,8 +98,20 @@
   {
     "mode": "REPEATED",
     "name": "hyperlinks",
-    "type": "STRING",
-    "description": "Array of hyperlinks from the body of the page"
+    "type": "RECORD",
+    "description": "Array of hyperlinks from the body of the page", 
+    "fields": [
+      {
+        "name": "link_url", 
+        "type": "STRING", 
+        "description": "Link URL"
+      }, 
+      {
+        "name": "link_type", 
+        "type": "STRING", 
+        "description": "Type of link"
+      }
+    ]
   },
   {
     "mode": "REPEATED",


### PR DESCRIPTION
Purpose of this PR is to introduce changes which update the `search.page` BigQuery table to include `link_type` (e.g. 'embedded') in addition to `link_url`.

`search.page` currently includes a `hyperlinks` field which contains an array of URL strings for hyperlinks in a given page.

This change updates the type of the `hyperlinks` column such that it is now an array of records, which contains both of: 

 - The link URL (`link_url`); and
 - The link type (`link_type`).

Specifically, the following changes have been made: 

 - **Updated table schema**: the schema for `search.page` has been updated to reflect that the `hyperlinks` field will now contain record-type values instead of strings
 - **Updated SQL**: SQL used to populate the `search.page` table has been updated to populate the `link_type` field in the `hyperlinks` column.

This change has been tested in staging and is producing valid table outputs without error.

**This change will necessitate front-end change to enable display of link type.**

At a minimum, the following files in the GovSearch repo will need attention: 

 - [buildSqlQuery.ts](https://github.com/alphagov/govuk-knowledge-graph-search/blob/c5ae86a16a27fecdae96112c0504947028014ae9/src/backend/bigquery/buildSqlQuery.ts#L85)
 - [buildSqlQuery.test.ts](https://github.com/alphagov/govuk-knowledge-graph-search/blob/c5ae86a16a27fecdae96112c0504947028014ae9/src/backend/bigquery/buildSqlQuery.test.ts#L197)