### PR TITLE
chore: terraform default firewalls

### DIFF
--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -480,7 +480,68 @@ resource "google_compute_project_metadata" "default" {
     serial-port-logging-enable = true
   }
 }
-#
+
+resource "google_compute_firewall" "default_allow_ssh" {
+  name    = "default-allow-ssh"
+  description = "Allow SSH from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_firewall" "default_allow_rdp" {
+  name    = "default-allow-rdp"
+  description = "Allow RDP from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3389"]
+  }
+}
+
+
+resource "google_compute_firewall" "default_allow_icmp" {
+  name    = "default-allow-icmp"
+  description = "Allow ICMP from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+
+resource "google_compute_firewall" "default_allow_internal" {
+  name    = "default-allow-internal"
+  description = "Allow internal traffic on the default network"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["10.128.0.0/9"]
+
+  allow {
+    protocol = "tcp"
+    ports = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports = ["0-65535"]
+  }
+}
 
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"

--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -481,68 +481,6 @@ resource "google_compute_project_metadata" "default" {
   }
 }
 
-resource "google_compute_firewall" "default_allow_ssh" {
-  name    = "default-allow-ssh"
-  description = "Allow SSH from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["22"]
-  }
-}
-
-resource "google_compute_firewall" "default_allow_rdp" {
-  name    = "default-allow-rdp"
-  description = "Allow RDP from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["3389"]
-  }
-}
-
-
-resource "google_compute_firewall" "default_allow_icmp" {
-  name    = "default-allow-icmp"
-  description = "Allow ICMP from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "icmp"
-  }
-}
-
-
-resource "google_compute_firewall" "default_allow_internal" {
-  name    = "default-allow-internal"
-  description = "Allow internal traffic on the default network"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["10.128.0.0/9"]
-
-  allow {
-    protocol = "tcp"
-    ports = ["0-65535"]
-  }
-
-  allow {
-    protocol = "udp"
-    ports = ["0-65535"]
-  }
-}
-
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"
   description = "Allow ingress via IAP"

--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -481,6 +481,20 @@ resource "google_compute_project_metadata" "default" {
   }
 }
 
+resource "google_compute_firewall" "default_allow_iap_ssh" {
+  name        = "default-allow-iap-ssh"
+  description = "Allow ingress via IAP"
+  network     = google_compute_network.default.name
+  priority    = 65534
+
+  source_ranges = ["35.235.240.0/20"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"
   description = "Allow ingress via IAP"

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -480,7 +480,68 @@ resource "google_compute_project_metadata" "default" {
     serial-port-logging-enable = true
   }
 }
-#
+
+resource "google_compute_firewall" "default_allow_ssh" {
+  name    = "default-allow-ssh"
+  description = "Allow SSH from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_firewall" "default_allow_rdp" {
+  name    = "default-allow-rdp"
+  description = "Allow RDP from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3389"]
+  }
+}
+
+
+resource "google_compute_firewall" "default_allow_icmp" {
+  name    = "default-allow-icmp"
+  description = "Allow ICMP from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+
+resource "google_compute_firewall" "default_allow_internal" {
+  name    = "default-allow-internal"
+  description = "Allow internal traffic on the default network"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["10.128.0.0/9"]
+
+  allow {
+    protocol = "tcp"
+    ports = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports = ["0-65535"]
+  }
+}
 
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -481,68 +481,6 @@ resource "google_compute_project_metadata" "default" {
   }
 }
 
-resource "google_compute_firewall" "default_allow_ssh" {
-  name    = "default-allow-ssh"
-  description = "Allow SSH from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["22"]
-  }
-}
-
-resource "google_compute_firewall" "default_allow_rdp" {
-  name    = "default-allow-rdp"
-  description = "Allow RDP from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["3389"]
-  }
-}
-
-
-resource "google_compute_firewall" "default_allow_icmp" {
-  name    = "default-allow-icmp"
-  description = "Allow ICMP from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "icmp"
-  }
-}
-
-
-resource "google_compute_firewall" "default_allow_internal" {
-  name    = "default-allow-internal"
-  description = "Allow internal traffic on the default network"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["10.128.0.0/9"]
-
-  allow {
-    protocol = "tcp"
-    ports = ["0-65535"]
-  }
-
-  allow {
-    protocol = "udp"
-    ports = ["0-65535"]
-  }
-}
-
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"
   description = "Allow ingress via IAP"

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -481,6 +481,20 @@ resource "google_compute_project_metadata" "default" {
   }
 }
 
