### PR TITLE
fix: Make redis-cli contingent on redis existing

### DIFF
--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -290,6 +290,9 @@ module "redis-cli-container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "~> 2.0"
 
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   container = {
     image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
     tty : true
@@ -442,16 +445,19 @@ resource "google_compute_instance_template" "redis_cli" {
   name         = "redis-cli"
   machine_type = "e2-medium"
 
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   disk {
     boot         = true
-    source_image = module.redis-cli-container.source_image
+    source_image = module.redis-cli-container[0].source_image
     disk_size_gb = 10
   }
 
   metadata = {
     google-logging-enabled     = true
     serial-port-logging-enable = true
-    gce-container-declaration  = module.redis-cli-container.metadata_value
+    gce-container-declaration  = module.redis-cli-container[0].metadata_value
   }
 
   network_interface {

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -174,6 +174,10 @@ resource "google_workflows_workflow" "redis_cli" {
   region          = var.region
   description     = "Create a virtual machine for accessing the Memorystore Redis instance"
   service_account = google_service_account.workflow_redis_cli.id
+
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   source_contents = templatefile(
     "workflows/redis-cli.yaml",
     {
@@ -181,7 +185,7 @@ resource "google_workflows_workflow" "redis_cli" {
       zone           = var.zone,
       network_name   = google_redis_instance.session_store[0].authorized_network,
       subnetwork_id  = google_compute_subnetwork.cloudrun.id,
-      metadata_value = jsonencode(module.redis-cli-container.metadata_value)
+      metadata_value = jsonencode(module.redis-cli-container[0].metadata_value)
     }
   )
 }

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -290,6 +290,9 @@ module "redis-cli-container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "~> 2.0"
 
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   container = {
     image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
     tty : true
@@ -442,16 +445,19 @@ resource "google_compute_instance_template" "redis_cli" {
   name         = "redis-cli"
   machine_type = "e2-medium"
 
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   disk {
     boot         = true
-    source_image = module.redis-cli-container.source_image
+    source_image = module.redis-cli-container[0].source_image
     disk_size_gb = 10
   }
 
   metadata = {
     google-logging-enabled     = true
     serial-port-logging-enable = true
-    gce-container-declaration  = module.redis-cli-container.metadata_value
+    gce-container-declaration  = module.redis-cli-container[0].metadata_value
   }
 
   network_interface {

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -174,6 +174,10 @@ resource "google_workflows_workflow" "redis_cli" {
   region          = var.region
   description     = "Create a virtual machine for accessing the Memorystore Redis instance"
   service_account = google_service_account.workflow_redis_cli.id
+
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   source_contents = templatefile(
     "workflows/redis-cli.yaml",
     {
@@ -181,7 +185,7 @@ resource "google_workflows_workflow" "redis_cli" {
       zone           = var.zone,
       network_name   = google_redis_instance.session_store[0].authorized_network,
       subnetwork_id  = google_compute_subnetwork.cloudrun.id,
-      metadata_value = jsonencode(module.redis-cli-container.metadata_value)
+      metadata_value = jsonencode(module.redis-cli-container[0].metadata_value)
     }
   )
 }

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -290,6 +290,9 @@ module "redis-cli-container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "~> 2.0"
 
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   container = {
     image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
     tty : true
@@ -442,16 +445,19 @@ resource "google_compute_instance_template" "redis_cli" {
   name         = "redis-cli"
   machine_type = "e2-medium"
 
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   disk {
     boot         = true
-    source_image = module.redis-cli-container.source_image
+    source_image = module.redis-cli-container[0].source_image
     disk_size_gb = 10
   }
 
   metadata = {
     google-logging-enabled     = true
     serial-port-logging-enable = true
-    gce-container-declaration  = module.redis-cli-container.metadata_value
+    gce-container-declaration  = module.redis-cli-container[0].metadata_value
   }
 
   network_interface {

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -174,6 +174,10 @@ resource "google_workflows_workflow" "redis_cli" {
   region          = var.region
   description     = "Create a virtual machine for accessing the Memorystore Redis instance"
   service_account = google_service_account.workflow_redis_cli.id
+
+  # Enable / Disable
+  count = var.enable_redis_session_store_instance ? 1 : 0
+
   source_contents = templatefile(
     "workflows/redis-cli.yaml",
     {
@@ -181,7 +185,7 @@ resource "google_workflows_workflow" "redis_cli" {
       zone           = var.zone,
       network_name   = google_redis_instance.session_store[0].authorized_network,
       subnetwork_id  = google_compute_subnetwork.cloudrun.id,
-      metadata_value = jsonencode(module.redis-cli-container.metadata_value)
+      metadata_value = jsonencode(module.redis-cli-container[0].metadata_value)
     }
   )
 }


### PR DESCRIPTION
Update the changes in #566 to make the redis-cli virtual machine
template optional, using the same setting that makes redis itself
optional.

Without this commit, it isn't possible to apply the same terraform
configuration to the staging environment, where redis is disabled
(because it isn't integrated with Signon's staging environment.)
