### PR TITLE
feat: tables to populate govsearch dropdowns

### DIFF
--- a/terraform-dev/bigquery-search.tf
+++ b/terraform-dev/bigquery-search.tf
@@ -46,6 +46,30 @@ resource "google_bigquery_dataset_iam_policy" "search" {
   policy_data = data.google_iam_policy.bigquery_dataset_search.policy_data
 }
 
+resource "google_bigquery_table" "search_document_type" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "document_type"
+  friendly_name = "Distinct document types"
+  description   = "Distinct document types for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/document-type.json")
+}
+
+resource "google_bigquery_table" "search_locale" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "locale"
+  friendly_name = "Distinct locales"
+  description   = "Distinct locales for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/locale.json")
+}
+
+resource "google_bigquery_table" "search_organisation" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "organisation"
+  friendly_name = "Distinct organisations"
+  description   = "Distinct organisations for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/organisation.json")
+}
+
 resource "google_bigquery_table" "search_page" {
   dataset_id    = google_bigquery_dataset.search.dataset_id
   table_id      = "page"
@@ -64,6 +88,39 @@ resource "google_bigquery_table" "search_taxon" {
 
 # Because these queries are scheduled, without any way to manage their
 # dependencies on source tables, they musn't use each other as a source.
+resource "google_bigquery_data_transfer_config" "search_document_type" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Document type"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/document-type.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
+resource "google_bigquery_data_transfer_config" "search_locale" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Locale"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/locale.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
+resource "google_bigquery_data_transfer_config" "search_organisation" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Organisation"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/organisation.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
 resource "google_bigquery_data_transfer_config" "search_page" {
   data_source_id = "scheduled_query" # This is a magic word
   display_name   = "Page"

--- a/terraform-dev/bigquery/document-type.sql
+++ b/terraform-dev/bigquery/document-type.sql
@@ -1,0 +1,4 @@
+TRUNCATE TABLE search.document_type;
+INSERT INTO search.document_type
+SELECT DISTINCT document_type.document_type
+FROM content.document_type

--- a/terraform-dev/bigquery/locale.sql
+++ b/terraform-dev/bigquery/locale.sql
@@ -1,0 +1,4 @@
+TRUNCATE TABLE search.locale;
+INSERT INTO search.locale
+SELECT DISTINCT locale.locale
+FROM content.locale

--- a/terraform-dev/bigquery/organisation.sql
+++ b/terraform-dev/bigquery/organisation.sql
@@ -1,0 +1,10 @@
+TRUNCATE TABLE search.organisation;
+INSERT INTO search.organisation
+SELECT DISTINCT title.title
+FROM content.title
+INNER JOIN content.document_type USING (url)
+INNER JOIN content.locale USING (url)
+WHERE
+  TRUE
+  AND document_type.document_type = 'organisation'
+  AND locale.locale = 'en'

--- a/terraform-dev/schemas/search/document-type.json
+++ b/terraform-dev/schemas/search/document-type.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "document_type",
+        "type": "STRING",
+        "description": "Internal name of a taxon"
+    }
+]

--- a/terraform-dev/schemas/search/locale.json
+++ b/terraform-dev/schemas/search/locale.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "locale",
+        "type": "STRING",
+        "description": "The ISO 639-1 two-letter code of the language of an edition on GOV.UK"
+    }
+]

--- a/terraform-dev/schemas/search/organisation.json
+++ b/terraform-dev/schemas/search/organisation.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "title",
+        "type": "STRING",
+        "description": "Title of an organisation"
+    }
+]

--- a/terraform-staging/bigquery-search.tf
+++ b/terraform-staging/bigquery-search.tf
@@ -46,6 +46,30 @@ resource "google_bigquery_dataset_iam_policy" "search" {
   policy_data = data.google_iam_policy.bigquery_dataset_search.policy_data
 }
 
+resource "google_bigquery_table" "search_document_type" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "document_type"
+  friendly_name = "Distinct document types"
+  description   = "Distinct document types for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/document-type.json")
+}
+
+resource "google_bigquery_table" "search_locale" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "locale"
+  friendly_name = "Distinct locales"
+  description   = "Distinct locales for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/locale.json")
+}
+
+resource "google_bigquery_table" "search_organisation" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "organisation"
+  friendly_name = "Distinct organisations"
+  description   = "Distinct organisations for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/organisation.json")
+}
+
 resource "google_bigquery_table" "search_page" {
   dataset_id    = google_bigquery_dataset.search.dataset_id
   table_id      = "page"
@@ -64,6 +88,39 @@ resource "google_bigquery_table" "search_taxon" {
 
 # Because these queries are scheduled, without any way to manage their
 # dependencies on source tables, they musn't use each other as a source.
+resource "google_bigquery_data_transfer_config" "search_document_type" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Document type"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/document-type.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
+resource "google_bigquery_data_transfer_config" "search_locale" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Locale"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/locale.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
+resource "google_bigquery_data_transfer_config" "search_organisation" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Organisation"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/organisation.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
 resource "google_bigquery_data_transfer_config" "search_page" {
   data_source_id = "scheduled_query" # This is a magic word
   display_name   = "Page"

--- a/terraform-staging/bigquery/document-type.sql
+++ b/terraform-staging/bigquery/document-type.sql
@@ -1,0 +1,4 @@
+TRUNCATE TABLE search.document_type;
+INSERT INTO search.document_type
+SELECT DISTINCT document_type.document_type
+FROM content.document_type

--- a/terraform-staging/bigquery/locale.sql
+++ b/terraform-staging/bigquery/locale.sql
@@ -1,0 +1,4 @@
+TRUNCATE TABLE search.locale;
+INSERT INTO search.locale
+SELECT DISTINCT locale.locale
+FROM content.locale

--- a/terraform-staging/bigquery/organisation.sql
+++ b/terraform-staging/bigquery/organisation.sql
@@ -1,0 +1,10 @@
+TRUNCATE TABLE search.organisation;
+INSERT INTO search.organisation
+SELECT DISTINCT title.title
+FROM content.title
+INNER JOIN content.document_type USING (url)
+INNER JOIN content.locale USING (url)
+WHERE
+  TRUE
+  AND document_type.document_type = 'organisation'
+  AND locale.locale = 'en'

--- a/terraform-staging/schemas/search/document-type.json
+++ b/terraform-staging/schemas/search/document-type.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "document_type",
+        "type": "STRING",
+        "description": "Internal name of a taxon"
+    }
+]

--- a/terraform-staging/schemas/search/locale.json
+++ b/terraform-staging/schemas/search/locale.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "locale",
+        "type": "STRING",
+        "description": "The ISO 639-1 two-letter code of the language of an edition on GOV.UK"
+    }
+]

