### PR TITLE
Add link text to the `hyperlinks` struct

### DIFF
--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -32,21 +32,24 @@ all_links AS (
   SELECT DISTINCT
     link_type,
     from_url as url, 
-    to_url as link_url
+    to_url as link_url,
+    CAST(NULL AS STRING) as link_text
   FROM
     content.expanded_links
   UNION ALL
   SELECT DISTINCT
     "embedded" as link_type,
     url,
-    link_url
+    link_url, 
+    link_text
   FROM
     content.embedded_links
   UNION ALL
   SELECT DISTINCT
     "transaction_start_link" AS link_type,
     url,
-    link_url
+    link_url, 
+    CAST(NULL AS string) as link_text
   FROM
     content.transaction_start_link
 ),
@@ -56,7 +59,8 @@ links AS (
     ARRAY_AGG(
       STRUCT(
         link_url, 
-        link_type
+        link_type, 
+        link_text
       )
     ) AS hyperlink
   FROM 

--- a/terraform-dev/schemas/search/page.json
+++ b/terraform-dev/schemas/search/page.json
@@ -110,6 +110,12 @@
         "name": "link_type", 
         "type": "STRING", 
         "description": "Type of link"
+      }, 
+      {
+        "mode": "NULLABLE",
+        "name": "link_text", 
+        "type": "STRING", 
+        "description": "Text for the link"
       }
     ]
   },

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -32,21 +32,24 @@ all_links AS (
   SELECT DISTINCT
     link_type,
     from_url as url, 
-    to_url as link_url
+    to_url as link_url,
+    CAST(NULL AS STRING) as link_text
   FROM
     content.expanded_links
   UNION ALL
   SELECT DISTINCT
     "embedded" as link_type,
     url,
-    link_url
+    link_url, 
+    link_text
   FROM
     content.embedded_links
   UNION ALL
   SELECT DISTINCT
     "transaction_start_link" AS link_type,
     url,
-    link_url
+    link_url, 
+    CAST(NULL AS string) as link_text
   FROM
     content.transaction_start_link
 ),
@@ -56,7 +59,8 @@ links AS (
     ARRAY_AGG(
       STRUCT(
         link_url, 
-        link_type
+        link_type, 
+        link_text
       )
     ) AS hyperlink
   FROM 

--- a/terraform-staging/schemas/search/page.json
+++ b/terraform-staging/schemas/search/page.json
@@ -110,6 +110,12 @@
         "name": "link_type", 
         "type": "STRING", 
         "description": "Type of link"
+      }, 
+      {
+        "mode": "NULLABLE",
+        "name": "link_text", 
+        "type": "STRING", 
+        "description": "Text for the link"
       }
     ]
   },

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -32,21 +32,24 @@ all_links AS (
   SELECT DISTINCT
     link_type,
     from_url as url, 
-    to_url as link_url
+    to_url as link_url,
+    CAST(NULL AS STRING) as link_text
   FROM
     content.expanded_links
   UNION ALL
   SELECT DISTINCT
     "embedded" as link_type,
     url,
-    link_url
+    link_url, 
+    link_text
   FROM
     content.embedded_links
   UNION ALL
   SELECT DISTINCT
     "transaction_start_link" AS link_type,
     url,
-    link_url
+    link_url, 
+    CAST(NULL AS string) as link_text
   FROM
     content.transaction_start_link
 ),
@@ -56,7 +59,8 @@ links AS (
     ARRAY_AGG(
       STRUCT(
         link_url, 
-        link_type
+        link_type, 
+        link_text
       )
     ) AS hyperlink
   FROM 

--- a/terraform/schemas/search/page.json
+++ b/terraform/schemas/search/page.json
@@ -110,6 +110,12 @@
         "name": "link_type", 
         "type": "STRING", 
         "description": "Type of link"
+      }, 
+      {
+        "mode": "NULLABLE",
+        "name": "link_text", 
+        "type": "STRING", 
+        "description": "Text for the link"
       }
     ]
   },


### PR DESCRIPTION
It may be necessary to enable the population of link text instead of / along side link URL values for link searches.

The purpose of this change is to populate link text alongside link URLs (where link text is available).

Specifically, this change will:

1. Modify the schema of `search.page` table to include an additional field (`link_text`) in the `hyperlinks` struct;
2. Modify the `page.sql` SQL to populate the `link_text` field where possible (e.g. for embedded links).

It is not expected that this will necessitate front-end change in the meantime, where

1. The front-end already reads data from an array of records (the fundamental structure of the `search.page` table is not changing); and
2. The front-end has recently been made to read specific fields from the record values in the `hyperlinks` field.