### PR TITLE
Fix: terraform bigquery jobs with random strings

### DIFF
--- a/terraform-dev/cloud-function.tf
+++ b/terraform-dev/cloud-function.tf
@@ -134,14 +134,14 @@ resource "google_bigquery_connection" "govspeak_to_html" {
 }
 
 # generate a random string suffix for a bigquery job to deploy the function
-resource "random_string" "random" {
+resource "random_string" "deploy_govspeak_to_html" {
   length  = 20
   special = false
 }
 
 ## Run a bigquery job to deploy the remote function
 resource "google_bigquery_job" "deploy_govspeak_to_html" {
-  job_id   = "d_job_${random_string.random.result}"
+  job_id   = "d_job_${random_string.deploy_govspeak_to_html.result}"
   location = var.region
 
   query {

--- a/terraform-dev/cloud-run.tf
+++ b/terraform-dev/cloud-run.tf
@@ -27,9 +27,15 @@ resource "google_cloud_run_v2_service_iam_policy" "parse_html" {
   policy_data = data.google_iam_policy.cloud_run_parse_html.policy_data
 }
 
+# generate a random string suffix for a bigquery job to deploy the function
+resource "random_string" "deploy_parse_html" {
+  length  = 20
+  special = false
+}
+
 ## Run a bigquery job to deploy the remote function
 resource "google_bigquery_job" "deploy_parse_html" {
-  job_id   = "d_job_${random_string.random.result}"
+  job_id   = "d_job_${random_string.deploy_parse_html.result}"
   location = var.region
 
   query {

--- a/terraform-staging/cloud-function.tf
+++ b/terraform-staging/cloud-function.tf
@@ -134,14 +134,14 @@ resource "google_bigquery_connection" "govspeak_to_html" {
 }
 
 # generate a random string suffix for a bigquery job to deploy the function
-resource "random_string" "random" {
+resource "random_string" "deploy_govspeak_to_html" {
   length  = 20
   special = false
 }
 
 ## Run a bigquery job to deploy the remote function
 resource "google_bigquery_job" "deploy_govspeak_to_html" {
-  job_id   = "d_job_${random_string.random.result}"
+  job_id   = "d_job_${random_string.deploy_govspeak_to_html.result}"
   location = var.region
 
   query {

--- a/terraform-staging/cloud-run.tf
+++ b/terraform-staging/cloud-run.tf
@@ -27,9 +27,15 @@ resource "google_cloud_run_v2_service_iam_policy" "parse_html" {
   policy_data = data.google_iam_policy.cloud_run_parse_html.policy_data
 }
 
+# generate a random string suffix for a bigquery job to deploy the function
+resource "random_string" "deploy_parse_html" {
+  length  = 20
+  special = false
+}
+
 ## Run a bigquery job to deploy the remote function
 resource "google_bigquery_job" "deploy_parse_html" {
-  job_id   = "d_job_${random_string.random.result}"
+  job_id   = "d_job_${random_string.deploy_parse_html.result}"
   location = var.region
 
   query {

--- a/terraform/cloud-function.tf
+++ b/terraform/cloud-function.tf
@@ -134,14 +134,14 @@ resource "google_bigquery_connection" "govspeak_to_html" {
 }
 
 # generate a random string suffix for a bigquery job to deploy the function
-resource "random_string" "random" {
+resource "random_string" "deploy_govspeak_to_html" {
   length  = 20
   special = false
 }
 
 ## Run a bigquery job to deploy the remote function
 resource "google_bigquery_job" "deploy_govspeak_to_html" {
-  job_id   = "d_job_${random_string.random.result}"
+  job_id   = "d_job_${random_string.deploy_govspeak_to_html.result}"
   location = var.region
 
   query {

--- a/terraform/cloud-run.tf
+++ b/terraform/cloud-run.tf
@@ -27,9 +27,15 @@ resource "google_cloud_run_v2_service_iam_policy" "parse_html" {
   policy_data = data.google_iam_policy.cloud_run_parse_html.policy_data
 }
 
+# generate a random string suffix for a bigquery job to deploy the function
+resource "random_string" "deploy_parse_html" {
+  length  = 20
+  special = false
+}
+
 ## Run a bigquery job to deploy the remote function
 resource "google_bigquery_job" "deploy_parse_html" {
-  job_id   = "d_job_${random_string.random.result}"
+  job_id   = "d_job_${random_string.deploy_parse_html.result}"
   location = var.region
 
   query {


### PR DESCRIPTION
The resource 'random_string' only creates one string, not one for every
time it is referenced.
