### PR TITLE
feat: import data from the Publisher app database

### DIFF
--- a/.github/workflows/docker-publisher-dev.yml
+++ b/.github/workflows/docker-publisher-dev.yml
@@ -1,0 +1,72 @@
+name: Docker-publisher-dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/publisher/**'
+      - '.github/workflows/docker-publisher-dev.yml'
+
+defaults:
+  run:
+    working-directory: docker/publisher
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'publisher'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-dev.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-publisher-staging.yml
+++ b/.github/workflows/docker-publisher-staging.yml
@@ -1,0 +1,72 @@
+name: Docker-publisher-staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - staging
+    paths:
+      - 'docker/publisher/**'
+      - '.github/workflows/docker-publisher-staging.yml'
+
+defaults:
+  run:
+    working-directory: docker/publisher
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'publisher'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/957740527277/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-staging.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-publisher.yml
+++ b/.github/workflows/docker-publisher.yml
@@ -1,0 +1,72 @@
+name: Docker-publisher
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/publisher/**'
+      - '.github/workflows/docker-publisher.yml'
+
+defaults:
+  run:
+    working-directory: docker/publisher
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'publisher'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/19513753240/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/docker/publisher/Dockerfile
+++ b/docker/publisher/Dockerfile
@@ -1,0 +1,31 @@
+FROM mongo:4.4.16
+
+# Install gcloud
+# https://cloud.google.com/sdk/docs/install#deb
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update -y
+RUN apt-get install -y \
+  apt-transport-https \
+  ca-certificates \
+  gnupg \
+  curl
+RUN \
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+  | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+  | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+  && apt-get update -y \
+  && apt-get install google-cloud-cli -y \
+  # Clean up
+  && rm -rf /var/lib/apt/lists/*
+
+ARG GITHUB_SHA=missing
+ENV GITHUB_SHA=${GITHUB_SHA}
+
+ARG GITHUB_REF=missing
+ENV GITHUB_REF=${GITHUB_REF}
+
+# Run a script from a copy of the HEAD of the repository
+CMD \
+  gcloud storage cat "gs://${PROJECT_ID}-repository/src/publisher/run.sh" \
+  | bash

--- a/src/content/run.sh
+++ b/src/content/run.sh
@@ -145,7 +145,10 @@ gcloud --project "${PROJECT_ID}" compute instances create mongodb \
     --zone="${ZONE}"
 
 date
-# Export the content_items table as CSV, to be loaded into BigQuery
+# Export the content_items table as CSV, to be loaded into BigQuery.
+#
+# Compression can cause trouble with big files or big columns. See
+# /src/postgres/functions.sh. But this file is small, with small columns.
 QUERY="\copy content_items TO STDOUT WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',');"
 DEST="gs://${PROJECT_ID}-data-processed/content-store/content_items.csv.gz"
 psql \

--- a/src/publisher/functions.sh
+++ b/src/publisher/functions.sh
@@ -1,0 +1,174 @@
+#! /bin/bash
+
+# Extract datasets of nodes, attributes and edges from the MongoDB content store
+# database.
+
+# Count the number of times that each distinct row of a CSV appears.
+#
+# This handles newlines in quoted columns.  You have to pass a comma-separated
+# list of column names that could contain newlines.
+#
+# Input is via stdin.
+#
+# Usage:
+# command_that_emits_csv | count_distinct escape_cols=col1,col2
+#
+# Where col1 and col2 are columns that might contain newlines.
+#
+# This depends on Python's CSV library to escape and unescape newline
+# characters.
+#
+# Performance (speed and memory) should be okay.  The Python steps are
+# parallelised, and only load a few lines at a time.  The unix steps are also
+# efficient.
+count_distinct () {
+  local escape_cols    # reset first
+  local "${@}"
+  python3 ../../src/utils/toggle_escapes.py \
+    --escape_cols=${escape_cols} \
+  | ( \
+    read -r; \
+    printf "count,%s\n" "$REPLY"; \
+    LC_ALL=C sort -S 100% \
+    | LC_ALL=C uniq -c \
+    | sed -E 's/(\s*)([[:digit:]]+)(\s+)/\2,/' \
+  ) \
+  | python3 ../../src/utils/toggle_escapes.py \
+    --unescape_cols=${escape_cols}
+}
+
+# Compress and upload to cloud bucket
+#
+# Usage:
+# command_that_emits_text | upload file_name=myfile
+#
+# The suffix ".csv.gz" is automatically appended to the file name.
+#
+# Single backslashes are doubled, because Neo4j interprets a single backslash as
+# an escape character.
+upload () {
+  local file_name # reset in case they are defined globally
+  local "${@}"
+  gzip -c \
+  | gcloud storage cp - "gs://${PROJECT_ID}-data-processed/content-store/${file_name}.csv.gz" --quiet
+}
+
+# Upload from cloud bucket to BigQuery table
+#
+# Usage:
+# send_to_bigquery file_name=myfile
+#
+# The suffix ".csv.gz" is automatically appended to the file name.
+send_to_bigquery () {
+  local file_name # reset in case they are defined globally
+  local "${@}"
+  bq load \
+    --quiet=true \
+    --replace \
+    --source_format="CSV" \
+    --allow_quoted_newlines \
+    --skip_leading_rows=1 \
+    "content.${file_name}" \
+    "gs://${PROJECT_ID}-data-processed/content-store/${file_name}.csv.gz"
+}
+
+# Wrapper around mongoexport to preset --db=content_store and --type=csv
+#
+# The `collection=` parameter is optional.  Its default is `content_items`.
+#
+# The `query=` parameter is optional.
+#
+# Usage:
+#
+# query_mongo \
+#   collection=my_collection \
+#   fields=col1,col2
+#
+# query_mongo \
+#   collection=my_collection \
+#   fields=col1,col2 \
+#   query='{ "my_field": { "$exists": true } }'
+query_mongo () {
+  local type collection fields query # reset in case they are defined globally
+  local "${@}"
+  mongoexport \
+    --quiet \
+    --db=content_store \
+    --type=${type:-csv} \
+    --collection=${collection:-content_items} \
+    --fields=${fields} \
+    --query="${query}"
+}
+
+# Wrappers around python scripts
+#
+# Use of these scripts requres type=json to be specified in the query_mongo
+# command.
+#
+# Usage:
+#
+# extract_text_from_html
+#   input_col=html \
+#   id_cols=url,html \
+#
+# extract_hyperlinks_from_html \
+#   input_col=html \
+#   id_cols=url \
+#
+# extract_abbreviations_from_html \
+#   input_col=html \
+#   id_cols=url \
+extract_text_from_html () {
+  local input_col id_cols # reset in case they are defined globally
+  local "${@}"
+  { echo $id_cols,text,text_without_blank_lines & \
+    parallel \
+      --pipe \
+      --round-robin \
+      --line-buffer \
+      --keep-order \
+      python3 ../../src/utils/extract_text_from_html.py \
+      --input_col=${input_col} \
+      --id_cols=${id_cols} \
+  ;}
+}
+extract_hyperlinks_from_html () {
+  local input_col id_cols # reset in case they are defined globally
+  local "${@}"
+  { echo $id_cols,link_url,link_url_bare,link_text & \
+    parallel \
+      --pipe \
+      --round-robin \
+      --line-buffer \
+      --keep-order \
+      python3 ../../src/utils/extract_hyperlinks_from_html.py \
+      --input_col=${input_col} \
+      --id_cols=${id_cols} \
+  ;}
+}
+extract_abbreviations_from_html () {
+  local input_col id_cols # reset in case they are defined globally
+  local "${@}"
+  { echo $id_cols,abbreviation_title,abbreviation_text & \
+    parallel \
+      --pipe \
+      --round-robin \
+      --line-buffer \
+      --keep-order \
+      python3 ../../src/utils/extract_abbreviations_from_html.py \
+      --input_col=${input_col} \
+      --id_cols=${id_cols} \
+  ;}
+}
+
+# Execute an SQL file in BigQuery
+#
+# Usage:
+# query_bigquery file_name=myfile.sql
+query_bigquery () {
+  local file_name # reset in case they are defined globally
+  local "${@}"
+  bq query \
+    --use_legacy_sql=false \
+    < "${file_name}"
+}

--- a/src/publisher/js/editions.js
+++ b/src/publisher/js/editions.js
@@ -1,0 +1,21 @@
+// The timestamp of every edition of every document in the Publisher app, with
+// some other metadata.  This date is more meaningful than the updated_at field
+// of the Publishing API, which includes many 'editions' that only exist for techy
+// reasons rather than editing reasons.
+//
+// db = govuk_content_production
+db.editions.aggregate([
+  // 'archived' editions were once 'published', and have since been superseded by
+  // a later edition.
+  { $match: { "state": { $in: [ "published", "archived" ] } } },
+  { $project: {
+    _id: false,
+    "url": { "$concat": [ "https://www.gov.uk/", "$slug" ] },
+    // created_at: true, // when the edition was first drafted
+    updated_at: true, // almost but not quite the same time as the updated_at of the corresponding edition in the Publishing API.
+    version_number: true, // sequence, sometimes in a different order from updated_at e.g. /1619-bursary-fund
+    state: true, // 'published', or 'archived' if superseded
+    major_change: true, // not often true
+  } },
+  { $out: "editions"},
+])

--- a/src/publisher/run.sh
+++ b/src/publisher/run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Run both mongod and scripts that interact with the database
+# https://docs.docker.com/config/containers/multi-service_container/
+
+# turn on bash's job control
+set -m
+
+# Start mongo and put it in the background
+mongod --nojournal &
+
+# Wait for mongo to start
+sleep 5
+
+# Restore the Publisher app database from its backup .bson file in GCP Storage
+
+# Construct the file's URL
+OBJECT=$(
+gcloud compute instances describe publisher \
+  --project $PROJECT_ID \
+  --zone $ZONE \
+  --format="value[separator=\"/\"](metadata.items.object_bucket, metadata.items.object_name)"
+)
+OBJECT_URL="gs://$OBJECT"
+
+# https://stackoverflow.com/questions/6575221
+gcloud storage cat "${OBJECT_URL}" \
+  | gunzip -c \
+  | mongorestore --archive
+
+# Obtain the latest state of the repository
+gcloud storage cp -r gs://$PROJECT_ID-repository/\* .
+
+# Prepare to export some data to BigQuery
+cd src/publisher
+
+DATABASE=govuk_content_production
+OUTPUT_COLLECTION=output
+FILE=editions
+OBJECT="gs://${PROJECT_ID}-data-processed/publisher/${FILE}.csv.gz"
+DATASET=publisher
+TABLE="${DATASET}.${FILE}"
+
+# Create a dataset in mongodb of relevant metadata about relevant editions of
+# documents.
+mongo ${DATABASE} js/${FILE}.js
+
+# 1. Export that dataset
+# 2. Upload it to a cloud bucket
+mongoexport \
+  --quiet \
+  --db=govuk_content_production \
+  --type=csv \
+  --collection="${OUTPUT_COLLECTION}" \
+  --fields=url,updated_at,version_number,state,major_change \
+  | gcloud storage cp - "${OBJECT}" --quiet --gzip-in-flight-all
+
+# Upload the dataset from the cloud bucket to a BigQuery table
+bq load \
+  --quiet=true \
+  --replace \
+  --source_format="CSV" \
+  --allow_quoted_newlines \
+  --skip_leading_rows=1 \
+  "${TABLE}" \
+  "${OBJECT}"
+
+# Stop this instance
+# https://stackoverflow.com/a/41232669
+gcloud compute instances delete publisher --quiet --zone=$ZONE

--- a/terraform-dev/artifact-registry.tf
+++ b/terraform-dev/artifact-registry.tf
@@ -40,9 +40,10 @@ data "google_iam_policy" "artifact_registry_docker" {
   binding {
     role = "roles/artifactregistry.reader"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
     ]
   }

--- a/terraform-dev/bigquery-publisher.tf
+++ b/terraform-dev/bigquery-publisher.tf
@@ -1,0 +1,48 @@
+# A dataset of tables from the Publisher app mongo database
+
+resource "google_bigquery_dataset" "publisher" {
+  dataset_id            = "publisher"
+  friendly_name         = "publisher"
+  description           = "Data from the GOV.UK Publisher app database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_publisher" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.gce_publisher.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_publisher_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "publisher" {
+  dataset_id  = google_bigquery_dataset.publisher.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_publisher.policy_data
+}
+
+resource "google_bigquery_table" "publisher_editions" {
+  dataset_id    = google_bigquery_dataset.publisher.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table derived from the GOV.UK Publisher app Mongo database"
+  schema        = file("schemas/publisher/editions.json")
+}

--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -42,6 +42,9 @@ storage_data_processed_object_viewer_members = [
 bigquery_content_data_viewer_members = [
 ]
 
+bigquery_publisher_data_viewer_members = [
+]
+
 # BigQuery dataset: functions
 bigquery_functions_data_viewer_members = [
 ]

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -136,6 +136,10 @@ variable "bigquery_content_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_publisher_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_functions_data_viewer_members" {
   type = list(string)
 }
@@ -285,13 +289,14 @@ data "google_iam_policy" "project" {
     role = "roles/bigquery.jobUser"
     members = concat(
       [
-        google_service_account.gce_mongodb.member,
-        google_service_account.gce_postgres.member,
-        google_service_account.gce_content.member,
         google_service_account.bigquery_page_transitions.member,
         google_service_account.bigquery_scheduled_queries_search.member,
-        google_service_account.workflow_bank_holidays.member,
+        google_service_account.gce_content.member,
+        google_service_account.gce_mongodb.member,
+        google_service_account.gce_postgres.member,
+        google_service_account.gce_publisher.member,
         google_service_account.govgraphsearch.member,
+        google_service_account.workflow_bank_holidays.member,
       ],
       var.bigquery_job_user_members
     )
@@ -357,9 +362,10 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/compute.instanceAdmin.v1"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.workflow_govuk_integration_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]

--- a/terraform-dev/schemas/publisher/editions.json
+++ b/terraform-dev/schemas/publisher/editions.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+  },
+  {
+    "name": "updated_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "description": "Almost but not quite the same time as the updated_at of the corresponding edition in the Publishing API"
+  },
+  {
+    "name": "version_number",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Sometimes in a different sequence from updated_at, e.g. /1619-bursary-fund"
+  },
+  {
+    "name": "state",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "'published', or 'archived' if supserseded"
+  },
+  {
+    "name": "major_change",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED",
+    "description": "Whether the edition was a major change to the previous edition. Rarely 'true'"
+  }
+]

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -47,9 +47,10 @@ data "google_iam_policy" "bucket_repository" {
   binding {
     role = "roles/storage.objectViewer"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
     ]
   }
 
@@ -105,9 +106,10 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.bigquery_page_transitions.member,
       google_service_account.workflow_bank_holidays.member,
     ]

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -13,17 +13,18 @@ resource "google_service_account" "eventarc" {
 resource "google_workflows_workflow" "govuk_integration_database_backups" {
   name            = "govuk-integration-database-backups"
   region          = var.region
-  description     = "Run a databases instances from their templates"
+  description     = "Run database instances from their templates"
   service_account = google_service_account.workflow_govuk_integration_database_backups.id
   source_contents = templatefile(
     "workflows/govuk-integration-database-backups.yaml",
     {
-      project_id              = var.project_id,
-      zone                    = var.zone,
-      postgres_startup_script = jsonencode(var.postgres-startup-script),
-      mongodb_metadata_value  = jsonencode(module.mongodb-container.metadata_value),
-      postgres_metadata_value = jsonencode(module.postgres-container.metadata_value)
-      content_metadata_value  = jsonencode(module.content-container.metadata_value)
+      project_id               = var.project_id
+      zone                     = var.zone
+      postgres_startup_script  = jsonencode(var.postgres-startup-script)
+      content_metadata_value   = jsonencode(module.content-container.metadata_value)
+      mongodb_metadata_value   = jsonencode(module.mongodb-container.metadata_value)
+      postgres_metadata_value  = jsonencode(module.postgres-container.metadata_value)
+      publisher_metadata_value = jsonencode(module.publisher-container.metadata_value)
     }
   )
 }

--- a/terraform-dev/workflows/govuk-integration-database-backups.yaml
+++ b/terraform-dev/workflows/govuk-integration-database-backups.yaml
@@ -91,6 +91,35 @@ main:
                           value: ${content_metadata_value}
           - return_started_content:
               return: $${"Started content instance"}
+        - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
+          steps:
+          - log_starting_publisher_instance:
+              call: sys.log
+              args:
+                  text: "Starting publisher instance"
+                  severity: INFO
+          - start_mongodb:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/publisher
+                  body:
+                      name: publisher
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${publisher_metadata_value}
+          - return_started_publisher:
+              return: $${"Started publisher instance"}
   - log_not_starting_instance:
       call: sys.log
       args:

--- a/terraform-staging/artifact-registry.tf
+++ b/terraform-staging/artifact-registry.tf
@@ -40,9 +40,10 @@ data "google_iam_policy" "artifact_registry_docker" {
   binding {
     role = "roles/artifactregistry.reader"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
     ]
   }

--- a/terraform-staging/bigquery-publisher.tf
+++ b/terraform-staging/bigquery-publisher.tf
@@ -1,0 +1,48 @@
+# A dataset of tables from the Publisher app mongo database
+
+resource "google_bigquery_dataset" "publisher" {
+  dataset_id            = "publisher"
+  friendly_name         = "publisher"
+  description           = "Data from the GOV.UK Publisher app database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_publisher" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.gce_publisher.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_publisher_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "publisher" {
+  dataset_id  = google_bigquery_dataset.publisher.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_publisher.policy_data
+}
+
+resource "google_bigquery_table" "publisher_editions" {
+  dataset_id    = google_bigquery_dataset.publisher.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table derived from the GOV.UK Publisher app Mongo database"
+  schema        = file("schemas/publisher/editions.json")
+}

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -43,6 +43,9 @@ storage_data_processed_object_viewer_members = [
 bigquery_content_data_viewer_members = [
 ]
 
+bigquery_publisher_data_viewer_members = [
+]
+
 # BigQuery dataset: functions
 bigquery_functions_data_viewer_members = [
 ]

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -136,6 +136,10 @@ variable "bigquery_content_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_publisher_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_functions_data_viewer_members" {
   type = list(string)
 }
@@ -285,13 +289,14 @@ data "google_iam_policy" "project" {
     role = "roles/bigquery.jobUser"
     members = concat(
       [
-        google_service_account.gce_mongodb.member,
-        google_service_account.gce_postgres.member,
-        google_service_account.gce_content.member,
         google_service_account.bigquery_page_transitions.member,
         google_service_account.bigquery_scheduled_queries_search.member,
-        google_service_account.workflow_bank_holidays.member,
+        google_service_account.gce_content.member,
+        google_service_account.gce_mongodb.member,
+        google_service_account.gce_postgres.member,
+        google_service_account.gce_publisher.member,
         google_service_account.govgraphsearch.member,
+        google_service_account.workflow_bank_holidays.member,
       ],
       var.bigquery_job_user_members
     )
@@ -357,9 +362,10 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/compute.instanceAdmin.v1"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.workflow_govuk_integration_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]

--- a/terraform-staging/schemas/publisher/editions.json
+++ b/terraform-staging/schemas/publisher/editions.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+  },
+  {
+    "name": "updated_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "description": "Almost but not quite the same time as the updated_at of the corresponding edition in the Publishing API"
+  },
+  {
+    "name": "version_number",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Sometimes in a different sequence from updated_at, e.g. /1619-bursary-fund"
+  },
+  {
+    "name": "state",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "'published', or 'archived' if supserseded"
+  },
+  {
+    "name": "major_change",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED",
+    "description": "Whether the edition was a major change to the previous edition. Rarely 'true'"
+  }
+]

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -47,9 +47,10 @@ data "google_iam_policy" "bucket_repository" {
   binding {
     role = "roles/storage.objectViewer"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
     ]
   }
 
@@ -105,9 +106,10 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.bigquery_page_transitions.member,
       google_service_account.workflow_bank_holidays.member,
     ]

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -13,17 +13,18 @@ resource "google_service_account" "eventarc" {
 resource "google_workflows_workflow" "govuk_integration_database_backups" {
   name            = "govuk-integration-database-backups"
   region          = var.region
-  description     = "Run a databases instances from their templates"
+  description     = "Run database instances from their templates"
   service_account = google_service_account.workflow_govuk_integration_database_backups.id
   source_contents = templatefile(
     "workflows/govuk-integration-database-backups.yaml",
     {
-      project_id              = var.project_id,
-      zone                    = var.zone,
-      postgres_startup_script = jsonencode(var.postgres-startup-script),
-      mongodb_metadata_value  = jsonencode(module.mongodb-container.metadata_value),
-      postgres_metadata_value = jsonencode(module.postgres-container.metadata_value)
-      content_metadata_value  = jsonencode(module.content-container.metadata_value)
+      project_id               = var.project_id
+      zone                     = var.zone
+      postgres_startup_script  = jsonencode(var.postgres-startup-script)
+      content_metadata_value   = jsonencode(module.content-container.metadata_value)
+      mongodb_metadata_value   = jsonencode(module.mongodb-container.metadata_value)
+      postgres_metadata_value  = jsonencode(module.postgres-container.metadata_value)
+      publisher_metadata_value = jsonencode(module.publisher-container.metadata_value)
     }
   )
 }

--- a/terraform-staging/workflows/govuk-integration-database-backups.yaml
+++ b/terraform-staging/workflows/govuk-integration-database-backups.yaml
@@ -91,6 +91,35 @@ main:
                           value: ${content_metadata_value}
           - return_started_content:
               return: $${"Started content instance"}
+        - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
+          steps:
+          - log_starting_publisher_instance:
+              call: sys.log
+              args:
+                  text: "Starting publisher instance"
+                  severity: INFO
+          - start_mongodb:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/publisher
+                  body:
+                      name: publisher
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${publisher_metadata_value}
+          - return_started_publisher:
+              return: $${"Started publisher instance"}
   - log_not_starting_instance:
       call: sys.log
       args:

--- a/terraform/artifact-registry.tf
+++ b/terraform/artifact-registry.tf
@@ -40,9 +40,10 @@ data "google_iam_policy" "artifact_registry_docker" {
   binding {
     role = "roles/artifactregistry.reader"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
     ]
   }

--- a/terraform/bigquery-publisher.tf
+++ b/terraform/bigquery-publisher.tf
@@ -1,0 +1,48 @@
+# A dataset of tables from the Publisher app mongo database
+
+resource "google_bigquery_dataset" "publisher" {
+  dataset_id            = "publisher"
+  friendly_name         = "publisher"
+  description           = "Data from the GOV.UK Publisher app database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_publisher" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.gce_publisher.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_publisher_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "publisher" {
+  dataset_id  = google_bigquery_dataset.publisher.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_publisher.policy_data
+}
+
+resource "google_bigquery_table" "publisher_editions" {
+  dataset_id    = google_bigquery_dataset.publisher.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table derived from the GOV.UK Publisher app Mongo database"
+  schema        = file("schemas/publisher/editions.json")
+}

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -49,6 +49,10 @@ bigquery_content_data_viewer_members = [
   "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
 ]
 
+# BigQuery dataset: publisher
+bigquery_publisher_data_viewer_members = [
+]
+
 # BigQuery dataset: functions
 bigquery_functions_data_viewer_members = [
   "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -136,6 +136,10 @@ variable "bigquery_content_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_publisher_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_functions_data_viewer_members" {
   type = list(string)
 }
@@ -285,13 +289,14 @@ data "google_iam_policy" "project" {
     role = "roles/bigquery.jobUser"
     members = concat(
       [
-        google_service_account.gce_mongodb.member,
-        google_service_account.gce_postgres.member,
-        google_service_account.gce_content.member,
         google_service_account.bigquery_page_transitions.member,
         google_service_account.bigquery_scheduled_queries_search.member,
-        google_service_account.workflow_bank_holidays.member,
+        google_service_account.gce_content.member,
+        google_service_account.gce_mongodb.member,
+        google_service_account.gce_postgres.member,
+        google_service_account.gce_publisher.member,
         google_service_account.govgraphsearch.member,
+        google_service_account.workflow_bank_holidays.member,
       ],
       var.bigquery_job_user_members
     )
@@ -357,9 +362,10 @@ data "google_iam_policy" "project" {
   binding {
     role = "roles/compute.instanceAdmin.v1"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.workflow_govuk_integration_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]

--- a/terraform/schemas/publisher/editions.json
+++ b/terraform/schemas/publisher/editions.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+  },
+  {
+    "name": "updated_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "description": "Almost but not quite the same time as the updated_at of the corresponding edition in the Publishing API"
+  },
+  {
+    "name": "version_number",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Sometimes in a different sequence from updated_at, e.g. /1619-bursary-fund"
+  },
+  {
+    "name": "state",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "'published', or 'archived' if supserseded"
+  },
+  {
+    "name": "major_change",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED",
+    "description": "Whether the edition was a major change to the previous edition. Rarely 'true'"
+  }
+]

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -47,9 +47,10 @@ data "google_iam_policy" "bucket_repository" {
   binding {
     role = "roles/storage.objectViewer"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
     ]
   }
 
@@ -105,9 +106,10 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
+      google_service_account.gce_content.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_postgres.member,
-      google_service_account.gce_content.member,
+      google_service_account.gce_publisher.member,
       google_service_account.bigquery_page_transitions.member,
       google_service_account.workflow_bank_holidays.member,
     ]

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -13,17 +13,18 @@ resource "google_service_account" "eventarc" {
 resource "google_workflows_workflow" "govuk_integration_database_backups" {
   name            = "govuk-integration-database-backups"
   region          = var.region
-  description     = "Run a databases instances from their templates"
+  description     = "Run database instances from their templates"
   service_account = google_service_account.workflow_govuk_integration_database_backups.id
   source_contents = templatefile(
     "workflows/govuk-integration-database-backups.yaml",
     {
-      project_id              = var.project_id,
-      zone                    = var.zone,
-      postgres_startup_script = jsonencode(var.postgres-startup-script),
-      mongodb_metadata_value  = jsonencode(module.mongodb-container.metadata_value),
-      postgres_metadata_value = jsonencode(module.postgres-container.metadata_value)
-      content_metadata_value  = jsonencode(module.content-container.metadata_value)
+      project_id               = var.project_id
+      zone                     = var.zone
+      postgres_startup_script  = jsonencode(var.postgres-startup-script)
+      content_metadata_value   = jsonencode(module.content-container.metadata_value)
+      mongodb_metadata_value   = jsonencode(module.mongodb-container.metadata_value)
+      postgres_metadata_value  = jsonencode(module.postgres-container.metadata_value)
+      publisher_metadata_value = jsonencode(module.publisher-container.metadata_value)
     }
   )
 }

--- a/terraform/workflows/govuk-integration-database-backups.yaml
+++ b/terraform/workflows/govuk-integration-database-backups.yaml
@@ -91,6 +91,35 @@ main:
                           value: ${content_metadata_value}
           - return_started_content:
               return: $${"Started content instance"}
+        - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
+          steps:
+          - log_starting_publisher_instance:
+              call: sys.log
+              args:
+                  text: "Starting publisher instance"
+                  severity: INFO
+          - start_mongodb:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/publisher
+                  body:
+                      name: publisher
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${publisher_metadata_value}
+          - return_started_publisher:
+              return: $${"Started publisher instance"}
   - log_not_starting_instance:
       call: sys.log
       args:


### PR DESCRIPTION
Closes #586

The `updated_at` and `public_updated_at` fields in the Publishing API
(and downstream in the Content API) aren't good for telling when a
document was updated in the Publisher app, which is most mainstream
content.

Publisher app database backup files are [now
available in a GCP bucket](https://github.com/alphagov/govuk-s3-mirror/pull/53).

We're interested in ones with state 'archived' or 'published'.
Unfortunately the timestamps don't quite match the Publishing API
database, being out by a few seconds, so matching the editions will be
tricky.

An example query to join the Publisher data to the Publishing data, by
approximate timestamp:

```sh
with real_updates as (SELECT
  a.base_path,
  a.updated_at,
  a.public_updated_at,
FROM
  `govuk-knowledge-graph-dev.test.publishing-publisher` AS a -- the Publishing API data
where EXISTS(
  SELECT
    TRUE
  FROM
    `govuk-knowledge-graph-dev.test.publisher-updated-at` AS b -- the Publisher app data
  WHERE
    a.base_path = '/' || b.slug
    and a.updated_at >= b.updated_at
    AND timestamp_diff(a.updated_at, b.updated_at, second) <= 60)
),
latest as (select base_path, max(updated_at) as updated_at from real_updates group by base_path)
select * from latest order by updated_at
```

References:
* https://trello.com/c/pzNnETtk/119-add-data-about-when-a-content-item-had-either-a-major-or-minor-update-to-the-content-* api
* https://trello.com/c/J6zfW1EK/13-publishing-api-has-many-inaccurate-dates
* https://github.com/alphagov/publishing-api/pull/1597
* https://gds.slack.com/archives/C02CM46TD52/p1688046251340989
* https://gov-uk.atlassian.net/wiki/spaces/CC/pages/32145674/Using+Publisher
