### PR TITLE
Use service account blocks rather than strings

### DIFF
--- a/terraform-dev/artifact-registry.tf
+++ b/terraform-dev/artifact-registry.tf
@@ -40,15 +40,15 @@ data "google_iam_policy" "artifact_registry_docker" {
   binding {
     role = "roles/artifactregistry.reader"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member
     ]
   }
 
   binding {
     role = "roles/artifactregistry.writer"
     members = [
-      "serviceAccount:${google_service_account.artifact_registry_docker.email}",
+      google_service_account.artifact_registry_docker.member,
     ]
   }
 }

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -13,10 +13,10 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.bigquery_page_transitions.member,
     ]
   }
   binding {
@@ -32,8 +32,8 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -13,10 +13,10 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {
@@ -29,11 +29,11 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
     ]
   }

--- a/terraform-dev/bigquery-publishing.tf
+++ b/terraform-dev/bigquery-publishing.tf
@@ -13,7 +13,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
+      google_service_account.gce_postgres.member,
     ]
   }
   binding {
@@ -27,7 +27,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     members = [
       "projectReaders",
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
 }

--- a/terraform-dev/bigquery-search.tf
+++ b/terraform-dev/bigquery-search.tf
@@ -19,7 +19,7 @@ data "google_iam_policy" "bigquery_dataset_search" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {
@@ -33,8 +33,8 @@ data "google_iam_policy" "bigquery_dataset_search" {
     members = [
       "projectReaders",
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.govgraphsearch.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
 }

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -37,7 +37,7 @@ data "google_iam_policy" "bigquery_dataset_test" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {

--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -15,7 +15,7 @@ data "google_iam_policy" "service_account-gce_mongodb" {
   binding {
     role = "roles/iam.serviceAccountUser"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
     ]
   }
 }
@@ -30,7 +30,7 @@ data "google_iam_policy" "service_account-gce_postgres" {
   binding {
     role = "roles/iam.serviceAccountUser"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
     ]
   }
 }

--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -63,7 +63,7 @@ data "google_iam_policy" "sso_oauth_client_id" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }
@@ -77,7 +77,7 @@ data "google_iam_policy" "sso_oauth_client_secret" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }
@@ -91,7 +91,7 @@ data "google_iam_policy" "cookie-session-signature" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -239,12 +239,12 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/bigquery.jobUser"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.bigquery_page_transitions.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
@@ -295,9 +295,9 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/compute.instanceAdmin.v1"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_govuk_integration_database_backups.member
     ]
   }
 
@@ -346,8 +346,8 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/logging.logWriter"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
+      google_service_account.workflow_bank_holidays.member
     ]
   }
 
@@ -368,9 +368,9 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/workflows.invoker"
     members = [
-      "serviceAccount:${google_service_account.eventarc.email}",
-      "serviceAccount:${google_service_account.scheduler_bank_holidays.email}",
-      "serviceAccount:${google_service_account.scheduler_page_views.email}",
+      google_service_account.eventarc.member,
+      google_service_account.scheduler_bank_holidays.member,
+      google_service_account.scheduler_page_views.member
     ]
   }
 

--- a/terraform-dev/source-repositories.tf
+++ b/terraform-dev/source-repositories.tf
@@ -14,7 +14,7 @@ data "google_iam_policy" "source_repositories_alphagov_govuk_knowledge_graph_gcp
   binding {
     role = "roles/writer"
     members = [
-      "serviceAccount:${google_service_account.source_repositories_github.email}",
+      google_service_account.source_repositories_github.member,
     ]
   }
 }

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -40,15 +40,15 @@ data "google_iam_policy" "bucket_repository" {
   binding {
     role = "roles/storage.admin"
     members = [
-      "serviceAccount:${google_service_account.storage_github.email}",
+      google_service_account.storage_github.member,
     ]
   }
 
   binding {
     role = "roles/storage.objectViewer"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member
     ]
   }
 
@@ -104,10 +104,10 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.bigquery_page_transitions.member,
+      google_service_account.workflow_bank_holidays.member,
     ]
   }
 

--- a/terraform-staging/artifact-registry.tf
+++ b/terraform-staging/artifact-registry.tf
@@ -40,15 +40,15 @@ data "google_iam_policy" "artifact_registry_docker" {
   binding {
     role = "roles/artifactregistry.reader"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member
     ]
   }
 
   binding {
     role = "roles/artifactregistry.writer"
     members = [
-      "serviceAccount:${google_service_account.artifact_registry_docker.email}",
+      google_service_account.artifact_registry_docker.member,
     ]
   }
 }

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -13,10 +13,10 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.bigquery_page_transitions.member,
     ]
   }
   binding {
@@ -32,8 +32,8 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -13,10 +13,10 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {
@@ -29,11 +29,11 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
     ]
   }

