### PR TITLE
feat: parse HTML and extract things such as text

### DIFF
--- a/.github/workflows/docker-parse-html-dev.yml
+++ b/.github/workflows/docker-parse-html-dev.yml
@@ -1,0 +1,80 @@
+name: Docker-parse-html-dev
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/parse-html/Dockerfile'
+      - 'docker/parse-html/entrypoint.sh'
+      - '.github/workflows/docker-parse-html-dev.yml'
+
+defaults:
+  run:
+    working-directory: docker/parse-html
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'parse-html'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-dev.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+
+    # Create a new revision of the Cloud Run service using the new image
+    - name: 'Cloud Run deploy'
+      id: 'deploy'
+      uses: 'google-github-actions/deploy-cloudrun@v2'
+      with:
+        service: 'parse-html'
+        image: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker/parse-html:latest'

--- a/.github/workflows/docker-parse-html-staging.yml
+++ b/.github/workflows/docker-parse-html-staging.yml
@@ -1,0 +1,72 @@
+name: Docker-parse-html-staging
+
+on:
+  push:
+    branches:
+      - staging
+    paths:
+      - 'docker/parse-html/Dockerfile'
+      - 'docker/parse-html/entrypoint.sh'
+      - '.github/workflows/docker-parse-html-staging.yml'
+
+defaults:
+  run:
+    working-directory: docker/parse-html
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'parse-html'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-staging.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-parse-html.yml
+++ b/.github/workflows/docker-parse-html.yml
@@ -1,0 +1,72 @@
+name: Docker-parse-html
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/parse-html/Dockerfile'
+      - 'docker/parse-html/entrypoint.sh'
+      - '.github/workflows/docker-parse-html.yml'
+
+defaults:
+  run:
+    working-directory: docker/parse-html
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'parse-html'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/ruby-lint-and-test.yml
+++ b/.github/workflows/ruby-lint-and-test.yml
@@ -1,0 +1,36 @@
+name: Ruby Lint and Test
+
+on:
+  pull_request:
+    paths:
+      - 'docker/parse-html/**'
+
+defaults:
+  run:
+    working-directory: docker/parse-html
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Set up Ruby
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2.2' # or the version you need
+
+    # Install dependencies
+    - name: Install dependencies
+      run: |
+        bundle install --jobs 4 --retry 3
+
+    # Run RuboCop
+    - name: Run RuboCop
+      run: bundle exec rubocop
+
+    # Run RSpec
+    - name: Run RSpec tests
+      run: bundle exec rspec

--- a/docker/parse-html/.dockerignore
+++ b/docker/parse-html/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+README.md
+.ruby-version
+.bundle/
+vendor/

--- a/docker/parse-html/.rubocop.yml
+++ b/docker/parse-html/.rubocop.yml
@@ -1,0 +1,20 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+
+AllCops:
+  TargetRubyVersion: 3.2.2
+
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************

--- a/docker/parse-html/Dockerfile
+++ b/docker/parse-html/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:3.3.0-alpine3.19
+
+RUN apk --no-cache add \
+    build-base \
+    chromium \
+    chromium-chromedriver
+
+ENV CHROMEDRIVER_PATH /usr/bin/chromedriver
+ENV CHROME_BIN /usr/bin/chromium-browser
+
+WORKDIR /usr/src/app
+COPY Gemfile* .
+
+RUN bundle install
+
+COPY . .
+
+# Run the web service on container startup.
+ENTRYPOINT ["bundle", "exec", "functions-framework-ruby", "--target", "parse_html"]

--- a/docker/parse-html/Gemfile
+++ b/docker/parse-html/Gemfile
@@ -3,3 +3,8 @@ source "https://rubygems.org"
 gem "functions_framework"
 gem "json"
 gem "selenium-webdriver"
+
+group :development, :test do
+  gem 'rspec'
+  gem "byebug", require: true
+end

--- a/docker/parse-html/Gemfile
+++ b/docker/parse-html/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "functions_framework"
+gem "json"
+gem "selenium-webdriver"

--- a/docker/parse-html/Gemfile
+++ b/docker/parse-html/Gemfile
@@ -5,6 +5,8 @@ gem "json"
 gem "selenium-webdriver"
 
 group :development, :test do
-  gem 'rspec'
   gem "byebug", require: true
+  gem "rspec"
+  gem "rubocop"
+  gem "rubocop-govuk", require: false
 end

--- a/docker/parse-html/Gemfile.lock
+++ b/docker/parse-html/Gemfile.lock
@@ -1,18 +1,47 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
     byebug (11.1.3)
     cloud_events (0.7.1)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
