### PR TITLE
refactor: don't derive page views in graph dataset

### DIFF
--- a/src/mongodb/bigquery/page.sql
+++ b/src/mongodb/bigquery/page.sql
@@ -22,8 +22,7 @@ SELECT
   department_analytics_profile.department_analytics_profile,
   c.text,
   CAST(NULL AS INT64) AS part_index,
-  CAST(NULL AS STRING) AS slug,
-  page_views.number_of_views AS page_views
+  CAST(NULL AS STRING) AS slug
 FROM content.url AS u
 LEFT JOIN content.document_type USING (url)
 LEFT JOIN content.schema_name USING (url)
@@ -43,7 +42,6 @@ LEFT JOIN content.title USING (url)
 LEFT JOIN content.description USING (url)
 LEFT JOIN content.department_analytics_profile USING (url)
 LEFT JOIN content.content AS c USING (url)
-LEFT JOIN private.page_views USING (url)
 ;
 
 -- Derive a table of parts nodes from their parent page nodes
@@ -56,12 +54,10 @@ SELECT
     parts.part_title AS title,
     c.text AS text,
     parts.part_index AS part_index,
-    parts.slug AS slug,
-    page_views.number_of_views AS page_views
+    parts.slug AS slug
   )
 FROM graph.page
 INNER JOIN content.parts ON page.url = parts.base_path
 LEFT JOIN content.content AS c ON c.url = parts.url
-LEFT JOIN private.page_views on (page_views.url = parts.url)
 ;
 INSERT INTO graph.page SELECT * FROM graph.part;

--- a/terraform-dev/bigquery-private.tf
+++ b/terraform-dev/bigquery-private.tf
@@ -29,6 +29,7 @@ data "google_iam_policy" "bigquery_dataset_private" {
       [
         "projectReaders",
         google_service_account.gce_mongodb.member,
+        google_service_account.bigquery_scheduled_queries_search.member,
       ],
       var.bigquery_private_data_viewer_members,
     )

--- a/terraform-dev/bigquery/page.sql
+++ b/terraform-dev/bigquery/page.sql
@@ -113,7 +113,7 @@ SELECT
   publisher_updated_at.publisher_updated_at,
   withdrawn_at,
   withdrawn_explanation,
