### PR TITLE
Terraform the service account for CI/CD

### DIFF
--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -230,6 +230,13 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role = "roles/artifactregistry.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
     role = "roles/artifactregistry.serviceAgent"
     members = [
       "serviceAccount:service-${var.project_number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
@@ -275,6 +282,13 @@ data "google_iam_policy" "project" {
     role = "roles/cloudbuild.builds.builder"
     members = [
       "serviceAccount:${var.project_number}@cloudbuild.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/cloudbuild.builds.editor"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
     ]
   }
 
@@ -375,9 +389,30 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role = "roles/run.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
     role = "roles/run.serviceAgent"
     members = [
       "serviceAccount:service-${var.project_number}@serverless-robot-prod.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/serviceusage.serviceUsageConsumer"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
+    role = "roles/storage.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
     ]
   }
 

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -150,6 +150,62 @@ data "google_iam_policy" "bucket_data_processed" {
   }
 }
 
+# Bucket for building Cloud Run apps
+resource "google_storage_bucket" "cloudbuild" {
+  name                        = "${var.project_id}_cloudbuild" # Must be globally unique
+  force_destroy               = false                          # terraform won't delete the bucket unless it is empty
+  location                    = var.location
+  storage_class               = "STANDARD" # https://cloud.google.com/storage/docs/storage-classes
+  uniform_bucket_level_access = true
+  versioning {
+    enabled = false
+  }
+}
+
+resource "google_storage_bucket_iam_policy" "cloudbuild" {
+  bucket      = google_storage_bucket.cloudbuild.name
+  policy_data = data.google_iam_policy.bucket_cloudbuild.policy_data
+}
+
+data "google_iam_policy" "bucket_cloudbuild" {
+  binding {
+    role = "roles/storage.objectAdmin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyBucketOwner"
+    members = [
+      "projectEditor:${var.project_id}",
+      "projectOwner:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyBucketReader"
+    members = [
+      "projectViewer:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyObjectOwner"
+    members = [
+      "projectEditor:${var.project_id}",
+      "projectOwner:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyObjectReader"
+    members = [
+      "projectViewer:${var.project_id}",
+    ]
+  }
+}
+
 // Header files of CSV files, for concatenation.
 // BigQuery exports a single, large table as many separate files, which then
 // must be concatenated.  They are exported without headers, so that they can be

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -230,6 +230,13 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role = "roles/artifactregistry.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
     role = "roles/artifactregistry.serviceAgent"
     members = [
       "serviceAccount:service-${var.project_number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
@@ -275,6 +282,13 @@ data "google_iam_policy" "project" {
     role = "roles/cloudbuild.builds.builder"
     members = [
       "serviceAccount:${var.project_number}@cloudbuild.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/cloudbuild.builds.editor"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
     ]
   }
 
@@ -375,9 +389,30 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role = "roles/run.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
     role = "roles/run.serviceAgent"
     members = [
       "serviceAccount:service-${var.project_number}@serverless-robot-prod.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/serviceusage.serviceUsageConsumer"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
+    role = "roles/storage.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
     ]
   }
 

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -150,6 +150,62 @@ data "google_iam_policy" "bucket_data_processed" {
   }
 }
 
+# Bucket for building Cloud Run apps
+resource "google_storage_bucket" "cloudbuild" {
+  name                        = "${var.project_id}_cloudbuild" # Must be globally unique
+  force_destroy               = false                          # terraform won't delete the bucket unless it is empty
+  location                    = var.location
+  storage_class               = "STANDARD" # https://cloud.google.com/storage/docs/storage-classes
+  uniform_bucket_level_access = true
+  versioning {
+    enabled = false
+  }
+}
+
+resource "google_storage_bucket_iam_policy" "cloudbuild" {
+  bucket      = google_storage_bucket.cloudbuild.name
+  policy_data = data.google_iam_policy.bucket_cloudbuild.policy_data
+}
+
+data "google_iam_policy" "bucket_cloudbuild" {
+  binding {
+    role = "roles/storage.objectAdmin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyBucketOwner"
+    members = [
+      "projectEditor:${var.project_id}",
+      "projectOwner:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyBucketReader"
+    members = [
+      "projectViewer:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyObjectOwner"
+    members = [
+      "projectEditor:${var.project_id}",
+      "projectOwner:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyObjectReader"
+    members = [
+      "projectViewer:${var.project_id}",
+    ]
+  }
+}
+
 // Header files of CSV files, for concatenation.
 // BigQuery exports a single, large table as many separate files, which then
 // must be concatenated.  They are exported without headers, so that they can be

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -230,6 +230,13 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role = "roles/artifactregistry.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
     role = "roles/artifactregistry.serviceAgent"
     members = [
       "serviceAccount:service-${var.project_number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
@@ -275,6 +282,13 @@ data "google_iam_policy" "project" {
     role = "roles/cloudbuild.builds.builder"
     members = [
       "serviceAccount:${var.project_number}@cloudbuild.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/cloudbuild.builds.editor"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
     ]
   }
 
@@ -375,9 +389,30 @@ data "google_iam_policy" "project" {
   }
 
   binding {
+    role = "roles/run.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
     role = "roles/run.serviceAgent"
     members = [
       "serviceAccount:service-${var.project_number}@serverless-robot-prod.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/serviceusage.serviceUsageConsumer"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
+    role = "roles/storage.admin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
     ]
   }
 

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -150,6 +150,62 @@ data "google_iam_policy" "bucket_data_processed" {
   }
 }
 
+# Bucket for building Cloud Run apps
+resource "google_storage_bucket" "cloudbuild" {
+  name                        = "${var.project_id}_cloudbuild" # Must be globally unique
+  force_destroy               = false                          # terraform won't delete the bucket unless it is empty
+  location                    = var.location
+  storage_class               = "STANDARD" # https://cloud.google.com/storage/docs/storage-classes
+  uniform_bucket_level_access = true
+  versioning {
+    enabled = false
+  }
+}
+
+resource "google_storage_bucket_iam_policy" "cloudbuild" {
+  bucket      = google_storage_bucket.cloudbuild.name
+  policy_data = data.google_iam_policy.bucket_cloudbuild.policy_data
+}
+
+data "google_iam_policy" "bucket_cloudbuild" {
+  binding {
+    role = "roles/storage.objectAdmin"
+    members = [
+      google_service_account.govgraphsearch_deploy.member,
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyBucketOwner"
+    members = [
+      "projectEditor:${var.project_id}",
+      "projectOwner:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyBucketReader"
+    members = [
+      "projectViewer:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyObjectOwner"
+    members = [
+      "projectEditor:${var.project_id}",
+      "projectOwner:${var.project_id}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.legacyObjectReader"
+    members = [
+      "projectViewer:${var.project_id}",
+    ]
+  }
+}
+
 // Header files of CSV files, for concatenation.
 // BigQuery exports a single, large table as many separate files, which then
 // must be concatenated.  They are exported without headers, so that they can be


### PR DESCRIPTION
This service account is already in use by the GitHub Actions of the
repository https://github.com/alphagov/govuk-knowledge-graph-search

It needs the roles/permissions that are documented here:
https://cloud.google.com/run/docs/reference/iam/roles#additional-configuration

Edit 2023-10-31: because it's deploying from source, it also needs the roles/permissions that are documented here: https://cloud.google.com/run/docs/deploying-source-code#permissions_required_to_deploy

[Trello card](https://trello.com/c/nwWkD5d6/121-terraform-govsearch-ci-cd-service-accounts)

Also closes #405
