### PR TITLE
fix: scope bucket to project

### DIFF
--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -49,7 +49,7 @@ resource "google_bigquery_routine" "libphonenumber_find_phone_numbers_in_text" {
   )
   imported_libraries = [
     // From https://github.com/catamphetamine/libphonenumber-js
-    "gs://govuk-knowledge-graph-dev-lib/libphonenumber-max.js",
+    "gs://${google_storage_bucket_object.libphonenumber.bucket}/${google_storage_bucket_object.libphonenumber.output_name}",
   ]
   return_type = jsonencode(
     {

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -49,7 +49,7 @@ resource "google_bigquery_routine" "libphonenumber_find_phone_numbers_in_text" {
   )
   imported_libraries = [
     // From https://github.com/catamphetamine/libphonenumber-js
-    "gs://govuk-knowledge-graph-dev-lib/libphonenumber-max.js",
+    "gs://${google_storage_bucket_object.libphonenumber.bucket}/${google_storage_bucket_object.libphonenumber.output_name}",
   ]
   return_type = jsonencode(
     {

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -49,7 +49,7 @@ resource "google_bigquery_routine" "libphonenumber_find_phone_numbers_in_text" {
   )
   imported_libraries = [
     // From https://github.com/catamphetamine/libphonenumber-js
-    "gs://govuk-knowledge-graph-dev-lib/libphonenumber-max.js",
+    "gs://${google_storage_bucket_object.libphonenumber.bucket}/${google_storage_bucket_object.libphonenumber.output_name}",
   ]
   return_type = jsonencode(
     {


### PR DESCRIPTION
The terraform configuration of a BigQuery function mistakenly loaded a
javascript library from a bucket in the dev project, instead of loading
it from a bucket in the same project as the function belongs to.