+    drb (2.2.0)
+      ruby2_keywords
     functions_framework (1.4.1)
       cloud_events (>= 0.7.0, < 2.a)
       puma (>= 4.3.0, < 7.a)
       rack (>= 2.1, < 4.a)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
     json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    minitest (5.21.2)
+    mutex_m (0.2.0)
     nio4r (2.7.0)
+    parallel (1.24.0)
+    parser (3.3.0.4)
+      ast (~> 2.4.1)
+      racc
     puma (6.4.1)
       nio4r (~> 2.0)
+    racc (1.7.3)
     rack (3.0.8)
+    rainbow (3.1.1)
+    regexp_parser (2.9.0)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -27,11 +56,50 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
+    rubocop (1.59.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
+    rubocop-govuk (4.13.0)
+      rubocop (= 1.59.0)
+      rubocop-ast (= 1.30.0)
+      rubocop-rails (= 2.23.0)
+      rubocop-rake (= 0.6.0)
+      rubocop-rspec (= 2.25.0)
+    rubocop-rails (2.23.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.25.0)
+      rubocop (~> 1.40)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.16.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
     websocket (1.2.10)
 
 PLATFORMS
@@ -42,6 +110,8 @@ DEPENDENCIES
   functions_framework
   json
   rspec
+  rubocop
+  rubocop-govuk
   selenium-webdriver
 
 BUNDLED WITH

--- a/docker/parse-html/Gemfile.lock
+++ b/docker/parse-html/Gemfile.lock
@@ -1,7 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
     cloud_events (0.7.1)
+    diff-lcs (1.5.0)
     functions_framework (1.4.1)
       cloud_events (>= 0.7.0, < 2.a)
       puma (>= 4.3.0, < 7.a)
@@ -12,6 +14,19 @@ GEM
       nio4r (~> 2.0)
     rack (3.0.8)
     rexml (3.2.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
     rubyzip (2.3.2)
     selenium-webdriver (4.16.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -23,8 +38,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  byebug
   functions_framework
   json
+  rspec
   selenium-webdriver
 
 BUNDLED WITH

--- a/docker/parse-html/Gemfile.lock
+++ b/docker/parse-html/Gemfile.lock
@@ -1,0 +1,31 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cloud_events (0.7.1)
+    functions_framework (1.4.1)
+      cloud_events (>= 0.7.0, < 2.a)
+      puma (>= 4.3.0, < 7.a)
+      rack (>= 2.1, < 4.a)
+    json (2.7.1)
+    nio4r (2.7.0)
+    puma (6.4.1)
+      nio4r (~> 2.0)
+    rack (3.0.8)
+    rexml (3.2.6)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.16.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
+    websocket (1.2.10)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  functions_framework
+  json
+  selenium-webdriver
+
+BUNDLED WITH
+   2.4.10

--- a/docker/parse-html/README.md
+++ b/docker/parse-html/README.md
@@ -45,7 +45,7 @@ rspec
 
 More things can be extracted from HTML by adding code to the `app.rb` script in
 the function `parse_html()` beneath the comment `# TODO: extract other things
-from the HTML`. That function should be refactored, of course.
+from the HTML`.
 
 ## Alternatives
 

--- a/docker/parse-html/README.md
+++ b/docker/parse-html/README.md
@@ -1,0 +1,59 @@
+# BigQuery Remote Function to Parse HTML
+
+A function to parse a string of HTML passed in by BigQuery, and return things
+extracted from the HTML, in the form that BigQuery expects (JSON).
+
+## BigQuery Remote Functions
+
+BigQuery supports various kinds of custom function, depending on whether it can
+be implemented in
+
+* pure SQL
+* or a programming language that is supported by Cloud Functions v2, and that
+  doesn't have any particular system requirements
+* or a fully customised system, in Docker, hosted in Cloud Run.
+
+We need a fully customised system, because we use Selenium with Chromedriver to
+parse the HTML, and those can't be installed as Ruby gems.  Hence we use the third option, which is a Docker container hosted by Cloud Run.
+
+## Goals
+
+* Parse each HTML string only once, and extract several things from it. This
+  lowers our BigQuery costs, which charge for the amount of data consumbed by
+  each query, so if we parse the same HTML several times in different queries,
+  then we are charged several times.
+* Extract plain text as it is rendered by a browser. This is why we use Selenium
+  and Chromedriver, which is a real browser, rather than nokogiri or
+  beautifulsoup. The main difference is the handling of newlines for `<h1>` and
+  `<div>` elements, and literal newline characters.
+* Be available to BigQuery so that we can compose the entire data pipeline in
+  SQL, where it is easier to test with frameworks such as DBT and SQLMesh.
+
+## Tests
+
+We use RSpec and a [GitHub
+Action](https://github.com/alphagov/govuk-knowledge-graph-gcp/actions/workflows/ruby-lint-and-test.yml),
+and `functions_framework`, which is Google's standard framework for testing
+BigQuery remote functions.
+
+```sh
+cd docker/parse-html
+rspec
+```
+
+## How to add features
+
+More things can be extracted from HTML by adding code to the `app.rb` script in
+the function `parse_html()` beneath the comment `# TODO: extract other things
+from the HTML`. That function should be refactored, of course.
+
+## Alternatives
+
+We previously [implemented](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/292/commits/6b15dd683f14a84d6cad1e904715280d76a343db) this in a virtual machine, using w3m to parse the HTML, Python to call w3m, gnu-parallel to handle parallelisation, and a Makefile to coordinate everything.
+
+This had the following disadvantages.
+
+* Inaccessible to ad hoc tasks
+* Complex to scale
+* Difficult to test
+* Relatively slow (several minutes to process the Content Store)

--- a/docker/parse-html/app.rb
+++ b/docker/parse-html/app.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+require "functions_framework"
+require 'json'
+require 'selenium-webdriver'
+
+
+TIMEOUT_SECONDS = 10 # How long to wait for each govspeak string to render
+
+# Start a global instance of Selenium and Chrome
+options = Selenium::WebDriver::Chrome::Options.new
+options.add_argument('--headless')
+options.add_argument('--disable-dev-shm-usage')
+options.add_argument('--disable-gpu')
+options.add_argument('--no-sandbox')
+options.add_argument('--remote-debugging-port=9222')
+options.add_argument('--window-size=1920,1080')
+
+$driver = Selenium::WebDriver.for(:chrome, options:)
+
+# https://cloud.google.com/functions/docs/create-deploy-http-ruby
+FunctionsFramework.http "parse_html" do |request|
+  # The request parameter is a Rack::Request object.
+  # See https://www.rubydoc.info/gems/rack/Rack/Request
+
+  begin
+    # You return a string, a Rack::Response object, a Rack response array, or
+    # a hash which will be JSON-encoded into a response.
+    return { "replies" => JSON.parse(request.body.read)["calls"].map {
+      |row| parse_html(row[0])
+    } }
+  rescue => e
+    return [500, { 'Content-Type' => 'application/text' }, [ e.message ]]
+  end
+end
+
+# Function to extract plain text from HTML with selenium
+def parse_html(html)
+  text = nil
+
+  begin
+
+    Timeout::timeout(TIMEOUT_SECONDS) do
+      # There isn't a good way to parse HTML from a string.
+      # The .get() method is like a search bar in the browser.
+      #
+      # We write the string to a temporary file and load that.
+      #
+      # Alternatively we could do:
+      #   driver.get("data:text/html;charset=utf-8," + htmlString)
+      # but browsers limit how much data they will accept that way.
+      t = Tempfile.new(['html', '.html'])
+      t.write(html)
+      t.close
+      $driver.get("file:///" + t.path)
+
+      # Extract plain text, as it would appear in a browse, i.e. newlines are
+      # ignored, <div> elements are rendered as newlines, <h1> elements appear
+      # on their own line, etc.
+      text = $driver.find_element(:css, "*").text
+
+      # TODO: extract other things from the HTML
+    rescue Timeout::Error => e
+      error_message = "HTML parsing timed out after #{TIMEOUT_SECONDS} seconds"
+    ensure
+      t.delete
+    end
+
+  rescue => e
+    error_message = e
+  end
+
+  return { "text" => text, "error" => error_message }
+end

--- a/docker/parse-html/app.rb
+++ b/docker/parse-html/app.rb
@@ -46,87 +46,18 @@ def parse_html(html, url)
 
   begin
     Timeout.timeout(TIMEOUT_SECONDS) do
-      # There isn't a good way to parse HTML from a string.
-      # The .get() method is like a search bar in the browser.
-      #
-      # We write the string to a temporary file and load that.
-      #
-      # Alternatively we could do:
-      #   driver.get("data:text/html;charset=utf-8," + htmlString)
-      # but browsers limit how much data they will accept that way.
-      t = Tempfile.new(["html", ".html"])
-      t.write(html)
-      t.close
-      $driver.get("file:///#{t.path}")
+      # Render the HTML in the chromedriver browser, which is in the global
+      # environment
+      parse_html_string(html)
 
-      # Extract plain text, as it would appear in a browse, i.e. newlines are
-      # ignored, <div> elements are rendered as newlines, <h1> elements appear
-      # on their own line, etc.
-      text = $driver.find_element(:css, "*").text
-
-      # Extract each hyperlink
-
-      # Selenium decided to return the property (the resolved URL) instead of
-      # the attribute (whatever the href is), even though the method is
-      # get_attribute.
-      # https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/1824
-      #
-      # Because we load the HTML from a file, Selenium prepends "file://" to
-      # relative links.
-      #
-      # We could do a string replacement of "file://", but what if a link really
-      # does start with "file://"?
-      #
-      # A workaround is to use javascript instead.
-      script = <<~SQUIGGLY_HEREDOC
-        var elems = document.querySelectorAll(':any-link'); // Select all anchor elements
-        var URLs = [];
-
-        [].forEach.call(elems, function (elem) {
-            URLs.push({
-                href: elem.getAttribute("href"), // Get the unaltered href attribute
-                text: elem.textContent // Get the text content of the link
-            });
-        });
-        return URLs
-      SQUIGGLY_HEREDOC
-
-      links = $driver.execute_script(script)
-
-      links.each do |link|
-        # Clean and qualify
-        link_href = clean_hyperlink(link["href"], url)
-
-        # Remove URL parameters and anchors
-        bare_href = URI.parse(link_href)
-        bare_href.query = nil
-        bare_href.fragment = nil
-        bare_href = bare_href.to_s
-
-        hyperlinks.push({
-          "link_url" => link_href,
-          "link_url_bare" => bare_href,
-          "link_text" => link["text"],
-        })
-      end
-
-      # Extract abbreviations
-      elems = $driver.find_elements(:css, "abbr")
-      elems.each do |elem|
-        abbreviation_title = elem.attribute("title") # Expansion
-        abbreviation_text = elem.text # Abbreviation
-
-        abbreviations.push({
-          "title" => abbreviation_title,
-          "text" => abbreviation_text,
-        })
-      end
+      # Extract things from the rendered HTML
+      text = extract_plain_text
+      hyperlinks = extract_hyperlinks(url)
+      abbreviations = extract_abbreviations
 
       # TODO: extract other things from the HTML
     rescue Timeout::Error
       "HTML parsing timed out after #{TIMEOUT_SECONDS} seconds"
-    ensure
-      t.delete
     end
   rescue StandardError => e
     error_message = e
@@ -138,6 +69,103 @@ def parse_html(html, url)
     "abbreviations" => abbreviations,
     "error" => error_message,
   }
+end
+
+# Function to parse a string of HTML with Selenium and Chromedriver
+#
+# There is no return value.
+#
+# A Selinium driver is assumed to exist in the global environment.
+# A temporary file will be created, for Chromedriver to load.
+#
+# @param html [String] HTML to parse
+def parse_html_string(html)
+  # There isn't a good way to parse HTML from a string.
+  # The .get() method is like a search bar in the browser.
+  #
+  # We write the string to a temporary file and load that.
+  #
+  # Alternatively we could do:
+  #   driver.get("data:text/html;charset=utf-8," + htmlString)
+  # but browsers limit how much data they will accept that way.
+
+  t = Tempfile.new(["html", ".html"])
+  t.write(html)
+  t.close
+  $driver.get("file:///#{t.path}")
+ensure
+  t.delete
+end
+
+# A function to extract plain text from a parsed HTML document, as it would
+# appear in a browser, i.e. newlines are ignored, <div> elements are rendered as
+# newlines, <h1> elements appear on their own line, etc.
+#
+# A Selinium driver is assumed to exist in the global environment, and to have
+# loaded an HTML page.
+def extract_plain_text
+  $driver.find_element(:css, "*").text
+end
+
+# A function to extract hyperlinks from a parsed HTML document.
+#
+# Returns an array of hashes, one per hyperlink.
+#
+# A Selinium driver is assumed to exist in the global environment, and to have
+# loaded an HTML page.
+#
+# @# @param url [String] URL of the HTML, so that links to sections within the HTML
+#                     can be fully qualified
+def extract_hyperlinks(url)
+  hyperlinks = []
+
+  # Extract each hyperlink
+  #
+  # Selenium returns the property (the resolved URL) instead of the
+  # attribute (whatever the href is), even though the method is
+  # get_attribute.
+  # https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/1824
+  #
+  # Because we load the HTML from a file, Selenium prepends "file://" to
+  # relative links.
+  #
+  # We could do a string replacement of "file://", but what if a link really
+  # does start with "file://"?
+  #
+  # A workaround is to use javascript instead.
+  script = <<~SQUIGGLY_HEREDOC
+    var elems = document.querySelectorAll(':any-link'); // Select all anchor elements
+    var URLs = [];
+
+    [].forEach.call(elems, function (elem) {
+    URLs.push({
+    href: elem.getAttribute("href"), // Get the unaltered href attribute
+    text: elem.textContent // Get the text content of the link
+    });
+    });
+    return URLs
+  SQUIGGLY_HEREDOC
+
+  links = $driver.execute_script(script)
+
+  links.each do |link|
+    # Clean and qualify
+    link_href = clean_hyperlink(link["href"], url)
+
+    # Remove URL parameters and anchors
+    bare_href = URI.parse(link_href)
+    bare_href.query = nil
+    bare_href.fragment = nil
+    bare_href = bare_href.to_s
+
+    hyperlinks.push({
+      "link_url" => link_href,
+      "link_url_bare" => bare_href,
+      "link_text" => link["text"],
+    })
+  end
+
+  hyperlinks
 end
 
 # Function to clean and fully qualify relative links and anchor links
@@ -165,4 +193,28 @@ def clean_hyperlink(href, from_url)
 
   href
 end
+
+# A function to extract <abbr> elements from a parsed HTML document.
+#
+# Returns an array of hashes, one per <abbr> element.
+#
+# A Selinium driver is assumed to exist in the global environment, and to have
+# loaded an HTML page.
+def extract_abbreviations
+  abbreviations = []
+
+  elems = $driver.find_elements(:css, "abbr")
+  elems.each do |elem|
+    abbreviation_title = elem.attribute("title") # Expansion
+    abbreviation_text = elem.text # Abbreviation
+
+    abbreviations.push({
+      "title" => abbreviation_title,
+      "text" => abbreviation_text,
+    })
+  end
+
+  abbreviations
+end
+
 # rubocop:enable Style/GlobalVars

--- a/docker/parse-html/app.rb
+++ b/docker/parse-html/app.rb
@@ -42,6 +42,7 @@ end
 def parse_html(html, url)
   text = nil
   hyperlinks = []
+  abbreviations = []
 
   begin
 
@@ -109,6 +110,16 @@ def parse_html(html, url)
           "link_text" => link["text"],
         })
       end
+
+      # Extract abbreviations
+      elems = $driver.find_elements(:css, "abbr")
+      elems.each do |elem|
+        abbreviation_title = elem.attribute("title") # Expansion
+        abbreviation_text = elem.text # Abbreviation
+
+        abbreviations.push({
+          "title" => abbreviation_title,
+          "text" => abbreviation_text,
         })
       end
 
@@ -123,7 +134,13 @@ def parse_html(html, url)
     error_message = e
   end
 
-  return { "text" => text, "hyperlinks" => hyperlinks, "error" => error_message }
+  return {
+    "text" => text,
+    "hyperlinks" => hyperlinks,
+    "abbreviations" => abbreviations,
+    "error" => error_message
+  }
+end
 
 # Function to clean and fully qualify relative links and anchor links
 #

--- a/docker/parse-html/spec/app_spec.rb
+++ b/docker/parse-html/spec/app_spec.rb
@@ -1,0 +1,167 @@
+require "rspec"
+require "functions_framework/testing"
+
+
+# Submit an http request, return an http response, with the body parsed into an
+# array of JSON objects.
+#
+# @param body [array] of arrays, one array per call to the function, where each
+# array has elements corresponding to the arguments of the function
+# parse_html().
+def request(calls)
+  body = {"calls" => calls}
+  url = ""
+  headers = ["Content-Type: application/json"]
+  body = body.to_json.to_s
+  request = make_post_request url, body, headers
+  response = call_http "parse_html", request
+  response.body = JSON.parse(response.body[0])["replies"]
+  return response
+end
+
+describe "parse_html() function" do
+  include FunctionsFramework::Testing
+
+  it "returns 200 with nil input" do
+    load_temporary "app.rb" do
+      response = request([[nil, nil]])
+      expect(response.status).to eq(200)
+    end
+  end
+
+  it "returns 200 with blank input" do
+    load_temporary "app.rb" do
+      response = request([["", ""]])
+      expect(response.status).to eq(200)
+    end
+  end
+
+  it "returns 200 with html input" do
+    load_temporary "app.rb" do
+      response = request([["<p>text</p>, ", ""]])
+      expect(response.status).to eq(200)
+    end
+  end
+
+  it "returns plain text from HTML" do
+    load_temporary "app.rb" do
+      response = request([["<p>text</p>", ""]])
+      expect(response.body[0]["text"]).to eq("text")
+    end
+  end
+
+  it "substitutes literal newline characters with a space" do
+    load_temporary "app.rb" do
+      response = request([["line1\n\nline2", ""]])
+      expect(response.body[0]["text"]).to eq("line1 line2")
+    end
+  end
+
+  it "substitutes <div> with a newline" do
+    load_temporary "app.rb" do
+      response = request([["line1<div>line2", ""]])
+      expect(response.body[0]["text"]).to eq("line1\nline2")
+    end
+  end
+
+  it "puts headings into their own line" do
+    load_temporary "app.rb" do
+      response = request([["<h1>heading</h1>content", ""]])
+      expect(response.body[0]["text"]).to eq("heading\ncontent")
+    end
+  end
+
+  it "extracts hyperlinks" do
+    load_temporary "app.rb" do
+      response = request([["<a href=\"https://www.gov.uk\">link text</a>", ""]])
+      expect(response.body[0]["hyperlinks"][0]).to eq({
+        "link_text" => "link text",
+        "link_url" => "https://www.gov.uk",
+        "link_url_bare" => "https://www.gov.uk",
+      })
+    end
+  end
+
+  it "strips parameters from URLs" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<a href=\"https://www.gov.uk/foo?param=bar\">link text</a>",
+        "https://www.gov.uk"
+      ]])
+      expect(response.body[0]["hyperlinks"][0]).to eq({
+        "link_text" => "link text",
+        "link_url" => "https://www.gov.uk/foo?param=bar",
+        "link_url_bare" => "https://www.gov.uk/foo",
+      })
+    end
+  end
+
+  it "strips anchors from URLs" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<a href=\"https://www.gov.uk#foo\">link text</a>",
+        "https://www.gov.uk"
+      ]])
+      expect(response.body[0]["hyperlinks"][0]).to eq({
+        "link_text" => "link text",
+        "link_url" => "https://www.gov.uk#foo",
+        "link_url_bare" => "https://www.gov.uk",
+      })
+    end
+  end
+
+  it "resolves relative links to the given domain" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<a href=\"/foo\">link text</a>",
+        "https://www.gov.uk"
+      ]])
+      expect(response.body[0]["hyperlinks"][0]).to eq({
+        "link_text" => "link text",
+        "link_url" => "https://www.gov.uk/foo",
+        "link_url_bare" => "https://www.gov.uk/foo",
+      })
+    end
+  end
+
+  it "resolves anchor links to the given domain" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<a href=\"#foo\">link text</a>",
+        "https://www.gov.uk"
+      ]])
+      expect(response.body[0]["hyperlinks"][0]).to eq({
+        "link_text" => "link text",
+        "link_url" => "https://www.gov.uk#foo",
+        "link_url_bare" => "https://www.gov.uk",
+      })
+    end
+  end
+
+  it "does not resolve absolute links to the given domain" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<a href=\"https://www.example.co.uk\">link text</a>",
+        "https://www.gov.uk"
+      ]])
+      expect(response.body[0]["hyperlinks"][0]).to eq({
+        "link_text" => "link text",
+        "link_url" => "https://www.example.co.uk",
+        "link_url_bare" => "https://www.example.co.uk",
+      })
+    end
+  end
+
+  it "extracts abbreviations" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<abbr title=\"Government Digital Service\">GDS</abbr>",
+        ""
+      ]])
+      expect(response.body[0]["abbreviations"][0]).to eq({
+        "text" => "GDS",
+        "title" => "Government Digital Service",
+      })
+    end
+  end
+end

--- a/docker/parse-html/spec/app_spec.rb
+++ b/docker/parse-html/spec/app_spec.rb
@@ -1,7 +1,6 @@
 require "rspec"
 require "functions_framework/testing"
 
-
 # Submit an http request, return an http response, with the body parsed into an
 # array of JSON objects.
 #
@@ -9,14 +8,14 @@ require "functions_framework/testing"
 # array has elements corresponding to the arguments of the function
 # parse_html().
 def request(calls)
-  body = {"calls" => calls}
+  body = { "calls" => calls }
   url = ""
   headers = ["Content-Type: application/json"]
   body = body.to_json.to_s
   request = make_post_request url, body, headers
   response = call_http "parse_html", request
   response.body = JSON.parse(response.body[0])["replies"]
-  return response
+  response
 end
 
 describe "parse_html() function" do
@@ -86,7 +85,7 @@ describe "parse_html() function" do
     load_temporary "app.rb" do
       response = request([[
         "<a href=\"https://www.gov.uk/foo?param=bar\">link text</a>",
-        "https://www.gov.uk"
+        "https://www.gov.uk",
       ]])
       expect(response.body[0]["hyperlinks"][0]).to eq({
         "link_text" => "link text",
@@ -100,7 +99,7 @@ describe "parse_html() function" do
     load_temporary "app.rb" do
       response = request([[
         "<a href=\"https://www.gov.uk#foo\">link text</a>",
-        "https://www.gov.uk"
+        "https://www.gov.uk",
       ]])
       expect(response.body[0]["hyperlinks"][0]).to eq({
         "link_text" => "link text",
@@ -114,7 +113,7 @@ describe "parse_html() function" do
     load_temporary "app.rb" do
       response = request([[
         "<a href=\"/foo\">link text</a>",
-        "https://www.gov.uk"
+        "https://www.gov.uk",
       ]])
       expect(response.body[0]["hyperlinks"][0]).to eq({
         "link_text" => "link text",
@@ -128,7 +127,7 @@ describe "parse_html() function" do
     load_temporary "app.rb" do
       response = request([[
         "<a href=\"#foo\">link text</a>",
-        "https://www.gov.uk"
+        "https://www.gov.uk",
       ]])
       expect(response.body[0]["hyperlinks"][0]).to eq({
         "link_text" => "link text",
@@ -142,7 +141,7 @@ describe "parse_html() function" do
     load_temporary "app.rb" do
       response = request([[
         "<a href=\"https://www.example.co.uk\">link text</a>",
-        "https://www.gov.uk"
+        "https://www.gov.uk",
       ]])
       expect(response.body[0]["hyperlinks"][0]).to eq({
         "link_text" => "link text",
@@ -156,7 +155,7 @@ describe "parse_html() function" do
     load_temporary "app.rb" do
       response = request([[
         "<abbr title=\"Government Digital Service\">GDS</abbr>",
-        ""
+        "",
       ]])
       expect(response.body[0]["abbreviations"][0]).to eq({
         "text" => "GDS",

--- a/terraform-dev/bigquery/parse-html.sql
+++ b/terraform-dev/bigquery/parse-html.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING)
+RETURNS JSON
+REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`
+OPTIONS (
+  endpoint = "${uri}",
+  max_batching_rows=1
+)

--- a/terraform-dev/cloud-run.tf
+++ b/terraform-dev/cloud-run.tf
@@ -1,0 +1,54 @@
+# A service to use as a remote function in BigQuery
+# Then create a place to put the app images
+resource "google_cloud_run_v2_service" "parse_html" {
+  name     = "parse-html"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    containers {
+      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+    }
+  }
+}
+
+data "google_iam_policy" "cloud_run_parse_html" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "serviceAccount:${google_bigquery_connection.govspeak_to_html.cloud_resource[0].service_account_id}",
+    ]
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_policy" "parse_html" {
+  location    = var.region
+  name        = google_cloud_run_v2_service.parse_html.name
+  policy_data = data.google_iam_policy.cloud_run_parse_html.policy_data
+}
+
+## Run a bigquery job to deploy the remote function
+resource "google_bigquery_job" "deploy_parse_html" {
+  job_id   = "d_job_${random_string.random.result}"
+  location = var.region
+
+  query {
+    priority = "INTERACTIVE"
+    query = templatefile(
+      "bigquery/parse-html.sql",
+      {
+        project_id = var.project_id
+        region     = var.region
+        uri        = google_cloud_run_v2_service.parse_html.uri
+      }
+    )
+    create_disposition = "" # must be set to "" for scripts
+    write_disposition  = "" # must be set to "" for scripts
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      google_cloud_run_v2_service.parse_html
+    ]
+  }
+}

