### PR TITLE
Update filename of Publishing API database backup

### DIFF
--- a/terraform-dev/workflows/govuk-integration-database-backups.yaml
+++ b/terraform-dev/workflows/govuk-integration-database-backups.yaml
@@ -33,7 +33,7 @@ main:
       - object_name: $${message_json.name}
   - maybe_start_an_instance:
       switch:
-        - condition: $${text.match_regex(object_name, "^publishing-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}-publishing_api_production\\.gz$")}
+        - condition: $${text.match_regex(object_name, "^publishing-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-publishing_api_production\\.gz$")}
           steps:
           - log_starting_postgres_instance:
               call: sys.log

--- a/terraform-staging/workflows/govuk-integration-database-backups.yaml
+++ b/terraform-staging/workflows/govuk-integration-database-backups.yaml
@@ -33,7 +33,7 @@ main:
       - object_name: $${message_json.name}
   - maybe_start_an_instance:
       switch:
-        - condition: $${text.match_regex(object_name, "^publishing-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}-publishing_api_production\\.gz$")}
+        - condition: $${text.match_regex(object_name, "^publishing-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-publishing_api_production\\.gz$")}
           steps:
           - log_starting_postgres_instance:
               call: sys.log

--- a/terraform/workflows/govuk-integration-database-backups.yaml
+++ b/terraform/workflows/govuk-integration-database-backups.yaml
@@ -33,7 +33,7 @@ main:
       - object_name: $${message_json.name}
   - maybe_start_an_instance:
       switch:
-        - condition: $${text.match_regex(object_name, "^publishing-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}-publishing_api_production\\.gz$")}
+        - condition: $${text.match_regex(object_name, "^publishing-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-publishing_api_production\\.gz$")}
           steps:
           - log_starting_postgres_instance:
               call: sys.log


### PR DESCRIPTION
A workflow that responds to the creation of these files needs to know
its exact name.  The format of the part of the name that represents time
has recently changed.