-  page_views,
+  page_views.number_of_views AS page_views,
   /*
   Title is preferred to internal name because it is typically of better quality;
   internal name should be used if title is not unique / repeated.
@@ -136,6 +136,7 @@ LEFT JOIN organisations USING (content_id)
 LEFT JOIN links USING (url)
 LEFT JOIN phone_numbers USING (url)
 LEFT JOIN entities USING (url)
+LEFT JOIN private.page_views USING (url)
 LEFT JOIN tagged_taxons ON (tagged_taxons.url = 'https://www.gov.uk/' || content_id)
 LEFT JOIN publisher_updated_at ON (STARTS_WITH(page.url, publisher_updated_at.url))
 WHERE

--- a/terraform-dev/schemas/graph/page.json
+++ b/terraform-dev/schemas/graph/page.json
@@ -124,11 +124,5 @@
         "name": "slug",
         "type": "STRING",
         "description": "What to add to the base_path to get the url"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "page_views",
-        "type": "INTEGER",
-        "description": "Number of page views from GA4 over 7 recent days"
     }
 ]

--- a/terraform-dev/schemas/graph/part.json
+++ b/terraform-dev/schemas/graph/part.json
@@ -124,11 +124,5 @@
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path of the part to get the url"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "page_views",
-    "type": "INTEGER",
-    "description": "Number of page views from GA4 over 7 recent days"
   }
 ]

--- a/terraform-staging/bigquery-private.tf
+++ b/terraform-staging/bigquery-private.tf
@@ -29,6 +29,7 @@ data "google_iam_policy" "bigquery_dataset_private" {
       [
         "projectReaders",
         google_service_account.gce_mongodb.member,
+        google_service_account.bigquery_scheduled_queries_search.member,
       ],
       var.bigquery_private_data_viewer_members,
     )

--- a/terraform-staging/bigquery/page.sql
+++ b/terraform-staging/bigquery/page.sql
@@ -113,7 +113,7 @@ SELECT
   publisher_updated_at.publisher_updated_at,
   withdrawn_at,
   withdrawn_explanation,
-  page_views,
+  page_views.number_of_views AS page_views,
   /*
   Title is preferred to internal name because it is typically of better quality;
   internal name should be used if title is not unique / repeated.
@@ -136,6 +136,7 @@ LEFT JOIN organisations USING (content_id)
 LEFT JOIN links USING (url)
 LEFT JOIN phone_numbers USING (url)
 LEFT JOIN entities USING (url)
+LEFT JOIN private.page_views USING (url)
 LEFT JOIN tagged_taxons ON (tagged_taxons.url = 'https://www.gov.uk/' || content_id)
 LEFT JOIN publisher_updated_at ON (STARTS_WITH(page.url, publisher_updated_at.url))
 WHERE

--- a/terraform-staging/schemas/graph/page.json
+++ b/terraform-staging/schemas/graph/page.json
@@ -124,11 +124,5 @@
         "name": "slug",
         "type": "STRING",
         "description": "What to add to the base_path to get the url"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "page_views",
-        "type": "INTEGER",
-        "description": "Number of page views from GA4 over 7 recent days"
     }
 ]

--- a/terraform-staging/schemas/graph/part.json
+++ b/terraform-staging/schemas/graph/part.json
@@ -124,11 +124,5 @@
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path of the part to get the url"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "page_views",
-    "type": "INTEGER",
-    "description": "Number of page views from GA4 over 7 recent days"
   }
 ]

--- a/terraform/bigquery-private.tf
+++ b/terraform/bigquery-private.tf
@@ -29,6 +29,7 @@ data "google_iam_policy" "bigquery_dataset_private" {
       [
         "projectReaders",
         google_service_account.gce_mongodb.member,
+        google_service_account.bigquery_scheduled_queries_search.member,
       ],
       var.bigquery_private_data_viewer_members,
     )

--- a/terraform/bigquery/page.sql
+++ b/terraform/bigquery/page.sql
@@ -113,7 +113,7 @@ SELECT
   publisher_updated_at.publisher_updated_at,
   withdrawn_at,
   withdrawn_explanation,
-  page_views,
+  page_views.number_of_views AS page_views,
   /*
   Title is preferred to internal name because it is typically of better quality;
   internal name should be used if title is not unique / repeated.
@@ -136,6 +136,7 @@ LEFT JOIN organisations USING (content_id)
 LEFT JOIN links USING (url)
 LEFT JOIN phone_numbers USING (url)
 LEFT JOIN entities USING (url)
+LEFT JOIN private.page_views USING (url)
 LEFT JOIN tagged_taxons ON (tagged_taxons.url = 'https://www.gov.uk/' || content_id)
 LEFT JOIN publisher_updated_at ON (STARTS_WITH(page.url, publisher_updated_at.url))
 WHERE

--- a/terraform/schemas/graph/page.json
+++ b/terraform/schemas/graph/page.json
@@ -124,11 +124,5 @@
         "name": "slug",
         "type": "STRING",
         "description": "What to add to the base_path to get the url"
-    },
-    {
-        "mode": "NULLABLE",
-        "name": "page_views",
-        "type": "INTEGER",
-        "description": "Number of page views from GA4 over 7 recent days"
     }
 ]

--- a/terraform/schemas/graph/part.json
+++ b/terraform/schemas/graph/part.json
@@ -124,11 +124,5 @@
     "name": "slug",
     "type": "STRING",
     "description": "What to add to the base_path of the part to get the url"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "page_views",
-    "type": "INTEGER",
-    "description": "Number of page views from GA4 over 7 recent days"
   }
 ]


### PR DESCRIPTION
Page views are sensitive, so they should only be in tables in the
`private` dataset, or other datasets that are private, such as the
`search` dataset that underpins the GovSearch app.
