### PR TITLE
Don't create duplicate pages from hyperlinks

### DIFF
--- a/src/mongodb/bigquery/hyperlinks_to.sql
+++ b/src/mongodb/bigquery/hyperlinks_to.sql
@@ -21,7 +21,7 @@ FROM content.embedded_links
 
 -- 2. Create destination Page nodes that don't yet exist.
 INSERT INTO graph.page (url)
-SELECT link_url AS url
+SELECT DISTINCT link_url AS url
 FROM graph.hyperlinks_to
 LEFT JOIN graph.page ON page.url = hyperlinks_to.link_url
 WHERE page.url IS NULL


### PR DESCRIPTION
We create records in the 'graph.page' table of pages that have content. Then we add more records of pages that don't have content but do exist as the target of hyperlinks. By mistake, we were creating duplicates when the same page was the target of multiple hyperlinks.  This was noticed for the homepage, with the following query.

```sql
SELECT *
FROM `govuk-knowledge-graph.graph.page`
WHERE url = "https://www.gov.uk"
```

Thanks to @exfalsoquodlibet for reporting the bug.