+resource "google_compute_firewall" "default_allow_iap_ssh" {
+  name        = "default-allow-iap-ssh"
+  description = "Allow ingress via IAP"
+  network     = google_compute_network.default.name
+  priority    = 65534
+
+  source_ranges = ["35.235.240.0/20"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"
   description = "Allow ingress via IAP"

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -480,7 +480,68 @@ resource "google_compute_project_metadata" "default" {
     serial-port-logging-enable = true
   }
 }
-#
+
+resource "google_compute_firewall" "default_allow_ssh" {
+  name    = "default-allow-ssh"
+  description = "Allow SSH from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_firewall" "default_allow_rdp" {
+  name    = "default-allow-rdp"
+  description = "Allow RDP from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3389"]
+  }
+}
+
+
+resource "google_compute_firewall" "default_allow_icmp" {
+  name    = "default-allow-icmp"
+  description = "Allow ICMP from anywhere"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+
+resource "google_compute_firewall" "default_allow_internal" {
+  name    = "default-allow-internal"
+  description = "Allow internal traffic on the default network"
+  network = google_compute_network.default.name
+  priority = 65534
+
+  source_ranges = ["10.128.0.0/9"]
+
+  allow {
+    protocol = "tcp"
+    ports = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports = ["0-65535"]
+  }
+}
 
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -481,68 +481,6 @@ resource "google_compute_project_metadata" "default" {
   }
 }
 
-resource "google_compute_firewall" "default_allow_ssh" {
-  name    = "default-allow-ssh"
-  description = "Allow SSH from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["22"]
-  }
-}
-
-resource "google_compute_firewall" "default_allow_rdp" {
-  name    = "default-allow-rdp"
-  description = "Allow RDP from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["3389"]
-  }
-}
-
-
-resource "google_compute_firewall" "default_allow_icmp" {
-  name    = "default-allow-icmp"
-  description = "Allow ICMP from anywhere"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "icmp"
-  }
-}
-
-
-resource "google_compute_firewall" "default_allow_internal" {
-  name    = "default-allow-internal"
-  description = "Allow internal traffic on the default network"
-  network = google_compute_network.default.name
-  priority = 65534
-
-  source_ranges = ["10.128.0.0/9"]
-
-  allow {
-    protocol = "tcp"
-    ports = ["0-65535"]
-  }
-
-  allow {
-    protocol = "udp"
-    ports = ["0-65535"]
-  }
-}
-
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"
   description = "Allow ingress via IAP"

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -481,6 +481,20 @@ resource "google_compute_project_metadata" "default" {
   }
 }
 
+resource "google_compute_firewall" "default_allow_iap_ssh" {
+  name        = "default-allow-iap-ssh"
+  description = "Allow ingress via IAP"
+  network     = google_compute_network.default.name
+  priority    = 65534
+
+  source_ranges = ["35.235.240.0/20"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
 resource "google_compute_firewall" "custom_vpc_for_cloud_run_allow_iap_ssh" {
   name        = "custom-vpc-for-cloud-run-allow-iap-ssh"
   description = "Allow ingress via IAP"


### PR DESCRIPTION
We never terraformed the firewalls that Google created automatically in the
'default' network.  We also don't need them.  The one that allows SSH can be
replaced by one that allows SSH via IAP, which is more secure, and is consistent
with how SSH via IAP is configured for the 'redis-cli' instance in the
'cloudrun' network.

1. Terraform the default firewalls
2. Delete the default firewalls
3. Allow SSH via IAP on the 'default' network
