### PR TITLE
Don't store service account keys

### DIFF
--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -79,19 +79,6 @@ resource "google_secret_manager_secret" "cookie-session-signature" {
   }
 }
 
-# Create a secret for GitHub Actions
-resource "google_secret_manager_secret" "github_action_secret" {
-  secret_id = "github-action-service-account-deploy-key"
-
-  replication {
-    user_managed {
-      replicas {
-        location = var.region
-      }
-    }
-  }
-}
-
 # Allow the Cloud Run service to access the GOV.UK Signon secrets
 data "google_iam_policy" "sso_oauth_client_id" {
   binding {

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -79,19 +79,6 @@ resource "google_secret_manager_secret" "cookie-session-signature" {
   }
 }
 
-# Create a secret for GitHub Actions
-resource "google_secret_manager_secret" "github_action_secret" {
-  secret_id = "github-action-service-account-deploy-key"
-
-  replication {
-    user_managed {
-      replicas {
-        location = var.region
-      }
-    }
-  }
-}
-
 # Allow the Cloud Run service to access the GOV.UK Signon secrets
 data "google_iam_policy" "sso_oauth_client_id" {
   binding {

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -79,19 +79,6 @@ resource "google_secret_manager_secret" "cookie-session-signature" {
   }
 }
 
-# Create a secret for GitHub Actions
-resource "google_secret_manager_secret" "github_action_secret" {
-  secret_id = "github-action-service-account-deploy-key"
-
-  replication {
-    user_managed {
-      replicas {
-        location = var.region
-      }
-    }
-  }
-}
-
 # Allow the Cloud Run service to access the GOV.UK Signon secrets
 data "google_iam_policy" "sso_oauth_client_id" {
   binding {


### PR DESCRIPTION
We have been storing service account keys in GCP secrets, because
otherwise they are only visible once.  But we don't need them to be
visible more than once.

1. Create key
2. Store it in a GitHub secret for a GitHub Action
3. Forget about it
4. If we accidentally delete the GitHub secret, we can easily create a
   new service account key.

We ought to rotate the keys periodically anyway, and ideally we'd use
keyless authentication via Workload Identity Federation.