--- a/terraform-staging/bigquery/parse-html.sql
+++ b/terraform-staging/bigquery/parse-html.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING)
+RETURNS JSON
+REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`
+OPTIONS (
+  endpoint = "${uri}",
+  max_batching_rows=1
+)

--- a/terraform-staging/cloud-run.tf
+++ b/terraform-staging/cloud-run.tf
@@ -1,0 +1,54 @@
+# A service to use as a remote function in BigQuery
+# Then create a place to put the app images
+resource "google_cloud_run_v2_service" "parse_html" {
+  name     = "parse-html"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    containers {
+      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+    }
+  }
+}
+
+data "google_iam_policy" "cloud_run_parse_html" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "serviceAccount:${google_bigquery_connection.govspeak_to_html.cloud_resource[0].service_account_id}",
+    ]
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_policy" "parse_html" {
+  location    = var.region
+  name        = google_cloud_run_v2_service.parse_html.name
+  policy_data = data.google_iam_policy.cloud_run_parse_html.policy_data
+}
+
+## Run a bigquery job to deploy the remote function
+resource "google_bigquery_job" "deploy_parse_html" {
+  job_id   = "d_job_${random_string.random.result}"
+  location = var.region
+
+  query {
+    priority = "INTERACTIVE"
+    query = templatefile(
+      "bigquery/parse-html.sql",
+      {
+        project_id = var.project_id
+        region     = var.region
+        uri        = google_cloud_run_v2_service.parse_html.uri
+      }
+    )
+    create_disposition = "" # must be set to "" for scripts
+    write_disposition  = "" # must be set to "" for scripts
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      google_cloud_run_v2_service.parse_html
+    ]
+  }
+}

--- a/terraform/bigquery/parse-html.sql
+++ b/terraform/bigquery/parse-html.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING)
+RETURNS JSON
+REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`
+OPTIONS (
+  endpoint = "${uri}",
+  max_batching_rows=1
+)

