### PR TITLE
feat: new vm and dataset 'content-api'

### DIFF
--- a/.github/workflows/docker-content-api-dev.yml
+++ b/.github/workflows/docker-content-api-dev.yml
@@ -1,0 +1,73 @@
+name: Docker-content-api-dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/content-api/Dockerfile'
+      - 'docker/content-api/entrypoint.sh'
+      - '.github/workflows/docker-content-api-dev.yml'
+
+defaults:
+  run:
+    working-directory: docker/content-api
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'content-api'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-dev.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-content-api-staging.yml
+++ b/.github/workflows/docker-content-api-staging.yml
@@ -1,0 +1,73 @@
+name: Docker-content-api-staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - staging
+    paths:
+      - 'docker/content-api/Dockerfile'
+      - 'docker/content-api/entrypoint.sh'
+      - '.github/workflows/docker-content-api-staging.yml'
+
+defaults:
+  run:
+    working-directory: docker/content-api
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'content-api'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/957740527277/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-staging.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-content-api.yml
+++ b/.github/workflows/docker-content-api.yml
@@ -1,0 +1,73 @@
+name: Docker-content-api
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/content-api/Dockerfile'
+      - 'docker/content-api/entrypoint.sh'
+      - '.github/workflows/docker-content-api.yml'
+
+defaults:
+  run:
+    working-directory: docker/content-api
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'content-api'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/19513753240/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/docker/content-api/Dockerfile
+++ b/docker/content-api/Dockerfile
@@ -1,0 +1,31 @@
+FROM postgres:16.0-alpine3.18
+
+# Install the gcloud CLI, a specific version from a long-term archive
+# Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
+ENV CLOUD_SDK_VERSION=452.0.1
+ENV PATH /google-cloud-sdk/bin:$PATH
+RUN addgroup -g 1000 -S cloudsdk && \
+    adduser -u 1000 -S cloudsdk -G cloudsdk
+RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
+RUN ARCH=`cat /tmp/arch` && apk --no-cache add \
+        curl \
+        python3 \
+        py3-crcmod \
+        py3-openssl \
+        bash \
+        libc6-compat \
+        openssh-client \
+        gnupg \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
+
+# Reset the postgres entrypoint to the docker default, so that we can run our
+# own CMD
+ENTRYPOINT []
+COPY entrypoint.sh .
+CMD bash entrypoint.sh

--- a/docker/content-api/entrypoint.sh
+++ b/docker/content-api/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Run a script from a copy of the HEAD of the repository
+# This sometimes fails with
+#
+# > ERROR: (gcloud.storage.cat) You do not currently have an active account selected.
+#
+# So retry for a few minutes.  Newly-built containers don't seem to work
+# immediately.
+
+MAX_RETRIES=10
+RETRY_INTERVAL_SECONDS=60
+COUNTER=0
+CMD="gcloud storage cat gs://${PROJECT_ID}-repository/src/content-api/run.sh"
+
+while [ $COUNTER -lt $MAX_RETRIES ]; do
+  $CMD
+  if [ $? -eq 0 ]; then
+    break
+  else
+    echo "Command failed, retrying in ${RETRY_INTERVAL_SECONDS} seconds..."
+    sleep $RETRY_INTERVAL_SECONDS
+    let COUNTER=COUNTER+1
+  fi
+done
+
+if [ $COUNTER -eq $MAX_RETRIES ]; then
+  echo "Command failed after $MAX_RETRIES attempts, exiting..."
+  exit 1
+fi
+
+$CMD | bash