--- a/terraform-staging/bigquery-publishing.tf
+++ b/terraform-staging/bigquery-publishing.tf
@@ -13,7 +13,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
+      google_service_account.gce_postgres.member,
     ]
   }
   binding {
@@ -27,7 +27,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     members = [
       "projectReaders",
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
 }

--- a/terraform-staging/bigquery-search.tf
+++ b/terraform-staging/bigquery-search.tf
@@ -19,7 +19,7 @@ data "google_iam_policy" "bigquery_dataset_search" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {
@@ -33,8 +33,8 @@ data "google_iam_policy" "bigquery_dataset_search" {
     members = [
       "projectReaders",
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.govgraphsearch.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
 }

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -37,7 +37,7 @@ data "google_iam_policy" "bigquery_dataset_test" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -15,7 +15,7 @@ data "google_iam_policy" "service_account-gce_mongodb" {
   binding {
     role = "roles/iam.serviceAccountUser"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
     ]
   }
 }
@@ -30,7 +30,7 @@ data "google_iam_policy" "service_account-gce_postgres" {
   binding {
     role = "roles/iam.serviceAccountUser"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
     ]
   }
 }

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -63,7 +63,7 @@ data "google_iam_policy" "sso_oauth_client_id" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }
@@ -77,7 +77,7 @@ data "google_iam_policy" "sso_oauth_client_secret" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }
@@ -91,7 +91,7 @@ data "google_iam_policy" "cookie-session-signature" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -239,12 +239,12 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/bigquery.jobUser"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.bigquery_page_transitions.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
@@ -295,9 +295,9 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/compute.instanceAdmin.v1"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_govuk_integration_database_backups.member
     ]
   }
 
@@ -346,8 +346,8 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/logging.logWriter"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
+      google_service_account.workflow_bank_holidays.member
     ]
   }
 
@@ -368,9 +368,9 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/workflows.invoker"
     members = [
-      "serviceAccount:${google_service_account.eventarc.email}",
-      "serviceAccount:${google_service_account.scheduler_bank_holidays.email}",
-      "serviceAccount:${google_service_account.scheduler_page_views.email}",
+      google_service_account.eventarc.member,
+      google_service_account.scheduler_bank_holidays.member,
+      google_service_account.scheduler_page_views.member
     ]
   }
 

--- a/terraform-staging/source-repositories.tf
+++ b/terraform-staging/source-repositories.tf
@@ -14,7 +14,7 @@ data "google_iam_policy" "source_repositories_alphagov_govuk_knowledge_graph_gcp
   binding {
     role = "roles/writer"
     members = [
-      "serviceAccount:${google_service_account.source_repositories_github.email}",
+      google_service_account.source_repositories_github.member,
     ]
   }
 }

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -40,15 +40,15 @@ data "google_iam_policy" "bucket_repository" {
   binding {
     role = "roles/storage.admin"
     members = [
-      "serviceAccount:${google_service_account.storage_github.email}",
+      google_service_account.storage_github.member,
     ]
   }
 
   binding {
     role = "roles/storage.objectViewer"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member
     ]
   }
 
@@ -104,10 +104,10 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.bigquery_page_transitions.member,
+      google_service_account.workflow_bank_holidays.member,
     ]
   }
 

