### PR TITLE
Truncate content_items table before repopulating

### DIFF
--- a/src/mongodb/sh/content_items.sh
+++ b/src/mongodb/sh/content_items.sh
@@ -14,6 +14,8 @@ mongoexport \
   "gs://${PROJECT_ID}-data-processed/content-store/content_items.json.gz" \
   --quiet
 
+bq query --use_legacy_sql=false "TRUNCATE TABLE content.content_items"
+
 bq load \
   --nosynchronous_mode \
   --noreplace \


### PR DESCRIPTION
I accidentally neglected to do this, so the table has been growing every
day, and now costs about £3/day in BigQuery storage.

https://trello.com/c/VefK1GNi/126-investigate-rising-bigquery-storage-cost

To check that it works, I force-pushed this branch to the `dev` branch, then
manually triggered the mongodb workflow, and then looked at the output of
```sql
SELECT *
FROM `govuk-knowledge-graph-dev.test.tables-metadata`;
```
to confirm that the table no longer has way more rows than any other table, and
that the tables that I'd expect to have been updated by the mongodb workflow
have been.

I'll also force-push to the `staging` branch, wait for the overnight batch, and
check in the morning that there are no alerts.