--- a/src/content-api/postgresql.conf.safe
+++ b/src/content-api/postgresql.conf.safe
@@ -1,0 +1,782 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'		# use data in another directory
+					# (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+#port = 5432				# (change requires restart)
+max_connections = 100			# (change requires restart)
+#superuser_reserved_connections = 3	# (change requires restart)
+#unix_socket_directories = '/var/run/postgresql'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+#tcp_user_timeout = 0			# TCP_USER_TIMEOUT, in milliseconds;
+					# 0 selects the system default
+
+# - Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+#password_encryption = md5		# md5 or scram-sha-256
+#db_user_namespace = off
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
+#krb_caseins_users = off
+
+# - SSL -
+
+#ssl = off
+#ssl_ca_file = ''
+#ssl_cert_file = 'server.crt'
+#ssl_crl_file = ''
+#ssl_key_file = 'server.key'
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+#ssl_prefer_server_ciphers = on
+#ssl_ecdh_curve = 'prime256v1'
+#ssl_min_protocol_version = 'TLSv1.2'
+#ssl_max_protocol_version = ''
+#ssl_dh_params_file = ''
+#ssl_passphrase_command = ''
+#ssl_passphrase_command_supports_reload = off
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = 4GB			# min 128kB, up to 25% of total memory is okay
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
+					# (change requires restart)
+#temp_buffers = 8MB			# min 800kB
+#max_prepared_transactions = 0		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+work_mem = 32MB				# min 64kB
+#hash_mem_multiplier = 1.0		# 1-1000.0 multiplier on hash table work_mem
+maintenance_work_mem = 2GB		# min 1MB, good for creating indexes
+#autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+#logical_decoding_work_mem = 64MB	# min 64kB
+#max_stack_depth = 2MB			# min 100kB
+#shared_memory_type = mmap		# the default is the first option
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+dynamic_shared_memory_type = posix	# the default is the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-process temp file space
+					# in kilobytes, or -1 for no limit
+
+# - Kernel Resources -
+
+#max_files_per_process = 1000		# min 64
+					# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-100 milliseconds (0 disables)
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 10		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 512kB		# measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
+#max_worker_processes = 8		# (change requires restart)
+#max_parallel_maintenance_workers = 2	# taken from max_parallel_workers
+#max_parallel_workers_per_gather = 2	# taken from max_parallel_workers
+#parallel_leader_participation = on
+#max_parallel_workers = 8		# maximum number of max_worker_processes that
+					# can be used in parallel operations
+#old_snapshot_threshold = -1		# 1min-60d; -1 disables; 0 is immediate
+					# (change requires restart)
+#backend_flush_after = 0		# measured in pages, 0 disables
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = replica			# minimal, replica, or logical
+					# (change requires restart)
+fsync = on				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
+synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, remote_apply, or on
+#wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+full_page_writes = on			# recover from partial page writes
+#wal_compression = off			# enable compression of full-page writes
+#wal_log_hints = off			# also do full page writes of non-critical updates
+					# (change requires restart)
+#wal_init_zero = on			# zero-fill new WAL files
+#wal_recycle = on			# recycle WAL files
+#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+#wal_writer_flush_after = 1MB		# measured in pages, 0 disables
+#wal_skip_threshold = 2MB
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_timeout = 5min		# range 30s-1d
+max_wal_size = 1GB
+min_wal_size = 80MB
+#checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_flush_after = 256kB		# measured in pages, 0 disables
+#checkpoint_warning = 30s		# 0 disables
+
+# - Archiving -
+
+#archive_mode = off		# enables archiving; off, on, or always
+				# (change requires restart)
+#archive_command = ''		# command to use to archive a logfile segment
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a logfile segment switch after this
+				# number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+#restore_command = ''		# command to use to restore an archived logfile segment
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
+				# (change requires restart)
+#archive_cleanup_command = ''	# command to execute at every restartpoint
+#recovery_end_command = ''	# command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+#recovery_target = ''		# 'immediate' to end recovery as soon as a
+                                # consistent state is reached
+				# (change requires restart)
+#recovery_target_name = ''	# the named restore point to which recovery will proceed
+				# (change requires restart)
+#recovery_target_time = ''	# the time stamp up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_xid = ''	# the transaction ID up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_lsn = ''	# the WAL LSN up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_inclusive = on # Specifies whether to stop:
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
+#recovery_target_timeline = 'latest'	# 'current', 'latest', or timeline ID
+				# (change requires restart)
+#recovery_target_action = 'pause'	# 'pause', 'promote', 'shutdown'
+				# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the master and on any standby that will send replication data.
+
+max_wal_senders = 0		# max number of walsender processes
+				# (change requires restart)
+#wal_keep_size = 0		# in megabytes; 0 disables
+#max_slot_wal_keep_size = -1	# in megabytes; -1 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+
+#max_replication_slots = 10	# max number of replication slots
+				# (change requires restart)
+#track_commit_timestamp = off	# collect timestamp of transaction commit
+				# (change requires restart)
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+#primary_conninfo = ''			# connection string to sending server
+#primary_slot_name = ''			# replication slot on sending server
+#promote_trigger_file = ''		# file name whose presence ends recovery
+#hot_standby = on			# "off" disallows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_create_temp_slot = off	# create temp slot if primary_slot_name
+					# is not set
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from master
+					# in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
+#recovery_min_apply_delay = 0		# minimum delay for applying changes during recovery
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4	# taken from max_worker_processes
+					# (change requires restart)
+#max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_parallel_append = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_incremental_sort = on
+#enable_tidscan = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_parallel_hash = on
+#enable_partition_pruning = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#parallel_tuple_cost = 0.1		# same scale as above
+#parallel_setup_cost = 1000.0	# same scale as above
+
+#jit_above_cost = 100000		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+#jit_inline_above_cost = 500000		# inline small functions if query is
+					# more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
+
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
+#effective_cache_size = 4GB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+#force_parallel_mode = off
+#jit = on				# allow JIT compilation
+#plan_cache_mode = auto			# auto, force_generic_plan or
+					# force_custom_plan
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, syslog, and eventlog,
+					# depending on platform.  csvlog
+					# requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off		# Enable capturing of stderr and csvlog
+					# into log files. Required to be on for
+					# csvlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'log'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
+					# can include strftime() escapes
+#log_file_mode = 0600			# creation mode for log files,
+					# begin with 0 to use octal notation
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+#log_rotation_age = 1d			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (win32):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#log_min_messages = warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+#log_min_duration_sample = -1		# -1 is disabled, 0 logs a sample of statements
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
+
+#log_statement_sample_rate = 1.0	# fraction of logged statements exceeding
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
+
+#log_transaction_sample_rate = 0.0	# fraction of transactions whose statements
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = '%m [%p] '		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_parameter_max_length = -1		# when logging statements, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_parameter_max_length_on_error = 0	# when logging an error, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_statement = 'none'			# none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+log_timezone = 'Etc/UTC'
+
+#------------------------------------------------------------------------------
+# PROCESS TITLE
+#------------------------------------------------------------------------------
+
+#cluster_name = ''			# added to process titles if nonempty
+					# (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query and Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none			# none, pl, all
+#track_activity_query_size = 1024	# (change requires restart)
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#log_autovacuum_min_duration = -1	# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_vacuum_insert_threshold = 1000	# min number of row inserts
+					# before vacuum; -1 disables insert
+					# vacuums
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_vacuum_insert_scale_factor = 0.2	# fraction of inserts over table
+					# size before insert vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+					# before forced vacuum
+					# (change requires restart)
+#autovacuum_vacuum_cost_delay = 2ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+#search_path = '"$user", public'	# schema names
+#row_security = on
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#default_table_access_method = 'heap'
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0			# in milliseconds, 0 is disabled
+#lock_timeout = 0			# in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
+#vacuum_cleanup_index_scale_factor = 0.1	# fraction of total number of tuples
+						# before index cleanup, 0 always performs
+						# index cleanup
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_fuzzy_search_limit = 0
+#gin_pending_list_limit = 4MB
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'Etc/UTC'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 1			# min -15, max 3; any value >0 actually
+					# selects precise output mode
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.utf8'			# locale for system error message
+					# strings
+lc_monetary = 'en_US.utf8'			# locale for monetary formatting
+lc_numeric = 'en_US.utf8'			# locale for number formatting
+lc_time = 'en_US.utf8'				# locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Shared Library Preloading -
+
+#shared_preload_libraries = ''	# (change requires restart)
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+#jit_provider = 'llvmjit'		# JIT library to use
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#extension_destdir = ''			# prepend path when loading extensions
+					# and shared objects (added by Debian)
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+#max_pred_locks_per_relation = -2	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2            # min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#escape_string_warning = on
+#lo_compat_privileges = off
+#operator_precedence_warning = off
+#quote_all_identifiers = off
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+#data_sync_retry = off			# retry or panic on failure to fsync
+					# data?
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+#include_dir = '...'			# include files ending in '.conf' from
+					# a directory, e.g., 'conf.d'
+#include_if_exists = '...'		# include file only if it exists
+#include = '...'			# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/src/content-api/postgresql.conf.write-optimised
+++ b/src/content-api/postgresql.conf.write-optimised
@@ -1,0 +1,782 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'		# use data in another directory
+					# (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+#port = 5432				# (change requires restart)
+max_connections = 100			# (change requires restart)
+#superuser_reserved_connections = 3	# (change requires restart)
+#unix_socket_directories = '/var/run/postgresql'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+#tcp_user_timeout = 0			# TCP_USER_TIMEOUT, in milliseconds;
+					# 0 selects the system default
+
+# - Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+#password_encryption = md5		# md5 or scram-sha-256
+#db_user_namespace = off
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
+#krb_caseins_users = off
+
+# - SSL -
+
+#ssl = off
+#ssl_ca_file = ''
+#ssl_cert_file = 'server.crt'
+#ssl_crl_file = ''
+#ssl_key_file = 'server.key'
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+#ssl_prefer_server_ciphers = on
+#ssl_ecdh_curve = 'prime256v1'
+#ssl_min_protocol_version = 'TLSv1.2'
+#ssl_max_protocol_version = ''
+#ssl_dh_params_file = ''
+#ssl_passphrase_command = ''
+#ssl_passphrase_command_supports_reload = off
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = 4GB			# min 128kB, up to 25% of total memory is okay
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
+					# (change requires restart)
+#temp_buffers = 8MB			# min 800kB
+#max_prepared_transactions = 0		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+work_mem = 32MB				# min 64kB
+#hash_mem_multiplier = 1.0		# 1-1000.0 multiplier on hash table work_mem
+maintenance_work_mem = 2GB		# min 1MB, good for creating indexes
+#autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+#logical_decoding_work_mem = 64MB	# min 64kB
+#max_stack_depth = 2MB			# min 100kB
+#shared_memory_type = mmap		# the default is the first option
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+dynamic_shared_memory_type = posix	# the default is the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-process temp file space
+					# in kilobytes, or -1 for no limit
+
+# - Kernel Resources -
+
+#max_files_per_process = 1000		# min 64
+					# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-100 milliseconds (0 disables)
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 10		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 512kB		# measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
+#max_worker_processes = 8		# (change requires restart)
+#max_parallel_maintenance_workers = 2	# taken from max_parallel_workers
+#max_parallel_workers_per_gather = 2	# taken from max_parallel_workers
+#parallel_leader_participation = on
+#max_parallel_workers = 8		# maximum number of max_worker_processes that
+					# can be used in parallel operations
+#old_snapshot_threshold = -1		# 1min-60d; -1 disables; 0 is immediate
+					# (change requires restart)
+#backend_flush_after = 0		# measured in pages, 0 disables
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = minimal			# minimal, replica, or logical
+					# (change requires restart)
+fsync = off				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
+synchronous_commit = off		# synchronization level;
+					# off, local, remote_write, remote_apply, or on
+#wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+full_page_writes = off			# recover from partial page writes
+#wal_compression = off			# enable compression of full-page writes
+#wal_log_hints = off			# also do full page writes of non-critical updates
+					# (change requires restart)
+#wal_init_zero = on			# zero-fill new WAL files
+#wal_recycle = on			# recycle WAL files
+#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+#wal_writer_flush_after = 1MB		# measured in pages, 0 disables
+#wal_skip_threshold = 2MB
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_timeout = 5min		# range 30s-1d
+max_wal_size = 1GB
+min_wal_size = 80MB
+#checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_flush_after = 256kB		# measured in pages, 0 disables
+#checkpoint_warning = 30s		# 0 disables
+
+# - Archiving -
+
+#archive_mode = off		# enables archiving; off, on, or always
+				# (change requires restart)
+#archive_command = ''		# command to use to archive a logfile segment
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a logfile segment switch after this
+				# number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+#restore_command = ''		# command to use to restore an archived logfile segment
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
+				# (change requires restart)
+#archive_cleanup_command = ''	# command to execute at every restartpoint
+#recovery_end_command = ''	# command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+#recovery_target = ''		# 'immediate' to end recovery as soon as a
+                                # consistent state is reached
+				# (change requires restart)
+#recovery_target_name = ''	# the named restore point to which recovery will proceed
+				# (change requires restart)
+#recovery_target_time = ''	# the time stamp up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_xid = ''	# the transaction ID up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_lsn = ''	# the WAL LSN up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_inclusive = on # Specifies whether to stop:
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
+#recovery_target_timeline = 'latest'	# 'current', 'latest', or timeline ID
+				# (change requires restart)
+#recovery_target_action = 'pause'	# 'pause', 'promote', 'shutdown'
+				# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the master and on any standby that will send replication data.
+
+max_wal_senders = 0		# max number of walsender processes
+				# (change requires restart)
+#wal_keep_size = 0		# in megabytes; 0 disables
+#max_slot_wal_keep_size = -1	# in megabytes; -1 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+
+#max_replication_slots = 10	# max number of replication slots
+				# (change requires restart)
+#track_commit_timestamp = off	# collect timestamp of transaction commit
+				# (change requires restart)
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+#primary_conninfo = ''			# connection string to sending server
+#primary_slot_name = ''			# replication slot on sending server
+#promote_trigger_file = ''		# file name whose presence ends recovery
+#hot_standby = on			# "off" disallows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_create_temp_slot = off	# create temp slot if primary_slot_name
+					# is not set
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from master
+					# in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
+#recovery_min_apply_delay = 0		# minimum delay for applying changes during recovery
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4	# taken from max_worker_processes
+					# (change requires restart)
+#max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_parallel_append = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_incremental_sort = on
+#enable_tidscan = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_parallel_hash = on
+#enable_partition_pruning = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#parallel_tuple_cost = 0.1		# same scale as above
+#parallel_setup_cost = 1000.0	# same scale as above
+
+#jit_above_cost = 100000		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+#jit_inline_above_cost = 500000		# inline small functions if query is
+					# more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
+
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
+#effective_cache_size = 4GB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+#force_parallel_mode = off
+#jit = on				# allow JIT compilation
+#plan_cache_mode = auto			# auto, force_generic_plan or
+					# force_custom_plan
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, syslog, and eventlog,
+					# depending on platform.  csvlog
+					# requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off		# Enable capturing of stderr and csvlog
+					# into log files. Required to be on for
+					# csvlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'log'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
+					# can include strftime() escapes
+#log_file_mode = 0600			# creation mode for log files,
+					# begin with 0 to use octal notation
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+#log_rotation_age = 1d			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (win32):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#log_min_messages = warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+#log_min_duration_sample = -1		# -1 is disabled, 0 logs a sample of statements
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
+
+#log_statement_sample_rate = 1.0	# fraction of logged statements exceeding
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
+
+#log_transaction_sample_rate = 0.0	# fraction of transactions whose statements
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = '%m [%p] '		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_parameter_max_length = -1		# when logging statements, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_parameter_max_length_on_error = 0	# when logging an error, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_statement = 'none'			# none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+log_timezone = 'Etc/UTC'
+
+#------------------------------------------------------------------------------
+# PROCESS TITLE
+#------------------------------------------------------------------------------
+
+#cluster_name = ''			# added to process titles if nonempty
+					# (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query and Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none			# none, pl, all
+#track_activity_query_size = 1024	# (change requires restart)
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#log_autovacuum_min_duration = -1	# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_vacuum_insert_threshold = 1000	# min number of row inserts
+					# before vacuum; -1 disables insert
+					# vacuums
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_vacuum_insert_scale_factor = 0.2	# fraction of inserts over table
+					# size before insert vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+					# before forced vacuum
+					# (change requires restart)
+#autovacuum_vacuum_cost_delay = 2ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+#search_path = '"$user", public'	# schema names
+#row_security = on
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#default_table_access_method = 'heap'
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0			# in milliseconds, 0 is disabled
+#lock_timeout = 0			# in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
+#vacuum_cleanup_index_scale_factor = 0.1	# fraction of total number of tuples
+						# before index cleanup, 0 always performs
+						# index cleanup
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_fuzzy_search_limit = 0
+#gin_pending_list_limit = 4MB
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'Etc/UTC'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 1			# min -15, max 3; any value >0 actually
+					# selects precise output mode
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.utf8'			# locale for system error message
+					# strings
+lc_monetary = 'en_US.utf8'			# locale for monetary formatting
+lc_numeric = 'en_US.utf8'			# locale for number formatting
+lc_time = 'en_US.utf8'				# locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Shared Library Preloading -
+
+#shared_preload_libraries = ''	# (change requires restart)
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+#jit_provider = 'llvmjit'		# JIT library to use
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#extension_destdir = ''			# prepend path when loading extensions
+					# and shared objects (added by Debian)
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+#max_pred_locks_per_relation = -2	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2            # min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#escape_string_warning = on
+#lo_compat_privileges = off
+#operator_precedence_warning = off
+#quote_all_identifiers = off
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+#data_sync_retry = off			# retry or panic on failure to fsync
+					# data?
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+#include_dir = '...'			# include files ending in '.conf' from
+					# a directory, e.g., 'conf.d'
+#include_if_exists = '...'		# include file only if it exists
+#include = '...'			# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/src/content-api/run.sh
+++ b/src/content-api/run.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Increase the amount of shared memory available.
+# This requires the container to run in privileged mode.
+# It prevents a postgres error
+# "could not resize shared memory segment: No space left on device"
+mount -o remount,size=8G /dev/shm
+
+# Run both postgres and scripts that interact with the database
+
+# Obtain the latest state of the repository
+echo "fetch repo"
+gcloud storage cp -r "gs://${PROJECT_ID}-repository/*" .
+
+# turn on bash's job control
+set -m
+
+# Start postgres in the background.  The docker-entrypoint.sh script is on the
+# path, and handles users and permissions
+# https://stackoverflow.com/a/48880635/937932
+cp src/content-api/postgresql.conf.write-optimised src/content-api/postgresql.conf
+docker-entrypoint.sh postgres -c config_file=src/content-api/postgresql.conf &
+
+# Wait for postgres to start
+sleep 5
+
+# Restore the Content API database from its backup file in GCP Storage
+
+# Construct the file's URL
+BUCKET=$(
+  gcloud compute instances describe content-api \
+    --project $PROJECT_ID \
+    --zone $ZONE \
+    --format="value(metadata.items.object_bucket)"
+)
+OBJECT=$(
+gcloud compute instances describe content-api \
+  --project $PROJECT_ID \
+  --zone $ZONE \
+  --format="value(metadata.items.object_name)"
+)
+OBJECT_URL="gs://$BUCKET/$OBJECT"
+FILE_PATH="data/$OBJECT"
+
+# https://stackoverflow.com/questions/6575221
+date
+echo "fetch database"
+gcloud storage cp "$OBJECT_URL" "$FILE_PATH"
+
+# Check that the file size is larger than an arbitrary size of 1GiB.
+# Typically they are nearly 3GiB.
+# On 2023-03-03 the database backup files had a problem and were only a few
+# megabytes.
+minimumsize=1073741824
+actualsize=$(wc -c <"$FILE_PATH")
+if [ $actualsize -le $minimumsize ]; then
+  # Turn this instance off and exit.  The data that is currrently in BigQuery
+  # will remain there.
+  gcloud compute instances delete content-api --quiet --zone=$ZONE
+  exit 1
+fi
+
+date
+pg_restore \
+  -U postgres \
+  --verbose \
+  --create \
+  --clean \
+  --dbname=postgres \
+  --no-owner \
+  --jobs=2 \
+  "$FILE_PATH"
+date
+rm "$FILE_PATH"
+
+# Restart postgres with a less-crashable configuration
+cp src/content-api/postgresql.conf.safe src/content-api/postgresql.conf
+psql -U postgres -c "SELECT pg_reload_conf();"
+
+date
+# Export the content_items table as CSV, to be loaded into BigQuery.
+#
+# Compression can cause trouble with big files or big columns. See
+# /src/publishing-api/functions.sh. But this file is small, with small columns.
+QUERY="\copy content_items TO STDOUT WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',');"
+DEST="gs://${PROJECT_ID}-data-processed/content-api/content_items.csv.gz"
+psql \
+  --username=postgres \
+  --dbname=content_store_production \
+  --command="${QUERY}" \
+  | gcloud storage cp - "${DEST}" \
+    --gzip-in-flight-all
+date
+
+# Remove the data that is currently in BigQuery
+bq --project_id "${PROJECT_ID}" query \
+  --use_legacy_sql=false \
+  "TRUNCATE TABLE content_api.content_items"
+
+# Load the new data into BigQuery
+date
+bq --project_id "${PROJECT_ID}" load \
+  --source_format="CSV" \
+  --allow_quoted_newlines \
+  --skip_leading_rows=1 \
+  --noreplace \
+  --nosynchronous_mode \
+  "content_api.content_items" \
+  "gs://${PROJECT_ID}-data-processed/content-api/content_items.csv.gz"
+date
+
+# Stop this instance
+# https://stackoverflow.com/a/41232669
+gcloud compute instances delete content-api --quiet --zone=$ZONE