--- a/terraform/artifact-registry.tf
+++ b/terraform/artifact-registry.tf
@@ -40,15 +40,15 @@ data "google_iam_policy" "artifact_registry_docker" {
   binding {
     role = "roles/artifactregistry.reader"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member
     ]
   }
 
   binding {
     role = "roles/artifactregistry.writer"
     members = [
-      "serviceAccount:${google_service_account.artifact_registry_docker.email}",
+      google_service_account.artifact_registry_docker.member,
     ]
   }
 }

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -13,10 +13,10 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.bigquery_page_transitions.member,
     ]
   }
   binding {
@@ -32,8 +32,8 @@ data "google_iam_policy" "bigquery_dataset_content_dataEditor" {
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -13,10 +13,10 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {
@@ -29,11 +29,11 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     role = "roles/bigquery.dataViewer"
     members = [
       "projectReaders",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
       "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
       "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
       "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
     ]
   }

--- a/terraform/bigquery-publishing.tf
+++ b/terraform/bigquery-publishing.tf
@@ -13,7 +13,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
+      google_service_account.gce_postgres.member,
     ]
   }
   binding {
@@ -27,7 +27,7 @@ data "google_iam_policy" "bigquery_dataset_publishing" {
     members = [
       "projectReaders",
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
 }

--- a/terraform/bigquery-search.tf
+++ b/terraform/bigquery-search.tf
@@ -19,7 +19,7 @@ data "google_iam_policy" "bigquery_dataset_search" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {
@@ -33,8 +33,8 @@ data "google_iam_policy" "bigquery_dataset_search" {
     members = [
       "projectReaders",
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.govgraphsearch.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
 }

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -37,7 +37,7 @@ data "google_iam_policy" "bigquery_dataset_test" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
+      google_service_account.bigquery_scheduled_queries_search.member,
     ]
   }
   binding {

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -15,7 +15,7 @@ data "google_iam_policy" "service_account-gce_mongodb" {
   binding {
     role = "roles/iam.serviceAccountUser"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
     ]
   }
 }
@@ -30,7 +30,7 @@ data "google_iam_policy" "service_account-gce_postgres" {
   binding {
     role = "roles/iam.serviceAccountUser"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
     ]
   }
 }

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -63,7 +63,7 @@ data "google_iam_policy" "sso_oauth_client_id" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }
@@ -77,7 +77,7 @@ data "google_iam_policy" "sso_oauth_client_secret" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }
@@ -91,7 +91,7 @@ data "google_iam_policy" "cookie-session-signature" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     members = [
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.govgraphsearch.member,
     ]
   }
 }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -239,12 +239,12 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/bigquery.jobUser"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
-      "serviceAccount:${google_service_account.bigquery_scheduled_queries_search.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
-      "serviceAccount:${google_service_account.govgraphsearch.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.bigquery_page_transitions.member,
+      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.workflow_bank_holidays.member,
+      google_service_account.govgraphsearch.member,
       "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
     ]
   }
@@ -295,9 +295,9 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/compute.instanceAdmin.v1"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.workflow_govuk_integration_database_backups.member
     ]
   }
 
@@ -346,8 +346,8 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/logging.logWriter"
     members = [
-      "serviceAccount:${google_service_account.workflow_govuk_integration_database_backups.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      google_service_account.workflow_govuk_integration_database_backups.member,
+      google_service_account.workflow_bank_holidays.member
     ]
   }
 
@@ -368,9 +368,9 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/workflows.invoker"
     members = [
-      "serviceAccount:${google_service_account.eventarc.email}",
-      "serviceAccount:${google_service_account.scheduler_bank_holidays.email}",
-      "serviceAccount:${google_service_account.scheduler_page_views.email}",
+      google_service_account.eventarc.member,
+      google_service_account.scheduler_bank_holidays.member,
+      google_service_account.scheduler_page_views.member
     ]
   }
 

--- a/terraform/source-repositories.tf
+++ b/terraform/source-repositories.tf
@@ -14,7 +14,7 @@ data "google_iam_policy" "source_repositories_alphagov_govuk_knowledge_graph_gcp
   binding {
     role = "roles/writer"
     members = [
-      "serviceAccount:${google_service_account.source_repositories_github.email}",
+      google_service_account.source_repositories_github.member,
     ]
   }
 }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -40,15 +40,15 @@ data "google_iam_policy" "bucket_repository" {
   binding {
     role = "roles/storage.admin"
     members = [
-      "serviceAccount:${google_service_account.storage_github.email}",
+      google_service_account.storage_github.member,
     ]
   }
 
   binding {
     role = "roles/storage.objectViewer"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}"
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member
     ]
   }
 
@@ -104,10 +104,10 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
-      "serviceAccount:${google_service_account.gce_mongodb.email}",
-      "serviceAccount:${google_service_account.gce_postgres.email}",
-      "serviceAccount:${google_service_account.bigquery_page_transitions.email}",
-      "serviceAccount:${google_service_account.workflow_bank_holidays.email}",
+      google_service_account.gce_mongodb.member,
+      google_service_account.gce_postgres.member,
+      google_service_account.bigquery_page_transitions.member,
+      google_service_account.workflow_bank_holidays.member,
     ]
   }
 


### PR DESCRIPTION
Assign members to roles by mentioning the terraform block rather than a
string.  This means that terraform can follow the dependencies between
IAM policies and service accounts, and avoid situations where terraform
deletes the entire policy just because one of the service accounts
doesn't exist yet.  We have locked ourselves out of the project a couple
of times now by falling into that trap.

Terraform should have an empty plan for this change.  Currently the plan
isn't empty, because there are discrepancies between the real
infrastructure and the configuration.