--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -1,0 +1,54 @@
+# A service to use as a remote function in BigQuery
+# Then create a place to put the app images
+resource "google_cloud_run_v2_service" "parse_html" {
+  name     = "parse-html"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    containers {
+      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+    }
+  }
+}
+
+data "google_iam_policy" "cloud_run_parse_html" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "serviceAccount:${google_bigquery_connection.govspeak_to_html.cloud_resource[0].service_account_id}",
+    ]
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_policy" "parse_html" {
+  location    = var.region
+  name        = google_cloud_run_v2_service.parse_html.name
+  policy_data = data.google_iam_policy.cloud_run_parse_html.policy_data
+}
+
+## Run a bigquery job to deploy the remote function
+resource "google_bigquery_job" "deploy_parse_html" {
+  job_id   = "d_job_${random_string.random.result}"
+  location = var.region
+
+  query {
+    priority = "INTERACTIVE"
+    query = templatefile(
+      "bigquery/parse-html.sql",
+      {
+        project_id = var.project_id
+        region     = var.region
+        uri        = google_cloud_run_v2_service.parse_html.uri
+      }
+    )
+    create_disposition = "" # must be set to "" for scripts
+    write_disposition  = "" # must be set to "" for scripts
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      google_cloud_run_v2_service.parse_html
+    ]
+  }
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/V5kpeEn0/192-make-govspeak-and-html-scripts-available-to-bigquery)