--- a/terraform-dev/artifact-registry.tf
+++ b/terraform-dev/artifact-registry.tf
@@ -40,6 +40,7 @@ data "google_iam_policy" "artifact_registry_docker" {
     role = "roles/artifactregistry.reader"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform-dev/bigquery-content-api.tf
+++ b/terraform-dev/bigquery-content-api.tf
@@ -1,0 +1,46 @@
+# A dataset of tables of GOV.UK content and related raw statistics
+
+resource "google_bigquery_dataset" "content_api" {
+  dataset_id            = "content_api"
+  friendly_name         = "Content API"
+  description           = "Tables from the GOV.UK Content API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_content_api" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.gce_content_api.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat([
+      "projectReaders",
+      ],
+      var.bigquery_content_api_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "content_api" {
+  dataset_id  = google_bigquery_dataset.content_api.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_content_api.policy_data
+}
+
+resource "google_bigquery_table" "content_api_content_items" {
+  dataset_id    = google_bigquery_dataset.content_api.dataset_id
+  table_id      = "content_items"
+  friendly_name = "Content items"
+  description   = "Content items table from the GOV.UK Content Store PostgreSQL database"
+  schema        = file("schemas/content-api/content-items.json")
+}

--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -47,6 +47,10 @@ bigquery_private_data_viewer_members = [
 bigquery_public_data_viewer_members = [
 ]
 
+# BigQuery dataset: content_api
+bigquery_content_api_data_viewer_members = [
+]
+
 # BigQuery dataset: content
 bigquery_content_data_viewer_members = [
 ]

--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -16,6 +16,12 @@ resource "google_service_account" "gce_content" {
   description  = "Service Account for the Content Store postgres instance on GCE"
 }
 
+resource "google_service_account" "gce_content_api" {
+  account_id   = "gce-content-api"
+  display_name = "Service account for the content-api instance"
+  description  = "Service account for the content-api instance on GCE"
+}
+
 resource "google_service_account" "gce_publisher" {
   account_id   = "gce-publisher"
   display_name = "Service Account for the Publisher mongobd instance"
@@ -72,6 +78,21 @@ data "google_iam_policy" "service_account-gce_content" {
 resource "google_service_account_iam_policy" "gce_content" {
   service_account_id = google_service_account.gce_content.name
   policy_data        = data.google_iam_policy.service_account-gce_content.policy_data
+}
+
+# Allow a workflow to attach the content-api service account to an instance.
+data "google_iam_policy" "service_account-gce_content_api" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+    members = [
+      google_service_account.workflow_govuk_integration_database_backups.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "gce_content_api" {
+  service_account_id = google_service_account.gce_content_api.name
+  policy_data        = data.google_iam_policy.service_account-gce_content_api.policy_data
 }
 
 # Allow a workflow to attach the publisher service account to an instance.
@@ -184,6 +205,65 @@ module "mongodb-container" {
         medium = "Memory"
       }
     },
+  ]
+
+  restart_policy = "Never"
+}
+
+# https://github.com/terraform-google-modules/terraform-google-container-vm
+module "content-api-container" {
+  source  = "terraform-google-modules/container-vm/google"
+  version = "~> 2.0"
+
+  container = {
+    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/content-api:latest"
+    tty : true
+    stdin : true
+    securityContext = {
+      privileged : true
+    }
+    env = [
+      {
+        name  = "POSTGRES_HOST_AUTH_METHOD"
+        value = "trust"
+      },
+      {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      },
+      {
+        name  = "ZONE"
+        value = var.zone
+      }
+    ]
+    volumeMounts = [
+      {
+        mountPath = "/var/lib/postgresql/data"
+        name      = "local-ssd-postgresql-data"
+        readOnly  = false
+      },
+      {
+        mountPath = "/data"
+        name      = "local-ssd-data"
+        readOnly  = false
+      }
+    ]
+  }
+
+  volumes = [
+    # https://github.com/terraform-google-modules/terraform-google-container-vm/issues/66
+    {
+      name = "local-ssd-postgresql-data"
+      hostPath = {
+        path = "/mnt/disks/local-ssd/postgresql-data"
+      }
+    },
+    {
+      name = "local-ssd-data"
+      hostPath = {
+        path = "/mnt/disks/local-ssd/data"
+      }
+    }
   ]
 
   restart_policy = "Never"
@@ -512,6 +592,49 @@ resource "google_compute_instance_template" "content" {
 
   service_account {
     email  = google_service_account.gce_content.email
+    scopes = ["cloud-platform"]
+  }
+}
+
+resource "google_compute_instance_template" "content_api" {
+  name = "content-api"
+  # 2 CPUs are enough that, while the largest table is being restored, all the
+  # other tables will also be restored, even if some of them are done in series
+  # rather than parallel.  Not much memory is required.  See postgresql.conf for
+  # the memory allowances.
+  machine_type = "c2d-highmem-2"
+
+  disk {
+    boot         = true
+    source_image = module.publishing-api-container.source_image
+    disk_size_gb = 10
+  }
+
+  disk {
+    device_name  = "local-ssd"
+    interface    = "NVME"
+    disk_type    = "local-ssd"
+    disk_size_gb = "375" # Must be exactly 375GB for a local SSD disk
+    type         = "SCRATCH"
+  }
+
+  metadata = {
+    # https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem#mounting_and_formatting_disks
+    user-data                  = var.postgres-startup-script
+    google-logging-enabled     = true
+    serial-port-logging-enable = true
+    gce-container-declaration  = module.publishing-api-container.metadata_value
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      network_tier = "STANDARD"
+    }
+  }
+
+  service_account {
+    email  = google_service_account.gce_content_api.email
     scopes = ["cloud-platform"]
   }
 }

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -132,6 +132,10 @@ variable "storage_data_processed_object_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_content_api_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_content_data_viewer_members" {
   type = list(string)
 }
@@ -288,6 +292,7 @@ data "google_iam_policy" "project" {
         google_service_account.bigquery_page_transitions.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_content.member,
+        google_service_account.gce_content_api.member,
         google_service_account.gce_mongodb.member,
         google_service_account.gce_publishing_api.member,
         google_service_account.gce_publisher.member,
@@ -358,6 +363,7 @@ data "google_iam_policy" "project" {
     role = "roles/compute.instanceAdmin.v1"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform-dev/schemas/content-api/content-items.json
+++ b/terraform-dev/schemas/content-api/content-items.json
@@ -1,0 +1,218 @@
+[
+  {
+    "name": "id",
+    "mode": "REQUIRED",
+    "type": "STRING",
+    "description": "UUID"
+  },
+  {
+    "name": "base_path",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The part of the URL after https://www.gov.uk/"
+  },
+  {
+    "name": "content_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "ID of the piece of content, of which this is an edition in a certain locale"
+  },
+  {
+    "name": "title",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Title of the edition"
+  },
+  {
+    "name": "description",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Description of the edition"
+  },
+  {
+    "name": "document_type",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The kind of thing that the content is about"
+  },
+  {
+    "name": "content_purpose_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "content_purpose_subgroup",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "content_purpose_supergroup",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "emaiL_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used by email subscriptions to identify publications and announcements"
+  },
+  {
+    "name": "government_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "navigation_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "search_user_need_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "user_journey_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "schema_name",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The JSON schema of the 'details' field. See https://docs.publishing.service.gov.uk/content-schemas.html"
+  },
+  {
+    "name": "locale",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The ISO 639-1 two-letter code of the language of the document, of which this is an edition"
+  },
+  {
+    "name": "first_published_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "The timestamp of the first edition of this document to have been published.  Automatically determined by the publishing-api, unless overridden by the publishing application."
+  },
+  {
+    "name": "public_updated_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "The timestamp of publication of the last edition to have been so significantly different from its predecessor that the publisher chose to inform users"
+  },
+  {
+    "name": "publishing_scheduled_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When an edition is/was to be made public"
+  },
+  {
+    "name": "details",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "The content of an edition, and other information that varies by schema"
+  },
+  {
+    "name": "publishing_app",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The application where a document is composed and submitted for publication"
+  },
+  {
+    "name": "rendering_app",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The application that renders the given edition as HTML"
+  },
+  {
+    "name": "routes",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "URLs that will be served with the given edition"
+  },
+  {
+    "name": "redirects",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "Redirects for the base path and any paths under the base path"
+  },
+  {
+    "name": "expanded_links",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "Metadata about content items that are associated with the given content item"
+  },
+  {
+    "name": "access_limited",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "List of authorised users (only used in the draft stack)"
+  },
+  {
+    "name": "auth_bypass_ids",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "A way to allow unauthenticated users to bypass access limitations by using a URL that includes a JSON Web Token (only used in the draft stack)"
+  },
+  {
+    "name": "phase",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "One of 'alpha', 'beta', or 'live', describing how finished the content is"
+  },
+  {
+    "name": "analytics_identifier",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "An identifier to track the content item in analytics software"
+  },
+  {
+    "name": "payload_version",
+    "mode": "NULLABLE",
+    "type": "INTEGER",
+    "description": "To mitigate race conditions when publishing content"
+  },
+  {
+    "name": "withdrawn_notice",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "When the content was withdrawn, and an explanation"
+  },
+  {
+    "name": "publishing_request_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "ID of a record of an app submitting the content to be published"
+  },
+  {
+    "name": "created_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When the document was first created."
+  },
+  {
+    "name": "updated_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When an edition was created, however trivial the change from any previous edition"
+  },
+  {
+    "name": "_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "For compatibility with a previous implementation of the content store"
+  },
+  {
+    "name": "scheduled_publishing_delay_seconds",
+    "mode": "NULLABLE",
+    "type": "INTEGER",
+    "description": "When an edition is/was to be made public"
+  }
+]

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -48,6 +48,7 @@ data "google_iam_policy" "bucket_repository" {
     role = "roles/storage.objectViewer"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,
@@ -107,6 +108,7 @@ data "google_iam_policy" "bucket_data_processed" {
     role = "roles/storage.objectAdmin"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -21,6 +21,7 @@ resource "google_workflows_workflow" "govuk_integration_database_backups" {
       project_id                    = var.project_id
       zone                          = var.zone
       postgres_startup_script       = jsonencode(var.postgres-startup-script)
+      content_api_metadata_value    = jsonencode(module.content-api-container.metadata_value)
       content_metadata_value        = jsonencode(module.content-container.metadata_value)
       mongodb_metadata_value        = jsonencode(module.mongodb-container.metadata_value)
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)

--- a/terraform-dev/workflows/govuk-integration-database-backups.yaml
+++ b/terraform-dev/workflows/govuk-integration-database-backups.yaml
@@ -64,6 +64,31 @@ main:
               return: $${"Started publishing-api instance"}
         - condition: $${text.match_regex(object_name, "^content-store-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-content_store_production\\.gz$")}
           steps:
+          - log_starting_content_api_instance:
+              call: sys.log
+              args:
+                  text: "Starting content-api instance"
+                  severity: INFO
+          - start_content_api:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/content-api
+                  body:
+                      name: content-api
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: user-data
+                          value: ${postgres_startup_script}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${content_api_metadata_value}
           - log_starting_content_instance:
               call: sys.log
               args:
@@ -89,8 +114,8 @@ main:
                           value: true
                         - key: gce-container-declaration
                           value: ${content_metadata_value}
-          - return_started_content:
-              return: $${"Started content instance"}
+          - return_started_content_api:
+              return: $${"Started content-api instance"}
         - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
           steps:
           - log_starting_publisher_instance:

--- a/terraform-staging/artifact-registry.tf
+++ b/terraform-staging/artifact-registry.tf
@@ -40,6 +40,7 @@ data "google_iam_policy" "artifact_registry_docker" {
     role = "roles/artifactregistry.reader"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform-staging/bigquery-content-api.tf
+++ b/terraform-staging/bigquery-content-api.tf
@@ -1,0 +1,46 @@
+# A dataset of tables of GOV.UK content and related raw statistics
+
+resource "google_bigquery_dataset" "content_api" {
+  dataset_id            = "content_api"
+  friendly_name         = "Content API"
+  description           = "Tables from the GOV.UK Content API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_content_api" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.gce_content_api.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat([
+      "projectReaders",
+      ],
+      var.bigquery_content_api_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "content_api" {
+  dataset_id  = google_bigquery_dataset.content_api.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_content_api.policy_data
+}
+
+resource "google_bigquery_table" "content_api_content_items" {
+  dataset_id    = google_bigquery_dataset.content_api.dataset_id
+  table_id      = "content_items"
+  friendly_name = "Content items"
+  description   = "Content items table from the GOV.UK Content Store PostgreSQL database"
+  schema        = file("schemas/content-api/content-items.json")
+}

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -48,6 +48,9 @@ bigquery_private_data_viewer_members = [
 bigquery_public_data_viewer_members = [
 ]
 
+# BigQuery dataset: content_api
+bigquery_content_api_data_viewer_members = [
+]
 
 # BigQuery dataset: content
 bigquery_content_data_viewer_members = [

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -16,6 +16,12 @@ resource "google_service_account" "gce_content" {
   description  = "Service Account for the Content Store postgres instance on GCE"
 }
 
+resource "google_service_account" "gce_content_api" {
+  account_id   = "gce-content-api"
+  display_name = "Service account for the content-api instance"
+  description  = "Service account for the content-api instance on GCE"
+}
+
 resource "google_service_account" "gce_publisher" {
   account_id   = "gce-publisher"
   display_name = "Service Account for the Publisher mongobd instance"
@@ -72,6 +78,21 @@ data "google_iam_policy" "service_account-gce_content" {
 resource "google_service_account_iam_policy" "gce_content" {
   service_account_id = google_service_account.gce_content.name
   policy_data        = data.google_iam_policy.service_account-gce_content.policy_data
+}
+
+# Allow a workflow to attach the content-api service account to an instance.
+data "google_iam_policy" "service_account-gce_content_api" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+    members = [
+      google_service_account.workflow_govuk_integration_database_backups.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "gce_content_api" {
+  service_account_id = google_service_account.gce_content_api.name
+  policy_data        = data.google_iam_policy.service_account-gce_content_api.policy_data
 }
 
 # Allow a workflow to attach the publisher service account to an instance.
@@ -184,6 +205,65 @@ module "mongodb-container" {
         medium = "Memory"
       }
     },
+  ]
+
+  restart_policy = "Never"
+}
+
+# https://github.com/terraform-google-modules/terraform-google-container-vm
+module "content-api-container" {
+  source  = "terraform-google-modules/container-vm/google"
+  version = "~> 2.0"
+
+  container = {
+    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/content-api:latest"
+    tty : true
+    stdin : true
+    securityContext = {
+      privileged : true
+    }
+    env = [
+      {
+        name  = "POSTGRES_HOST_AUTH_METHOD"
+        value = "trust"
+      },
+      {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      },
+      {
+        name  = "ZONE"
+        value = var.zone
+      }
+    ]
+    volumeMounts = [
+      {
+        mountPath = "/var/lib/postgresql/data"
+        name      = "local-ssd-postgresql-data"
+        readOnly  = false
+      },
+      {
+        mountPath = "/data"
+        name      = "local-ssd-data"
+        readOnly  = false
+      }
+    ]
+  }
+
+  volumes = [
+    # https://github.com/terraform-google-modules/terraform-google-container-vm/issues/66
+    {
+      name = "local-ssd-postgresql-data"
+      hostPath = {
+        path = "/mnt/disks/local-ssd/postgresql-data"
+      }
+    },
+    {
+      name = "local-ssd-data"
+      hostPath = {
+        path = "/mnt/disks/local-ssd/data"
+      }
+    }
   ]
 
   restart_policy = "Never"
@@ -512,6 +592,49 @@ resource "google_compute_instance_template" "content" {
 
   service_account {
     email  = google_service_account.gce_content.email
+    scopes = ["cloud-platform"]
+  }
+}
+
+resource "google_compute_instance_template" "content_api" {
+  name = "content-api"
+  # 2 CPUs are enough that, while the largest table is being restored, all the
+  # other tables will also be restored, even if some of them are done in series
+  # rather than parallel.  Not much memory is required.  See postgresql.conf for
+  # the memory allowances.
+  machine_type = "c2d-highmem-2"
+
+  disk {
+    boot         = true
+    source_image = module.publishing-api-container.source_image
+    disk_size_gb = 10
+  }
+
+  disk {
+    device_name  = "local-ssd"
+    interface    = "NVME"
+    disk_type    = "local-ssd"
+    disk_size_gb = "375" # Must be exactly 375GB for a local SSD disk
+    type         = "SCRATCH"
+  }
+
+  metadata = {
+    # https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem#mounting_and_formatting_disks
+    user-data                  = var.postgres-startup-script
+    google-logging-enabled     = true
+    serial-port-logging-enable = true
+    gce-container-declaration  = module.publishing-api-container.metadata_value
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      network_tier = "STANDARD"
+    }
+  }
+
+  service_account {
+    email  = google_service_account.gce_content_api.email
     scopes = ["cloud-platform"]
   }
 }

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -132,6 +132,10 @@ variable "storage_data_processed_object_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_content_api_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_content_data_viewer_members" {
   type = list(string)
 }
@@ -288,6 +292,7 @@ data "google_iam_policy" "project" {
         google_service_account.bigquery_page_transitions.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_content.member,
+        google_service_account.gce_content_api.member,
         google_service_account.gce_mongodb.member,
         google_service_account.gce_publishing_api.member,
         google_service_account.gce_publisher.member,
@@ -358,6 +363,7 @@ data "google_iam_policy" "project" {
     role = "roles/compute.instanceAdmin.v1"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform-staging/schemas/content-api/content-items.json
+++ b/terraform-staging/schemas/content-api/content-items.json
@@ -1,0 +1,218 @@
+[
+  {
+    "name": "id",
+    "mode": "REQUIRED",
+    "type": "STRING",
+    "description": "UUID"
+  },
+  {
+    "name": "base_path",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The part of the URL after https://www.gov.uk/"
+  },
+  {
+    "name": "content_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "ID of the piece of content, of which this is an edition in a certain locale"
+  },
+  {
+    "name": "title",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Title of the edition"
+  },
+  {
+    "name": "description",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Description of the edition"
+  },
+  {
+    "name": "document_type",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The kind of thing that the content is about"
+  },
+  {
+    "name": "content_purpose_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "content_purpose_subgroup",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "content_purpose_supergroup",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "emaiL_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used by email subscriptions to identify publications and announcements"
+  },
+  {
+    "name": "government_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "navigation_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "search_user_need_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "user_journey_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "schema_name",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The JSON schema of the 'details' field. See https://docs.publishing.service.gov.uk/content-schemas.html"
+  },
+  {
+    "name": "locale",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The ISO 639-1 two-letter code of the language of the document, of which this is an edition"
+  },
+  {
+    "name": "first_published_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "The timestamp of the first edition of this document to have been published.  Automatically determined by the publishing-api, unless overridden by the publishing application."
+  },
+  {
+    "name": "public_updated_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "The timestamp of publication of the last edition to have been so significantly different from its predecessor that the publisher chose to inform users"
+  },
+  {
+    "name": "publishing_scheduled_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When an edition is/was to be made public"
+  },
+  {
+    "name": "details",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "The content of an edition, and other information that varies by schema"
+  },
+  {
+    "name": "publishing_app",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The application where a document is composed and submitted for publication"
+  },
+  {
+    "name": "rendering_app",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The application that renders the given edition as HTML"
+  },
+  {
+    "name": "routes",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "URLs that will be served with the given edition"
+  },
+  {
+    "name": "redirects",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "Redirects for the base path and any paths under the base path"
+  },
+  {
+    "name": "expanded_links",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "Metadata about content items that are associated with the given content item"
+  },
+  {
+    "name": "access_limited",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "List of authorised users (only used in the draft stack)"
+  },
+  {
+    "name": "auth_bypass_ids",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "A way to allow unauthenticated users to bypass access limitations by using a URL that includes a JSON Web Token (only used in the draft stack)"
+  },
+  {
+    "name": "phase",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "One of 'alpha', 'beta', or 'live', describing how finished the content is"
+  },
+  {
+    "name": "analytics_identifier",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "An identifier to track the content item in analytics software"
+  },
+  {
+    "name": "payload_version",
+    "mode": "NULLABLE",
+    "type": "INTEGER",
+    "description": "To mitigate race conditions when publishing content"
+  },
+  {
+    "name": "withdrawn_notice",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "When the content was withdrawn, and an explanation"
+  },
+  {
+    "name": "publishing_request_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "ID of a record of an app submitting the content to be published"
+  },
+  {
+    "name": "created_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When the document was first created."
+  },
+  {
+    "name": "updated_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When an edition was created, however trivial the change from any previous edition"
+  },
+  {
+    "name": "_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "For compatibility with a previous implementation of the content store"
+  },
+  {
+    "name": "scheduled_publishing_delay_seconds",
+    "mode": "NULLABLE",
+    "type": "INTEGER",
+    "description": "When an edition is/was to be made public"
+  }
+]

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -48,6 +48,7 @@ data "google_iam_policy" "bucket_repository" {
     role = "roles/storage.objectViewer"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,
@@ -107,6 +108,7 @@ data "google_iam_policy" "bucket_data_processed" {
     role = "roles/storage.objectAdmin"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -21,6 +21,7 @@ resource "google_workflows_workflow" "govuk_integration_database_backups" {
       project_id                    = var.project_id
       zone                          = var.zone
       postgres_startup_script       = jsonencode(var.postgres-startup-script)
+      content_api_metadata_value    = jsonencode(module.content-api-container.metadata_value)
       content_metadata_value        = jsonencode(module.content-container.metadata_value)
       mongodb_metadata_value        = jsonencode(module.mongodb-container.metadata_value)
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)

--- a/terraform-staging/workflows/govuk-integration-database-backups.yaml
+++ b/terraform-staging/workflows/govuk-integration-database-backups.yaml
@@ -64,6 +64,31 @@ main:
               return: $${"Started publishing-api instance"}
         - condition: $${text.match_regex(object_name, "^content-store-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-content_store_production\\.gz$")}
           steps:
+          - log_starting_content_api_instance:
+              call: sys.log
+              args:
+                  text: "Starting content-api instance"
+                  severity: INFO
+          - start_content_api:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/content-api
+                  body:
+                      name: content-api
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: user-data
+                          value: ${postgres_startup_script}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${content_api_metadata_value}
           - log_starting_content_instance:
               call: sys.log
               args:
@@ -89,8 +114,8 @@ main:
                           value: true
                         - key: gce-container-declaration
                           value: ${content_metadata_value}
-          - return_started_content:
-              return: $${"Started content instance"}
+          - return_started_content_api:
+              return: $${"Started content-api instance"}
         - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
           steps:
           - log_starting_publisher_instance:

--- a/terraform/artifact-registry.tf
+++ b/terraform/artifact-registry.tf
@@ -40,6 +40,7 @@ data "google_iam_policy" "artifact_registry_docker" {
     role = "roles/artifactregistry.reader"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform/bigquery-content-api.tf
+++ b/terraform/bigquery-content-api.tf
@@ -1,0 +1,46 @@
+# A dataset of tables of GOV.UK content and related raw statistics
+
+resource "google_bigquery_dataset" "content_api" {
+  dataset_id            = "content_api"
+  friendly_name         = "Content API"
+  description           = "Tables from the GOV.UK Content API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48" # The minimum is 48
+}
+
+data "google_iam_policy" "bigquery_dataset_content_api" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.gce_content_api.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat([
+      "projectReaders",
+      ],
+      var.bigquery_content_api_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "content_api" {
+  dataset_id  = google_bigquery_dataset.content_api.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_content_api.policy_data
+}
+
+resource "google_bigquery_table" "content_api_content_items" {
+  dataset_id    = google_bigquery_dataset.content_api.dataset_id
+  table_id      = "content_items"
+  friendly_name = "Content items"
+  description   = "Content items table from the GOV.UK Content Store PostgreSQL database"
+  schema        = file("schemas/content-api/content-items.json")
+}

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -50,6 +50,10 @@ bigquery_private_data_viewer_members = [
 bigquery_public_data_viewer_members = [
 ]
 
+# BigQuery dataset: content_api
+bigquery_content_api_data_viewer_members = [
+]
+
 bigquery_content_data_viewer_members = [
   "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
   "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -16,6 +16,12 @@ resource "google_service_account" "gce_content" {
   description  = "Service Account for the Content Store postgres instance on GCE"
 }
 
+resource "google_service_account" "gce_content_api" {
+  account_id   = "gce-content-api"
+  display_name = "Service account for the content-api instance"
+  description  = "Service account for the content-api instance on GCE"
+}
+
 resource "google_service_account" "gce_publisher" {
   account_id   = "gce-publisher"
   display_name = "Service Account for the Publisher mongobd instance"
@@ -72,6 +78,21 @@ data "google_iam_policy" "service_account-gce_content" {
 resource "google_service_account_iam_policy" "gce_content" {
   service_account_id = google_service_account.gce_content.name
   policy_data        = data.google_iam_policy.service_account-gce_content.policy_data
+}
+
+# Allow a workflow to attach the content-api service account to an instance.
+data "google_iam_policy" "service_account-gce_content_api" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+    members = [
+      google_service_account.workflow_govuk_integration_database_backups.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "gce_content_api" {
+  service_account_id = google_service_account.gce_content_api.name
+  policy_data        = data.google_iam_policy.service_account-gce_content_api.policy_data
 }
 
 # Allow a workflow to attach the publisher service account to an instance.
@@ -184,6 +205,65 @@ module "mongodb-container" {
         medium = "Memory"
       }
     },
+  ]
+
+  restart_policy = "Never"
+}
+
+# https://github.com/terraform-google-modules/terraform-google-container-vm
+module "content-api-container" {
+  source  = "terraform-google-modules/container-vm/google"
+  version = "~> 2.0"
+
+  container = {
+    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/content-api:latest"
+    tty : true
+    stdin : true
+    securityContext = {
+      privileged : true
+    }
+    env = [
+      {
+        name  = "POSTGRES_HOST_AUTH_METHOD"
+        value = "trust"
+      },
+      {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      },
+      {
+        name  = "ZONE"
+        value = var.zone
+      }
+    ]
+    volumeMounts = [
+      {
+        mountPath = "/var/lib/postgresql/data"
+        name      = "local-ssd-postgresql-data"
+        readOnly  = false
+      },
+      {
+        mountPath = "/data"
+        name      = "local-ssd-data"
+        readOnly  = false
+      }
+    ]
+  }
+
+  volumes = [
+    # https://github.com/terraform-google-modules/terraform-google-container-vm/issues/66
+    {
+      name = "local-ssd-postgresql-data"
+      hostPath = {
+        path = "/mnt/disks/local-ssd/postgresql-data"
+      }
+    },
+    {
+      name = "local-ssd-data"
+      hostPath = {
+        path = "/mnt/disks/local-ssd/data"
+      }
+    }
   ]
 
   restart_policy = "Never"
@@ -512,6 +592,49 @@ resource "google_compute_instance_template" "content" {
 
   service_account {
     email  = google_service_account.gce_content.email
+    scopes = ["cloud-platform"]
+  }
+}
+
+resource "google_compute_instance_template" "content_api" {
+  name = "content-api"
+  # 2 CPUs are enough that, while the largest table is being restored, all the
+  # other tables will also be restored, even if some of them are done in series
+  # rather than parallel.  Not much memory is required.  See postgresql.conf for
+  # the memory allowances.
+  machine_type = "c2d-highmem-2"
+
+  disk {
+    boot         = true
+    source_image = module.publishing-api-container.source_image
+    disk_size_gb = 10
+  }
+
+  disk {
+    device_name  = "local-ssd"
+    interface    = "NVME"
+    disk_type    = "local-ssd"
+    disk_size_gb = "375" # Must be exactly 375GB for a local SSD disk
+    type         = "SCRATCH"
+  }
+
+  metadata = {
+    # https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem#mounting_and_formatting_disks
+    user-data                  = var.postgres-startup-script
+    google-logging-enabled     = true
+    serial-port-logging-enable = true
+    gce-container-declaration  = module.publishing-api-container.metadata_value
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      network_tier = "STANDARD"
+    }
+  }
+
+  service_account {
+    email  = google_service_account.gce_content_api.email
     scopes = ["cloud-platform"]
   }
 }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -132,6 +132,10 @@ variable "storage_data_processed_object_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_content_api_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_content_data_viewer_members" {
   type = list(string)
 }
@@ -288,6 +292,7 @@ data "google_iam_policy" "project" {
         google_service_account.bigquery_page_transitions.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_content.member,
+        google_service_account.gce_content_api.member,
         google_service_account.gce_mongodb.member,
         google_service_account.gce_publishing_api.member,
         google_service_account.gce_publisher.member,
@@ -358,6 +363,7 @@ data "google_iam_policy" "project" {
     role = "roles/compute.instanceAdmin.v1"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform/schemas/content-api/content-items.json
+++ b/terraform/schemas/content-api/content-items.json
@@ -1,0 +1,218 @@
+[
+  {
+    "name": "id",
+    "mode": "REQUIRED",
+    "type": "STRING",
+    "description": "UUID"
+  },
+  {
+    "name": "base_path",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The part of the URL after https://www.gov.uk/"
+  },
+  {
+    "name": "content_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "ID of the piece of content, of which this is an edition in a certain locale"
+  },
+  {
+    "name": "title",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Title of the edition"
+  },
+  {
+    "name": "description",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Description of the edition"
+  },
+  {
+    "name": "document_type",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The kind of thing that the content is about"
+  },
+  {
+    "name": "content_purpose_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "content_purpose_subgroup",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "content_purpose_supergroup",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "emaiL_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used by email subscriptions to identify publications and announcements"
+  },
+  {
+    "name": "government_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "navigation_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "search_user_need_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "user_journey_document_supertype",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "Used in topic pages for navigation"
+  },
+  {
+    "name": "schema_name",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The JSON schema of the 'details' field. See https://docs.publishing.service.gov.uk/content-schemas.html"
+  },
+  {
+    "name": "locale",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The ISO 639-1 two-letter code of the language of the document, of which this is an edition"
+  },
+  {
+    "name": "first_published_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "The timestamp of the first edition of this document to have been published.  Automatically determined by the publishing-api, unless overridden by the publishing application."
+  },
+  {
+    "name": "public_updated_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "The timestamp of publication of the last edition to have been so significantly different from its predecessor that the publisher chose to inform users"
+  },
+  {
+    "name": "publishing_scheduled_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When an edition is/was to be made public"
+  },
+  {
+    "name": "details",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "The content of an edition, and other information that varies by schema"
+  },
+  {
+    "name": "publishing_app",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The application where a document is composed and submitted for publication"
+  },
+  {
+    "name": "rendering_app",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "The application that renders the given edition as HTML"
+  },
+  {
+    "name": "routes",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "URLs that will be served with the given edition"
+  },
+  {
+    "name": "redirects",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "Redirects for the base path and any paths under the base path"
+  },
+  {
+    "name": "expanded_links",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "Metadata about content items that are associated with the given content item"
+  },
+  {
+    "name": "access_limited",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "List of authorised users (only used in the draft stack)"
+  },
+  {
+    "name": "auth_bypass_ids",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "A way to allow unauthenticated users to bypass access limitations by using a URL that includes a JSON Web Token (only used in the draft stack)"
+  },
+  {
+    "name": "phase",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "One of 'alpha', 'beta', or 'live', describing how finished the content is"
+  },
+  {
+    "name": "analytics_identifier",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "An identifier to track the content item in analytics software"
+  },
+  {
+    "name": "payload_version",
+    "mode": "NULLABLE",
+    "type": "INTEGER",
+    "description": "To mitigate race conditions when publishing content"
+  },
+  {
+    "name": "withdrawn_notice",
+    "mode": "NULLABLE",
+    "type": "JSON",
+    "description": "When the content was withdrawn, and an explanation"
+  },
+  {
+    "name": "publishing_request_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "ID of a record of an app submitting the content to be published"
+  },
+  {
+    "name": "created_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When the document was first created."
+  },
+  {
+    "name": "updated_at",
+    "mode": "NULLABLE",
+    "type": "TIMESTAMP",
+    "description": "When an edition was created, however trivial the change from any previous edition"
+  },
+  {
+    "name": "_id",
+    "mode": "NULLABLE",
+    "type": "STRING",
+    "description": "For compatibility with a previous implementation of the content store"
+  },
+  {
+    "name": "scheduled_publishing_delay_seconds",
+    "mode": "NULLABLE",
+    "type": "INTEGER",
+    "description": "When an edition is/was to be made public"
+  }
+]

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -48,6 +48,7 @@ data "google_iam_policy" "bucket_repository" {
     role = "roles/storage.objectViewer"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,
@@ -107,6 +108,7 @@ data "google_iam_policy" "bucket_data_processed" {
     role = "roles/storage.objectAdmin"
     members = [
       google_service_account.gce_content.member,
+      google_service_account.gce_content_api.member,
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -21,6 +21,7 @@ resource "google_workflows_workflow" "govuk_integration_database_backups" {
       project_id                    = var.project_id
       zone                          = var.zone
       postgres_startup_script       = jsonencode(var.postgres-startup-script)
+      content_api_metadata_value    = jsonencode(module.content-api-container.metadata_value)
       content_metadata_value        = jsonencode(module.content-container.metadata_value)
       mongodb_metadata_value        = jsonencode(module.mongodb-container.metadata_value)
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)

--- a/terraform/workflows/govuk-integration-database-backups.yaml
+++ b/terraform/workflows/govuk-integration-database-backups.yaml
@@ -64,6 +64,31 @@ main:
               return: $${"Started publishing-api instance"}
         - condition: $${text.match_regex(object_name, "^content-store-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-content_store_production\\.gz$")}
           steps:
+          - log_starting_content_api_instance:
+              call: sys.log
+              args:
+                  text: "Starting content-api instance"
+                  severity: INFO
+          - start_content_api:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/content-api
+                  body:
+                      name: content-api
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: user-data
+                          value: ${postgres_startup_script}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${content_api_metadata_value}
           - log_starting_content_instance:
               call: sys.log
               args:
@@ -89,8 +114,8 @@ main:
                           value: true
                         - key: gce-container-declaration
                           value: ${content_metadata_value}
-          - return_started_content:
-              return: $${"Started content instance"}
+          - return_started_content_api:
+              return: $${"Started content-api instance"}
         - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
           steps:
           - log_starting_publisher_instance:


### PR DESCRIPTION
First part of renaming the 'content' virtual machine and dataset to
'content-api'. Rather than rename it, it seemed cleaner to create a new
one, and then delete the old one.

The new `content-api` virtual machine restores the Content API (aka content store) database backup file to a running instance of Postgres, and exports the `content_items` table to the BigQuery table `content_api.content_items`.
