### PR TITLE
feat: Don't suffix the document type of page parts

### DIFF
--- a/src/mongodb/bigquery/page.sql
+++ b/src/mongodb/bigquery/page.sql
@@ -53,7 +53,6 @@ SELECT
   page.*
   REPLACE(
     parts.url AS url,
-    page.document_type || "_part" AS document_type,
     parts.part_title AS title,
     c.text AS text,
     parts.part_index AS part_index,


### PR DESCRIPTION
[Trello](https://trello.com/c/1MIvFqE2/65-dont-put-part-suffix-on-document-type-of-subpages)

Remove the `_part` suffix from subpages of `guide` and
`travel_advice` documents. It didn't turn out to be useful, and it
confused users of GovSearch, who expected all matching parts of a guide
to be shown when filtered for document_type=guide, rather than only the
first page.
