### PR TITLE
chore: revoke some GovSearch dataset permissions

### DIFF
--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -30,7 +30,6 @@ data "google_iam_policy" "bigquery_dataset_content" {
     members = concat([
       "projectReaders",
       google_service_account.bigquery_scheduled_queries_search.member,
-      google_service_account.govgraphsearch.member,
       ],
       var.bigquery_content_data_viewer_members,
     )

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -29,7 +29,6 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     members = concat(
       [
         "projectReaders",
-        google_service_account.govgraphsearch.member,
         google_service_account.bigquery_scheduled_queries_search.member,
       ],
       var.bigquery_graph_data_viewer_members,

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -30,7 +30,6 @@ data "google_iam_policy" "bigquery_dataset_content" {
     members = concat([
       "projectReaders",
       google_service_account.bigquery_scheduled_queries_search.member,
-      google_service_account.govgraphsearch.member,
       ],
       var.bigquery_content_data_viewer_members,
     )

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -29,7 +29,6 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     members = concat(
       [
         "projectReaders",
-        google_service_account.govgraphsearch.member,
         google_service_account.bigquery_scheduled_queries_search.member,
       ],
       var.bigquery_graph_data_viewer_members,

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -30,7 +30,6 @@ data "google_iam_policy" "bigquery_dataset_content" {
     members = concat([
       "projectReaders",
       google_service_account.bigquery_scheduled_queries_search.member,
-      google_service_account.govgraphsearch.member,
       ],
       var.bigquery_content_data_viewer_members,
     )

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -29,7 +29,6 @@ data "google_iam_policy" "bigquery_dataset_graph" {
     members = concat(
       [
         "projectReaders",
-        google_service_account.govgraphsearch.member,
         google_service_account.bigquery_scheduled_queries_search.member,
       ],
       var.bigquery_graph_data_viewer_members,


### PR DESCRIPTION
Following
https://github.com/alphagov/govuk-knowledge-graph-search/pull/233
GovSearch only needs access to the `search` dataset.
