### PR TITLE
Remove duckdb from postgres Dockerfile

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -26,11 +26,6 @@ RUN \
   gcc \
   ruby-full \
   && gem install govspeak -v 7.0.0 \
-  # Install duckdb
-  && curl -L -o duckdb.zip https://github.com/duckdb/duckdb/releases/download/v0.7.1/duckdb_cli-linux-amd64.zip \
-  && unzip duckdb.zip \
-  && rm duckdb.zip \
-  && mv duckdb /usr/bin \
   # Clean up
   && apt-get remove -y gcc \
   && apt-get autoremove -y \


### PR DESCRIPTION
Closes #458.

See the comment in src/postgres/functions.sh for why we didn't end up
using duckdb.

> We have to use uncompressed CSV for the largest table, so we might as well
> use it for the others too.
>
> BigQuery can't deal with compressed CSVs larger than 4GB.  The largest table
> is 19GB when compressed.
>
> Alternatively we could use Parquet (via DuckDB) but BigQuery can't cope with
> values larger than 10MiB in any particular column, and the largest page has
> 11302027 bytes (>10MiB) in the `details` column.
>
> /hmrc-internal-manuals/customs-authorisation-and-approval/caa08030
>
> https://webarchive.nationalarchives.gov.uk/ukgwa/20211120003440/https://www.gov.uk/hmrc-internal-manuals/customs-authorisation-and-approval/caa08030
>
> The DuckDB max_line_size parameter defaults to 2 MiB, which would eliminate
> those rows before they break BigQuery, but DuckDB stops with an error
> instead of ignoring those lines.
>
> The command gcloud bq load has options for ignoring bad lines, but they
> don't work for parquet.
>
> Finally, BigQuery does in fact seem to allow values larger than 10MiB, as
> long as they come from uncompressed CSV files.  So that's what we use.
>
> What a palaver.  "Big" Query, huh.
