### PR TITLE
[DO NOT MERGE YET] Enable searching of text "snippets"

### DIFF
--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -89,6 +89,7 @@ lines as (
         line_number, 
         line
       )
+      ORDER BY line_number ASC
     ) AS text
   FROM
     content.lines

--- a/terraform-dev/schemas/search/page.json
+++ b/terraform-dev/schemas/search/page.json
@@ -72,10 +72,22 @@
     "description": "Description of a page"
   },
   {
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "name": "text",
-    "type": "STRING",
-    "description": "The content of the page as plain text extracted from the HTML"
+    "type": "RECORD",
+    "description": "The content of the page as plain text extracted from the HTML",
+    "fields": [
+      {
+        "name": "line_number", 
+        "type": "INTEGER", 
+        "description": "The line number the text appears on"
+      }, 
+      {
+        "name": "line", 
+        "type": "STRING", 
+        "description": "The text appearing on the given line"
+      }
+    ]
   },
   {
     "mode": "REPEATED",
@@ -102,11 +114,13 @@
     "description": "Array of hyperlinks from the body of the page", 
     "fields": [
       {
+        "mode": "REQUIRED",
         "name": "link_url", 
         "type": "STRING", 
         "description": "Link URL"
       }, 
       {
+        "mode": "REQUIRED",
         "name": "link_type", 
         "type": "STRING", 
         "description": "Type of link"

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -89,6 +89,7 @@ lines as (
         line_number, 
         line
       )
+      ORDER BY line_number ASC
     ) AS text
   FROM
     content.lines

--- a/terraform-staging/schemas/search/page.json
+++ b/terraform-staging/schemas/search/page.json
@@ -72,10 +72,22 @@
     "description": "Description of a page"
   },
   {
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "name": "text",
-    "type": "STRING",
-    "description": "The content of the page as plain text extracted from the HTML"
+    "type": "RECORD",
+    "description": "The content of the page as plain text extracted from the HTML",
+    "fields": [
+      {
+        "name": "line_number", 
+        "type": "INTEGER", 
+        "description": "The line number the text appears on"
+      }, 
+      {
+        "name": "line", 
+        "type": "STRING", 
+        "description": "The text appearing on the given line"
+      }
+    ]
   },
   {
     "mode": "REPEATED",
@@ -102,11 +114,13 @@
     "description": "Array of hyperlinks from the body of the page", 
     "fields": [
       {
+        "mode": "REQUIRED",
         "name": "link_url", 
         "type": "STRING", 
         "description": "Link URL"
       }, 
       {
+        "mode": "REQUIRED",
         "name": "link_type", 
         "type": "STRING", 
         "description": "Type of link"

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -89,6 +89,7 @@ lines as (
         line_number, 
         line
       )
+      ORDER BY line_number ASC
     ) AS text
   FROM
     content.lines

--- a/terraform/schemas/search/page.json
+++ b/terraform/schemas/search/page.json
@@ -72,10 +72,22 @@
     "description": "Description of a page"
   },
   {
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "name": "text",
-    "type": "STRING",
-    "description": "The content of the page as plain text extracted from the HTML"
+    "type": "RECORD",
+    "description": "The content of the page as plain text extracted from the HTML",
+    "fields": [
+      {
+        "name": "line_number", 
+        "type": "INTEGER", 
+        "description": "The line number the text appears on"
+      }, 
+      {
+        "name": "line", 
+        "type": "STRING", 
+        "description": "The text appearing on the given line"
+      }
+    ]
   },
   {
     "mode": "REPEATED",
@@ -102,11 +114,13 @@
     "description": "Array of hyperlinks from the body of the page", 
     "fields": [
       {
+        "mode": "REQUIRED",
         "name": "link_url", 
         "type": "STRING", 
         "description": "Link URL"
       }, 
       {
+        "mode": "REQUIRED",
         "name": "link_type", 
         "type": "STRING", 
         "description": "Type of link"


### PR DESCRIPTION
The purpose of this change is to enable searching through individual lines of content.

It is proposed that this be enabled by:

1. Updating the schema for `search.page` to replace the **string** "text" field with an array of **records**, containing the same content separated into one or more string "lines" (accompanied by the associated integer line number)
2. Updating the SQL populating the `search.page` table to populate the "text" field with content lines from the `content.lines` table.

The change assumes that it is required to populate the `line_number` alongside the `line` (content) on the grounds that:

 - It will only make a small difference in how the front-end will need to be modified to facilitate the change; and
 - It could be useful later on

Note that one side-effect of this change is to increase the volume of data processed in the query which populates `search.page` by somewhere nearing 1GB (was previously ~5.8GB, is now 6.8GB).

**Important**: implementing this change will necessitate a change in the [GovSearch (front-end) repository](https://github.com/alphagov/govuk-knowledge-graph-search).

It's likely that **at least** the [line 14](https://github.com/alphagov/govuk-knowledge-graph-search/blob/59560c096474843062e22e3637a087eca9fa9a86/src/backend/bigquery/buildSqlQuery.ts#L14) in [buildSqlQuery.ts](https://github.com/alphagov/govuk-knowledge-graph-search/blob/59560c096474843062e22e3637a087eca9fa9a86/src/backend/bigquery/buildSqlQuery.ts) will need to be amended to specify that the search should take place against field `text.line` (as opposed to just `text`).