### PR TITLE
Allow users to view the publisher dataset

### DIFF
--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -51,6 +51,7 @@ bigquery_content_data_viewer_members = [
 
 # BigQuery dataset: publisher
 bigquery_publisher_data_viewer_members = [
+  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
 ]
 
 # BigQuery dataset: functions


### PR DESCRIPTION
Nothing in the dataset is sensitive.
