### PR TITLE
feat: bigquery datasets - private and public

### DIFF
--- a/terraform-dev/bigquery-private.tf
+++ b/terraform-dev/bigquery-private.tf
@@ -1,0 +1,39 @@
+# A dataset of tables derived from elsewhere that must not be accessible from
+# outside of GOV.UK.
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id            = "private"
+  friendly_name         = "Private"
+  description           = "Data that must not be accessible from outside of GOV.UK"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_private" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+      ],
+      var.bigquery_private_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "private" {
+  dataset_id  = google_bigquery_dataset.private.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_private.policy_data
+}

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -1,0 +1,39 @@
+# A dataset of tables derived from elsewhere that may be accessible from outside
+# of GOV.UK.
+
+resource "google_bigquery_dataset" "public" {
+  dataset_id            = "public"
+  friendly_name         = "Public"
+  description           = "Data that must not be accessible from outside of GOV.UK"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_public" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+      ],
+      var.bigquery_public_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "public" {
+  dataset_id  = google_bigquery_dataset.public.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
+}

--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -39,9 +39,19 @@ bigquery_job_user_members = [
 storage_data_processed_object_viewer_members = [
 ]
 
+# BigQuery dataset: private
+bigquery_private_data_viewer_members = [
+]
+
+# BigQuery dataset: public
+bigquery_public_data_viewer_members = [
+]
+
+# BigQuery dataset: content
 bigquery_content_data_viewer_members = [
 ]
 
+# BigQuery dataset: publisher
 bigquery_publisher_data_viewer_members = [
 ]
 

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -148,6 +148,14 @@ variable "bigquery_graph_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_private_data_viewer_members" {
+  type = list(string)
+}
+
+variable "bigquery_public_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_publishing_api_data_viewer_members" {
   type = list(string)
 }

--- a/terraform-staging/bigquery-private.tf
+++ b/terraform-staging/bigquery-private.tf
@@ -1,0 +1,39 @@
+# A dataset of tables derived from elsewhere that must not be accessible from
+# outside of GOV.UK.
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id            = "private"
+  friendly_name         = "Private"
+  description           = "Data that must not be accessible from outside of GOV.UK"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_private" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+      ],
+      var.bigquery_private_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "private" {
+  dataset_id  = google_bigquery_dataset.private.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_private.policy_data
+}

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -1,0 +1,39 @@
+# A dataset of tables derived from elsewhere that may be accessible from outside
+# of GOV.UK.
+
+resource "google_bigquery_dataset" "public" {
+  dataset_id            = "public"
+  friendly_name         = "Public"
+  description           = "Data that must not be accessible from outside of GOV.UK"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_public" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+      ],
+      var.bigquery_public_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "public" {
+  dataset_id  = google_bigquery_dataset.public.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
+}

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -40,9 +40,20 @@ bigquery_job_user_members = [
 storage_data_processed_object_viewer_members = [
 ]
 
+# BigQuery dataset: private
+bigquery_private_data_viewer_members = [
+]
+
+# BigQuery dataset: public
+bigquery_public_data_viewer_members = [
+]
+
+
+# BigQuery dataset: content
 bigquery_content_data_viewer_members = [
 ]
 
+# BigQuery dataset: publisher
 bigquery_publisher_data_viewer_members = [
 ]
 

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -148,6 +148,14 @@ variable "bigquery_graph_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_private_data_viewer_members" {
+  type = list(string)
+}
+
+variable "bigquery_public_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_publishing_api_data_viewer_members" {
   type = list(string)
 }

--- a/terraform/bigquery-private.tf
+++ b/terraform/bigquery-private.tf
@@ -1,0 +1,39 @@
+# A dataset of tables derived from elsewhere that must not be accessible from
+# outside of GOV.UK.
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id            = "private"
+  friendly_name         = "Private"
+  description           = "Data that must not be accessible from outside of GOV.UK"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_private" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+      ],
+      var.bigquery_private_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "private" {
+  dataset_id  = google_bigquery_dataset.private.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_private.policy_data
+}

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -1,0 +1,39 @@
+# A dataset of tables derived from elsewhere that may be accessible from outside
+# of GOV.UK.
+
+resource "google_bigquery_dataset" "public" {
+  dataset_id            = "public"
+  friendly_name         = "Public"
+  description           = "Data that must not be accessible from outside of GOV.UK"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_public" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+      ],
+      var.bigquery_public_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "public" {
+  dataset_id  = google_bigquery_dataset.public.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
+}

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -42,6 +42,14 @@ storage_data_processed_object_viewer_members = [
   "group:data-products@digital.cabinet-office.gov.uk",
 ]
 
+# BigQuery dataset: private
+bigquery_private_data_viewer_members = [
+]
+
+# BigQuery dataset: public
+bigquery_public_data_viewer_members = [
+]
+
 bigquery_content_data_viewer_members = [
   "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
   "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -148,6 +148,14 @@ variable "bigquery_graph_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_private_data_viewer_members" {
+  type = list(string)
+}
+
+variable "bigquery_public_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_publishing_api_data_viewer_members" {
   type = list(string)
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/mlKACiMO/112-govgraph-make-some-data-open)

Create two new BigQuery datasets, called 'private' and 'public', for
data that doesn't belong elsewhere.

An example of data that belongs in the 'private' dataset is data that is
derived from the Publishing API data in the 'publishing-api' dataset,
and that must not be publicly available.

An example of data that belongs in the 'public' dataset is data that is
derived from the Content API data in the 'content-api' dataset,
and that may be publicly available.

An example of data that doesn't belong in either the 'public' or
'private' datasets is data that is used directly by the GovSearch app.
It is better for that data to be in its own dataset, so that the
GovSearch app can be granted access to only the data that it needs, and
no more.
