### PR TITLE
Don't hardcode bucket name for mongo instance

### DIFF
--- a/docker/mongodb/run.sh
+++ b/docker/mongodb/run.sh
@@ -21,7 +21,7 @@ sleep 5
 # Instead of rewriting all the queries as SQL, we export the whole table from
 # postgres, as JSON, then load it into MongoDB, where we can use the original
 # queries.
-gcloud storage cat gs://govuk-knowledge-graph-dev-data-processed/content-store/content_items.json.gz \
+gcloud storage cat gs://$PROJECT_ID-data-processed/content-store/content_items.json.gz \
   | gunzip -c \
   | mongoimport --db=content_store --collection=content_items --quiet
 


### PR DESCRIPTION
PR #546 inadvertently hardcoded the name of the bucket from which the
mongo instance downloads a database backup file.  This meant it only ran
in the dev environment, not the others.