--- a/terraform-staging/schemas/search/organisation.json
+++ b/terraform-staging/schemas/search/organisation.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "title",
+        "type": "STRING",
+        "description": "Title of an organisation"
+    }
+]

--- a/terraform/bigquery-search.tf
+++ b/terraform/bigquery-search.tf
@@ -46,6 +46,30 @@ resource "google_bigquery_dataset_iam_policy" "search" {
   policy_data = data.google_iam_policy.bigquery_dataset_search.policy_data
 }
 
+resource "google_bigquery_table" "search_document_type" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "document_type"
+  friendly_name = "Distinct document types"
+  description   = "Distinct document types for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/document-type.json")
+}
+
+resource "google_bigquery_table" "search_locale" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "locale"
+  friendly_name = "Distinct locales"
+  description   = "Distinct locales for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/locale.json")
+}
+
+resource "google_bigquery_table" "search_organisation" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "organisation"
+  friendly_name = "Distinct organisations"
+  description   = "Distinct organisations for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/organisation.json")
+}
+
 resource "google_bigquery_table" "search_page" {
   dataset_id    = google_bigquery_dataset.search.dataset_id
   table_id      = "page"
@@ -64,6 +88,39 @@ resource "google_bigquery_table" "search_taxon" {
 
 # Because these queries are scheduled, without any way to manage their
 # dependencies on source tables, they musn't use each other as a source.
+resource "google_bigquery_data_transfer_config" "search_document_type" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Document type"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/document-type.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
+resource "google_bigquery_data_transfer_config" "search_locale" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Locale"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/locale.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
+resource "google_bigquery_data_transfer_config" "search_organisation" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Organisation"
+  location       = var.region
+  schedule       = "every day 06:00"
+  params = {
+    query = file("bigquery/organisation.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries_search.email
+}
+
 resource "google_bigquery_data_transfer_config" "search_page" {
   data_source_id = "scheduled_query" # This is a magic word
   display_name   = "Page"

--- a/terraform/bigquery/document-type.sql
+++ b/terraform/bigquery/document-type.sql
@@ -1,0 +1,4 @@
+TRUNCATE TABLE search.document_type;
+INSERT INTO search.document_type
+SELECT DISTINCT document_type.document_type
+FROM content.document_type

--- a/terraform/bigquery/locale.sql
+++ b/terraform/bigquery/locale.sql
@@ -1,0 +1,4 @@
+TRUNCATE TABLE search.locale;
+INSERT INTO search.locale
+SELECT DISTINCT locale.locale
+FROM content.locale

--- a/terraform/bigquery/organisation.sql
+++ b/terraform/bigquery/organisation.sql
@@ -1,0 +1,10 @@
+TRUNCATE TABLE search.organisation;
+INSERT INTO search.organisation
+SELECT DISTINCT title.title
+FROM content.title
+INNER JOIN content.document_type USING (url)
+INNER JOIN content.locale USING (url)
+WHERE
+  TRUE
+  AND document_type.document_type = 'organisation'
+  AND locale.locale = 'en'

--- a/terraform/schemas/search/document-type.json
+++ b/terraform/schemas/search/document-type.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "document_type",
+        "type": "STRING",
+        "description": "Internal name of a taxon"
+    }
+]

--- a/terraform/schemas/search/locale.json
+++ b/terraform/schemas/search/locale.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "locale",
+        "type": "STRING",
+        "description": "The ISO 639-1 two-letter code of the language of an edition on GOV.UK"
+    }
+]

--- a/terraform/schemas/search/organisation.json
+++ b/terraform/schemas/search/organisation.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "title",
+        "type": "STRING",
+        "description": "Title of an organisation"
+    }
+]


### PR DESCRIPTION
Corresponds to https://github.com/alphagov/govuk-knowledge-graph-search/issues/63

It will save money by allowing GovSearch to query for exactly the data
that it needs, rather than filtering bigger datasets, which it otherwise
does for every new session.

The queries are also adapted to run from the `content` dataset (which is
raw data), rather than the `graph` dataset (which is derived data), so
that the `graph` dataset can eventually be removed.