Implements part of https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/559

Depends on https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/561

# BigQuery Remote Function to Parse HTML

A function to parse a string of HTML passed in by BigQuery, and return things
extracted from the HTML, in the form that BigQuery expects (JSON).

## BigQuery Remote Functions

BigQuery supports various kinds of custom function, depending on whether it can
be implemented in

* pure SQL
* or a programming language that is supported by Cloud Functions v2, and that
  doesn't have any particular system requirements
* or a fully customised system, in Docker, hosted in Cloud Run.

We need a fully customised system, because we use Selenium with Chromedriver to
parse the HTML, and those can't be installed as Ruby gems.  Hence we use the third option, which is a Docker container hosted by Cloud Run.

## Goals

* Parse each HTML string only once, and extract several things from it. This
  lowers our BigQuery costs, which charge for the amount of data consumbed by
  each query, so if we parse the same HTML several times in different queries,
  then we are charged several times.
* Extract plain text as it is rendered by a browser. This is why we use Selenium
  and Chromedriver, which is a real browser, rather than nokogiri or
  beautifulsoup. The main difference is the handling of newlines for `<h1>` and
  `<div>` elements, and literal newline characters.
* Be available to BigQuery so that we can compose the entire data pipeline in
  SQL, where it is easier to test with frameworks such as DBT and SQLMesh.

## Tests

We use RSpec and a [GitHub
Action](https://github.com/alphagov/govuk-knowledge-graph-gcp/actions/workflows/ruby-lint-and-test.yml),
and `functions_framework`, which is Google's standard framework for testing
BigQuery remote functions.

```sh
cd docker/parse-html
rspec
```

## How to add features

More things can be extracted from HTML by adding code to the `app.rb` script in
the function `parse_html()` beneath the comment `# TODO: extract other things
from the HTML`.

## Alternatives

We previously [implemented](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/292/commits/6b15dd683f14a84d6cad1e904715280d76a343db) this in a virtual machine, using w3m to parse the HTML, Python to call w3m, gnu-parallel to handle parallelisation, and a Makefile to coordinate everything.

This had the following disadvantages.

* Inaccessible to ad hoc tasks
* Complex to scale
* Difficult to test
* Relatively slow (several minutes to process the Content Store)

