### PR TITLE
feat: don't store table metadata check results

### DIFF
--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -63,36 +63,8 @@ resource "google_bigquery_table" "tables_metadata" {
   description   = "Table modified date and row count, sorted ascending"
   view {
     use_legacy_sql = false
-    query          = <<EOF
-WITH tables AS (
-  SELECT * FROM content.__TABLES__
-  UNION ALL
-  SELECT * FROM graph.__TABLES__
-  UNION ALL
-  SELECT * FROM publishing_api.__TABLES__
-  UNION ALL
-  SELECT * FROM search.__TABLES__
-)
-SELECT
-  dataset_id,
-  table_id,
-  TIMESTAMP_MILLIS(last_modified_time) AS last_modified,
-  row_count
-FROM tables
-ORDER BY
-  last_modified,
-  row_count
-;
-EOF
+    query          = file("bigquery/tables-metadata.sql")
   }
-}
-
-resource "google_bigquery_table" "tables_metadata_check_results" {
-  dataset_id    = google_bigquery_dataset.test.dataset_id
-  table_id      = "tables-metadata-check-results"
-  friendly_name = "Tables metadata check results"
-  description   = "Results of the previous run of the check-tables-metatdata scheduled query"
-  schema        = file("schemas/test/tables-metadata-check-results.json")
 }
 
 resource "google_bigquery_data_transfer_config" "check_tables_metadata" {

--- a/terraform-dev/bigquery/check-tables-metadata.sql
+++ b/terraform-dev/bigquery/check-tables-metadata.sql
@@ -1,8 +1,6 @@
 -- Fail with an error message when certain conditions in the
 -- `test.tables-metadata` view are met.
 -- Errors will be picked up in the logs, generating an alert.
-TRUNCATE TABLE `test.tables-metadata-check-results`;
-INSERT INTO `test.tables-metadata-check-results`
 SELECT
   *,
   CASE

--- a/terraform-dev/bigquery/tables-metadata.sql
+++ b/terraform-dev/bigquery/tables-metadata.sql
@@ -1,0 +1,23 @@
+-- For alerting and debugging.
+--
+-- For each table in the project, its modified date and row count, sorted
+-- ascending.
+WITH tables AS (
+  SELECT * FROM content.__TABLES__
+  UNION ALL
+  SELECT * FROM graph.__TABLES__
+  UNION ALL
+  SELECT * FROM publishing_api.__TABLES__
+  UNION ALL
+  SELECT * FROM search.__TABLES__
+)
+SELECT
+  dataset_id,
+  table_id,
+  TIMESTAMP_MILLIS(last_modified_time) AS last_modified,
+  row_count
+FROM tables
+ORDER BY
+  last_modified,
+  row_count
+;

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -63,36 +63,8 @@ resource "google_bigquery_table" "tables_metadata" {
   description   = "Table modified date and row count, sorted ascending"
   view {
     use_legacy_sql = false
-    query          = <<EOF
-WITH tables AS (
-  SELECT * FROM content.__TABLES__
-  UNION ALL
-  SELECT * FROM graph.__TABLES__
-  UNION ALL
-  SELECT * FROM publishing_api.__TABLES__
-  UNION ALL
-  SELECT * FROM search.__TABLES__
-)
-SELECT
-  dataset_id,
-  table_id,
-  TIMESTAMP_MILLIS(last_modified_time) AS last_modified,
-  row_count
-FROM tables
-ORDER BY
-  last_modified,
-  row_count
-;
-EOF
+    query          = file("bigquery/tables-metadata.sql")
   }
-}
-
-resource "google_bigquery_table" "tables_metadata_check_results" {
-  dataset_id    = google_bigquery_dataset.test.dataset_id
-  table_id      = "tables-metadata-check-results"
-  friendly_name = "Tables metadata check results"
-  description   = "Results of the previous run of the check-tables-metatdata scheduled query"
-  schema        = file("schemas/test/tables-metadata-check-results.json")
 }
 
 resource "google_bigquery_data_transfer_config" "check_tables_metadata" {

--- a/terraform-staging/bigquery/check-tables-metadata.sql
+++ b/terraform-staging/bigquery/check-tables-metadata.sql
@@ -1,8 +1,6 @@
 -- Fail with an error message when certain conditions in the
 -- `test.tables-metadata` view are met.
 -- Errors will be picked up in the logs, generating an alert.
-TRUNCATE TABLE `test.tables-metadata-check-results`;
-INSERT INTO `test.tables-metadata-check-results`
 SELECT
   *,
   CASE

--- a/terraform-staging/bigquery/tables-metadata.sql
+++ b/terraform-staging/bigquery/tables-metadata.sql
@@ -1,0 +1,23 @@
+-- For alerting and debugging.
+--
+-- For each table in the project, its modified date and row count, sorted
+-- ascending.
+WITH tables AS (
+  SELECT * FROM content.__TABLES__
+  UNION ALL
+  SELECT * FROM graph.__TABLES__
+  UNION ALL
+  SELECT * FROM publishing_api.__TABLES__
+  UNION ALL
+  SELECT * FROM search.__TABLES__
+)
+SELECT
+  dataset_id,
+  table_id,
+  TIMESTAMP_MILLIS(last_modified_time) AS last_modified,
+  row_count
+FROM tables
+ORDER BY
+  last_modified,
+  row_count
+;

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -63,36 +63,8 @@ resource "google_bigquery_table" "tables_metadata" {
   description   = "Table modified date and row count, sorted ascending"
   view {
     use_legacy_sql = false
-    query          = <<EOF
-WITH tables AS (
-  SELECT * FROM content.__TABLES__
-  UNION ALL
-  SELECT * FROM graph.__TABLES__
-  UNION ALL
-  SELECT * FROM publishing_api.__TABLES__
-  UNION ALL
-  SELECT * FROM search.__TABLES__
-)
-SELECT
-  dataset_id,
-  table_id,
-  TIMESTAMP_MILLIS(last_modified_time) AS last_modified,
-  row_count
-FROM tables
-ORDER BY
-  last_modified,
-  row_count
-;
-EOF
+    query          = file("bigquery/tables-metadata.sql")
   }
-}
-
-resource "google_bigquery_table" "tables_metadata_check_results" {
-  dataset_id    = google_bigquery_dataset.test.dataset_id
-  table_id      = "tables-metadata-check-results"
-  friendly_name = "Tables metadata check results"
-  description   = "Results of the previous run of the check-tables-metatdata scheduled query"
-  schema        = file("schemas/test/tables-metadata-check-results.json")
 }
 
 resource "google_bigquery_data_transfer_config" "check_tables_metadata" {

--- a/terraform/bigquery/check-tables-metadata.sql
+++ b/terraform/bigquery/check-tables-metadata.sql
@@ -1,8 +1,6 @@
 -- Fail with an error message when certain conditions in the
 -- `test.tables-metadata` view are met.
 -- Errors will be picked up in the logs, generating an alert.
-TRUNCATE TABLE `test.tables-metadata-check-results`;
-INSERT INTO `test.tables-metadata-check-results`
 SELECT
   *,
   CASE

--- a/terraform/bigquery/tables-metadata.sql
+++ b/terraform/bigquery/tables-metadata.sql
@@ -1,0 +1,23 @@
+-- For alerting and debugging.
+--
+-- For each table in the project, its modified date and row count, sorted
+-- ascending.
+WITH tables AS (
+  SELECT * FROM content.__TABLES__
+  UNION ALL
+  SELECT * FROM graph.__TABLES__
+  UNION ALL
+  SELECT * FROM publishing_api.__TABLES__
+  UNION ALL
+  SELECT * FROM search.__TABLES__
+)
+SELECT
+  dataset_id,
+  table_id,
+  TIMESTAMP_MILLIS(last_modified_time) AS last_modified,
+  row_count
+FROM tables
+ORDER BY
+  last_modified,
+  row_count
+;


### PR DESCRIPTION
- Stop storing the results of the hourly check of table metadata. It
  wasn't ever useful. Instead, we always look at the
  `test.tables-metadata` view.
- Refactor the definition of the `test.tables-metadata` view query
  to be in a separate file.
