### PR TITLE
fix: add url parameter to parse_html() in BigQuery

### DIFF
--- a/terraform-dev/bigquery/parse-html.sql
+++ b/terraform-dev/bigquery/parse-html.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING)
+CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING, url STRING)
 RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`
 OPTIONS (

--- a/terraform-staging/bigquery/parse-html.sql
+++ b/terraform-staging/bigquery/parse-html.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING)
+CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING, url STRING)
 RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`
 OPTIONS (

--- a/terraform/bigquery/parse-html.sql
+++ b/terraform/bigquery/parse-html.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING)
+CREATE OR REPLACE FUNCTION `${project_id}.functions.parse_html`(html STRING, url STRING)
 RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`
 OPTIONS (


### PR DESCRIPTION
The parameter was missing in the BigQuery wrapper of the Cloud Function.
