### PR TITLE
feat: derive current editions from Publishing API

### DIFF
--- a/terraform-dev/bigquery-private.tf
+++ b/terraform-dev/bigquery-private.tf
@@ -15,6 +15,7 @@ data "google_iam_policy" "bigquery_dataset_private" {
     members = [
       "projectWriters",
       google_service_account.bigquery_page_views.member,
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -47,4 +48,12 @@ resource "google_bigquery_table" "page_views" {
   friendly_name = "Page views"
   description   = "Number of views of GOV.UK pages over 7 days"
   schema        = file("schemas/private/page-views.json")
+}
+
+resource "google_bigquery_table" "private_publishing_api_editions_new" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  table_id      = "publishing_api_editions_new"
+  friendly_name = "Publishing API editions (new)"
+  description   = "Publishing API editions from the latest batch update"
+  schema        = file("schemas/private/publishing-api-editions-new.json")
 }

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -14,6 +14,7 @@ data "google_iam_policy" "bigquery_dataset_public" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -36,4 +37,20 @@ data "google_iam_policy" "bigquery_dataset_public" {
 resource "google_bigquery_dataset_iam_policy" "public" {
   dataset_id  = google_bigquery_dataset.public.dataset_id
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
+}
+
+resource "google_bigquery_table" "public_publishing_api_editions_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_current"
+  friendly_name = "Publishing API editions (current)"
+  description   = "The most-recent edition of each document of each content item"
+  schema        = file("schemas/public/publishing-api-editions-current.json")
+}
+
+resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current"
+  schema        = file("schemas/public/publishing-api-editions-new-current.json")
 }

--- a/terraform-dev/bigquery-publishing-api.tf
+++ b/terraform-dev/bigquery-publishing-api.tf
@@ -13,6 +13,7 @@ data "google_iam_policy" "bigquery_dataset_publishing_api" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
       google_service_account.gce_publishing_api.member,
     ]
   }

--- a/terraform-dev/bigquery-scheduled-queries.tf
+++ b/terraform-dev/bigquery-scheduled-queries.tf
@@ -1,0 +1,19 @@
+# Scheduled queries that don't belong in terraform configurations of particular
+# datasets.
+
+resource "google_service_account" "bigquery_scheduled_queries" {
+  account_id   = "bigquery-scheduled"
+  display_name = "Bigquery scheduled queries"
+  description  = "Service account for scheduled BigQuery queries"
+}
+
+resource "google_bigquery_data_transfer_config" "publishing_api_editions_current" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Publishing API editions current"
+  location       = var.region
+  schedule       = "every day 00:00"
+  params = {
+    query = file("bigquery/publishing-api-editions-current.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform-dev/bigquery/README-publishing-api-editions-current.md
+++ b/terraform-dev/bigquery/README-publishing-api-editions-current.md
@@ -1,0 +1,321 @@
+# `publishing-api-editions-current.sql`
+
+This query maintains a table of one record per document as it currently appears
+on the GOV.UK website and in the Content API.
+
+## Source: `publishing-api.editions`
+
+The source data is from the Publishing API database, which contains a record of
+every version of every document that has ever been published or drafted (at
+least since the Publishing API was implemented).
+
+## Target `public.publishing-api-editions-current`
+
+The target is a table of editions of documents as they currently appear on the
+GOV.UK website and in the Content API.  Because this information is already
+publicly available, the table is in the `public` dataset.
+
+## Context
+
+An edition can appear on the GOV.UK website and in the Content API if there is a
+URL where that particular document is available in its own right, or if the
+document is rendered as part of another document that has a URL, such as a
+`person` rendered as part of an `organisation`.
+
+### Editions vs documents
+
+A "content item" (a piece of content) is purely conceptual. It doesn't
+necessarily map to a particular web page. It may represent an organisation, a
+person, a role, a set of contact details such as addresses and telephone
+numbers.  It also isn't versioned.  In the publishing database, it is
+represented only by its `content_id`.  It doesn't even have a 'type'.  There is no
+`content` table, because its only column would be its primary key: `content_id`.
+
+Each content item (unique key: `content_id`) has one or more "documents" (unique
+key: `content_id`, `locale`).  A piece of content has at most one document per
+locale.
+
+One document has one or more "editions" (key: `document_id`, `updated_at`).  The
+edition has a `document_type`, which describes what the edition's content
+item represents.  It is an odd name, and an odd place to record it.  The fact
+that the `document_type` belongs to the edition rather than to either the
+document or the content item means that the schema doesn't guarantee any of
+the following:
+
+* that every edition of the same content item has the same `document_type`
+* that every edition of the same document has the same `document_type`
+* that every _current_ edition of the same content item or document has the
+same `document_type`
+
+We must allow for the `document_type` to vary between:
+
+* different editions of a document, which means the `document_type` of an
+edition can change over time
+* most-recent editions of each document of a given content item, which means
+that different translations of the same content item might have different
+`document_type`s.
+
+A typical example is a consultation, which is represented by a different
+`document_type` in each part of its lifecycle, such as the one whose
+`content_id` is `9884ebdc-8135-4d19-909e-94c744dd7798`.
+
+1. `coming_soon`
+2. `consultation`
+3. `open_consultation`
+4. `closed_consultation`
+5. `consultation_outcome`
+
+Perhaps it would have made more sense to vary the `schema_name`, rather than
+the `document_type`.  Never mind.
+
+```sql
+-- Content items that have had more than one document type
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    locale,
+    document_type
+  FROM
+    publishing_api.editions
+  INNER JOIN
+    publishing_api.documents
+  ON
+    documents.id = editions.document_id )
+SELECT
+  content_id,
+  locale,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id,
+  locale
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|            `content_id`              | `locale` | `n_document_types` |
+|--------------------------------------+----------+--------------------|
+| 0000600f-265d-46b9-9deb-016405b7f369 | en       |                  3 |
+| 000061c8-671f-4d51-8e77-16431e827575 | en       |                  2 |
+| 0001f1a9-3285-4897-baa9-f6663aeb1e8a | en       |                  2 |
+| 00022740-0ba7-4fd0-8ca8-f0c3d6156fec | en       |                  2 |
+| 000227a8-f0d2-417d-8ce4-27a18d62d442 | en       |                  2 |
+| 00026064-784c-4eca-b24b-0f4b092a329a | en       |                  2 |
+| 0002b328-cf71-4271-8360-e0bcc4b6f8fb | en       |                  2 |
+| 000308e8-c04c-4416-89ac-f1d2442f77b6 | en       |                  2 |
+| 00037b70-5b08-44c2-bf0a-fa8eb636a60b | en       |                  2 |
+| 000601a7-19b7-5e92-984a-c2c87ab4d704 | en       |                  2 |
+
+```sql
+SELECT
+  locale,
+  editions.updated_at,
+  document_type,
+  schema_name
+FROM
+  publishing_api.editions
+INNER JOIN
+  publishing_api.documents
+ON
+  documents.id = editions.document_id
+WHERE
+  content_id = '9884ebdc-8135-4d19-909e-94c744dd7798'
+ORDER BY
+  locale,
+  editions.updated_at ;
+```
+
+```sql
+-- Current edition of each document
+CREATE TABLE
+  test.editions_current AS (
+  SELECT
+    documents.content_id,
+    documents.locale,
+    editions.*
+  FROM
+    publishing_api.editions
+  INNER JOIN
+    publishing_api.documents
+  ON
+    documents.id = editions.document_id
+  WHERE
+    state <> 'draft' QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1 );
+```
+
+```sql
+-- Content items that currently have documents whose editions are different
+-- document_types.
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    document_type
+  FROM
+    test.editions_current )
+SELECT
+  content_id,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|             `content_id`             | `n_document_types` |
+|--------------------------------------+--------------------|
+| 004a6456-8fc6-4321-b60b-ca436a8486de |                  2 |
+| 5f5c20e9-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f56a533-7631-11e4-a3cb-005056011aef |                  2 |
+| 5d2b66f9-7631-11e4-a3cb-005056011aef |                  2 |
+| 54134a63-e693-4950-9f39-23d03ca6acf6 |                  2 |
+| 6055de47-7631-11e4-a3cb-005056011aef |                  2 |
+| 87646ce8-ef69-4014-980a-c63b8ccde645 |                  2 |
+| 5fa5bc26-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f568fb2-7631-11e4-a3cb-005056011aef |                  2 |
+| 944c3cde-0915-4dda-bcdb-729eb413d7cd |                  2 |
+
+```sql
+SELECT
+  locale,
+  document_type,
+  updated_at
+FROM
+  test.editions_current
+WHERE
+  content_id = '004a6456-8fc6-4321-b60b-ca436a8486de' ;
+```
+
+| `locale` | `document_type` |         `updated_at`       |
+|----------+-----------------+----------------------------|
+| cy       | placeholder     | 2017-02-02 14:34:56.063013 |
+| en       | foi_release     | 2022-05-09 11:03:34.143869 |
+
+```sql
+-- Editions that are currently online with their own URL
+CREATE TABLE
+  test.editions_online AS (
+  SELECT
+    editions_current.*
+  FROM
+    test.editions_current
+  LEFT JOIN
+    publishing_api.unpublishings
+  ON
+    unpublishings.edition_id = editions_current.id
+  WHERE
+    content_store = 'live'
+    AND state <> 'superseded'
+    AND COALESCE(unpublishings.type <> 'vanish', TRUE)
+    AND ( LEFT(schema_name, 11) <> 'placeholder'
+      OR (
+        -- schema_name must be checked again because short-circuit evaluation
+        -- isn't available in this clause.
+        LEFT(schema_name, 11) = 'placeholder'
+        AND COALESCE(unpublishings.type IN ('gone',
+            'redirect'), FALSE) ) ) ) ;
+```
+
+```sql
+-- Online content items that currently have documents whose editions are
+-- different document_types.
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    document_type
+  FROM
+    test.editions_online )
+SELECT
+  content_id,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|             `content_id`             | `n_document_types` |
+|--------------------------------------+--------------------|
+| 5e2cef4d-7631-11e4-a3cb-005056011aef |                  2 |
+| 5fa5bc26-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f568fb2-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f56a533-7631-11e4-a3cb-005056011aef |                  2 |
+| 54134a63-e693-4950-9f39-23d03ca6acf6 |                  2 |
+| 6055de47-7631-11e4-a3cb-005056011aef |                  2 |
+| 87646ce8-ef69-4014-980a-c63b8ccde645 |                  2 |
+| 6031bb8f-7631-11e4-a3cb-005056011aef |                  2 |
+| 8508f8c9-38d3-41d4-a274-8b4cfb7de61c |                  2 |
+| 944c3cde-0915-4dda-bcdb-729eb413d7cd |                  2 |
+
+```sql
+SELECT
+  locale,
+  document_type,
+  updated_at,
+  base_path
+FROM
+  test.editions_online
+WHERE
+  content_id = '5e2cef4d-7631-11e4-a3cb-005056011aef' ;
+```
+
+| `locale` |  `document_type`   |        `updated_at`        |
+|----------+--------------------+----------------------------|
+| en       | statutory_guidance | 2023-09-29 10:09:26.803491 |
+| cy       | policy_paper       | 2021-01-28 09:32:20.036697 |
+
+## Implementation
+
+It would be expensive to maintain this table in a straightforward batch query,
+because the source table is big. Costs are lowered by:
+
+* Partitioning large tables on `updated_at`.
+* Subsetting for only those editions that haven't been seen yet.
+* Wrapping several queries in a single transaction.
+
+We tell which editions are new since the last update by inspecting the field
+`updated_at`, rather than the field `id`, which isn't guaranteed to be
+sequential, and often isn't.
+
+Unfortunately, `updated_at` isn't unique.  See the following query.
+
+```sql
+SELECT
+  updated_at,
+  COUNT(*) AS n,
+  ARRAY_AGG(id) AS ids
+FROM
+  `publishing_api.editions`
+GROUP BY
+  updated_at
+HAVING
+  n > 1
+ORDER BY
+  updated_at desc ;
+```
+
+It might be possible for multiple rows of the editions table to have the same
+`updated_at` time, but not be inserted in the same transaction, which means that
+they might also not appear in the same nightly backup file.  In case this
+happens, we always delete the records in the `editions_current` and
+`editions_online` tables that have the most recent `updated_at` date. Then we
+can safely treat all records on or after that date as new ones.

--- a/terraform-dev/bigquery/README.md
+++ b/terraform-dev/bigquery/README.md
@@ -1,0 +1,11 @@
+# Queries for batch execution and user-defined functions
+
+This directory contains queries that are executed as part of a daily batch, or
+that define custom functions to be used in other queries.
+
+## `publishing-api-editions-current.sql`
+
+Maintains a table of one record per document that currently appears on the
+website.
+
+See [`README-publishing-api-editions-current.sql`](README-publishing-api-editions-current.sql).

--- a/terraform-dev/bigquery/publishing-api-editions-current.sql
+++ b/terraform-dev/bigquery/publishing-api-editions-current.sql
@@ -1,0 +1,79 @@
+-- Maintains a table `public.publishing_api_editions_current` of one record per
+-- document as it currently appears on the GOV.UK website and in the Content
+-- API.
+--
+-- 1. Filter editions for ones since max(editions_current.updated_at).
+-- 2. Query those editions for the current editions of those documents.
+-- 3. Delete corresponding editions from editions_current and editions_online.
+-- 4. Insert the new current editions into editions_current.
+-- 5. Insert the new online editions into editions_online.
+
+-- All documents of schema_name='redirect' define a redirect in the 'redirect'
+-- column.  None do that aren't, so schema_name='redirect' is necessary and sufficient to
+-- identify redirects.
+
+BEGIN
+
+-- The timestamp of the most recent edition so far
+DECLARE max_updated_at TIMESTAMP DEFAULT (
+  -- Coalesce for the case when editions_current is empty
+  SELECT coalesce(max(updated_at), '0001-01-01 00:00:00+00')
+  FROM public.publishing_api_editions_current
+);
+
+-- In case the same timestamp also exists in a so-far unseen record, delete that
+-- record.  Then all records of that timestamp will be treated as though so-far
+-- unseen.
+DELETE FROM public.publishing_api_editions_current WHERE updated_at = max_updated_at;
+-- A set of so-far unseen editions.
+TRUNCATE TABLE private.publishing_api_editions_new;
+INSERT INTO private.publishing_api_editions_new
+  SELECT * FROM publishing_api.editions WHERE updated_at >= max_updated_at
+;
+
+-- Derive from the new editions a table of the latest edition per document, and
+-- a flag indicating whether it has a presence online (whether a redirect,
+  -- or embedded in other pages, or a page in its own right).
+TRUNCATE TABLE public.publishing_api_editions_new_current;
+INSERT INTO public.publishing_api_editions_new_current
+  SELECT
+    documents.content_id,
+    documents.locale,
+    publishing_api_editions_new.*,
+    -- TODO: derive other values here
+    (
+      coalesce(content_store = 'live', false) -- Includes items that are only embedded in others.
+      AND state <> 'superseded' -- Exclude this rare and illogical case
+      AND coalesce(unpublishings.type <> 'vanish', true)
+      AND (
+        coalesce(left(schema_name, 11) <> 'placeholder', true)
+        OR (
+          -- schema_name must be checked again because short-circuit evaluation
+          -- isn't available in this clause.
+          coalesce(left(schema_name, 11) = 'placeholder', false)
+          AND coalesce(unpublishings.type IN ('gone', 'redirect'), false)
+        )
+      )
+    ) AS is_online
+  FROM private.publishing_api_editions_new
+  INNER JOIN publishing_api.documents ON documents.id = publishing_api_editions_new.document_id
+  LEFT JOIN publishing_api.unpublishings ON unpublishings.edition_id = publishing_api_editions_new.id
+  WHERE state <> 'draft'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
+;
+
+-- Delete rows from the editions_current table where a newer edition of the same
+-- document is now available.
+MERGE INTO
+public.publishing_api_editions_current AS target
+USING public.publishing_api_editions_new_current AS source
+ON source.content_id = target.content_id AND source.locale = target.locale
+WHEN matched THEN DELETE
+;
+
+-- Insert the new editions into the editions_current table
+INSERT INTO public.publishing_api_editions_current
+SELECT * FROM public.publishing_api_editions_new_current
+;
+
+END

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -290,6 +290,7 @@ data "google_iam_policy" "project" {
     members = concat(
       [
         google_service_account.bigquery_page_views.member,
+        google_service_account.bigquery_scheduled_queries.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_content.member,
         google_service_account.gce_content_api.member,

--- a/terraform-dev/schemas/private/publishing-api-editions-new.json
+++ b/terraform-dev/schemas/private/publishing-api-editions-new.json
@@ -1,0 +1,147 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  }
+]

--- a/terraform-dev/schemas/public/publishing-api-editions-current.json
+++ b/terraform-dev/schemas/public/publishing-api-editions-current.json
@@ -1,0 +1,162 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_online",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform-dev/schemas/public/publishing-api-editions-new-current.json
+++ b/terraform-dev/schemas/public/publishing-api-editions-new-current.json
@@ -1,0 +1,162 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_online",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform-staging/bigquery-private.tf
+++ b/terraform-staging/bigquery-private.tf
@@ -15,6 +15,7 @@ data "google_iam_policy" "bigquery_dataset_private" {
     members = [
       "projectWriters",
       google_service_account.bigquery_page_views.member,
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -47,4 +48,12 @@ resource "google_bigquery_table" "page_views" {
   friendly_name = "Page views"
   description   = "Number of views of GOV.UK pages over 7 days"
   schema        = file("schemas/private/page-views.json")
+}
+
+resource "google_bigquery_table" "private_publishing_api_editions_new" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  table_id      = "publishing_api_editions_new"
+  friendly_name = "Publishing API editions (new)"
+  description   = "Publishing API editions from the latest batch update"
+  schema        = file("schemas/private/publishing-api-editions-new.json")
 }

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -14,6 +14,7 @@ data "google_iam_policy" "bigquery_dataset_public" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -36,4 +37,20 @@ data "google_iam_policy" "bigquery_dataset_public" {
 resource "google_bigquery_dataset_iam_policy" "public" {
   dataset_id  = google_bigquery_dataset.public.dataset_id
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
+}
+
+resource "google_bigquery_table" "public_publishing_api_editions_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_current"
+  friendly_name = "Publishing API editions (current)"
+  description   = "The most-recent edition of each document of each content item"
+  schema        = file("schemas/public/publishing-api-editions-current.json")
+}
+
+resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current"
+  schema        = file("schemas/public/publishing-api-editions-new-current.json")
 }

--- a/terraform-staging/bigquery-publishing-api.tf
+++ b/terraform-staging/bigquery-publishing-api.tf
@@ -13,6 +13,7 @@ data "google_iam_policy" "bigquery_dataset_publishing_api" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
       google_service_account.gce_publishing_api.member,
     ]
   }

--- a/terraform-staging/bigquery-scheduled-queries.tf
+++ b/terraform-staging/bigquery-scheduled-queries.tf
@@ -1,0 +1,19 @@
+# Scheduled queries that don't belong in terraform configurations of particular
+# datasets.
+
+resource "google_service_account" "bigquery_scheduled_queries" {
+  account_id   = "bigquery-scheduled"
+  display_name = "Bigquery scheduled queries"
+  description  = "Service account for scheduled BigQuery queries"
+}
+
+resource "google_bigquery_data_transfer_config" "publishing_api_editions_current" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Publishing API editions current"
+  location       = var.region
+  schedule       = "every day 00:00"
+  params = {
+    query = file("bigquery/publishing-api-editions-current.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform-staging/bigquery/README-publishing-api-editions-current.md
+++ b/terraform-staging/bigquery/README-publishing-api-editions-current.md
@@ -1,0 +1,321 @@
+# `publishing-api-editions-current.sql`
+
+This query maintains a table of one record per document as it currently appears
+on the GOV.UK website and in the Content API.
+
+## Source: `publishing-api.editions`
+
+The source data is from the Publishing API database, which contains a record of
+every version of every document that has ever been published or drafted (at
+least since the Publishing API was implemented).
+
+## Target `public.publishing-api-editions-current`
+
+The target is a table of editions of documents as they currently appear on the
+GOV.UK website and in the Content API.  Because this information is already
+publicly available, the table is in the `public` dataset.
+
+## Context
+
+An edition can appear on the GOV.UK website and in the Content API if there is a
+URL where that particular document is available in its own right, or if the
+document is rendered as part of another document that has a URL, such as a
+`person` rendered as part of an `organisation`.
+
+### Editions vs documents
+
+A "content item" (a piece of content) is purely conceptual. It doesn't
+necessarily map to a particular web page. It may represent an organisation, a
+person, a role, a set of contact details such as addresses and telephone
+numbers.  It also isn't versioned.  In the publishing database, it is
+represented only by its `content_id`.  It doesn't even have a 'type'.  There is no
+`content` table, because its only column would be its primary key: `content_id`.
+
+Each content item (unique key: `content_id`) has one or more "documents" (unique
+key: `content_id`, `locale`).  A piece of content has at most one document per
+locale.
+
+One document has one or more "editions" (key: `document_id`, `updated_at`).  The
+edition has a `document_type`, which describes what the edition's content
+item represents.  It is an odd name, and an odd place to record it.  The fact
+that the `document_type` belongs to the edition rather than to either the
+document or the content item means that the schema doesn't guarantee any of
+the following:
+
+* that every edition of the same content item has the same `document_type`
+* that every edition of the same document has the same `document_type`
+* that every _current_ edition of the same content item or document has the
+same `document_type`
+
+We must allow for the `document_type` to vary between:
+
+* different editions of a document, which means the `document_type` of an
+edition can change over time
+* most-recent editions of each document of a given content item, which means
+that different translations of the same content item might have different
+`document_type`s.
+
+A typical example is a consultation, which is represented by a different
+`document_type` in each part of its lifecycle, such as the one whose
+`content_id` is `9884ebdc-8135-4d19-909e-94c744dd7798`.
+
+1. `coming_soon`
+2. `consultation`
+3. `open_consultation`
+4. `closed_consultation`
+5. `consultation_outcome`
+
+Perhaps it would have made more sense to vary the `schema_name`, rather than
+the `document_type`.  Never mind.
+
+```sql
+-- Content items that have had more than one document type
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    locale,
+    document_type
+  FROM
+    publishing_api.editions
+  INNER JOIN
+    publishing_api.documents
+  ON
+    documents.id = editions.document_id )
+SELECT
+  content_id,
+  locale,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id,
+  locale
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|            `content_id`              | `locale` | `n_document_types` |
+|--------------------------------------+----------+--------------------|
+| 0000600f-265d-46b9-9deb-016405b7f369 | en       |                  3 |
+| 000061c8-671f-4d51-8e77-16431e827575 | en       |                  2 |
+| 0001f1a9-3285-4897-baa9-f6663aeb1e8a | en       |                  2 |
+| 00022740-0ba7-4fd0-8ca8-f0c3d6156fec | en       |                  2 |
+| 000227a8-f0d2-417d-8ce4-27a18d62d442 | en       |                  2 |
+| 00026064-784c-4eca-b24b-0f4b092a329a | en       |                  2 |
+| 0002b328-cf71-4271-8360-e0bcc4b6f8fb | en       |                  2 |
+| 000308e8-c04c-4416-89ac-f1d2442f77b6 | en       |                  2 |
+| 00037b70-5b08-44c2-bf0a-fa8eb636a60b | en       |                  2 |
+| 000601a7-19b7-5e92-984a-c2c87ab4d704 | en       |                  2 |
+
+```sql
+SELECT
+  locale,
+  editions.updated_at,
+  document_type,
+  schema_name
+FROM
+  publishing_api.editions
+INNER JOIN
+  publishing_api.documents
+ON
+  documents.id = editions.document_id
+WHERE
+  content_id = '9884ebdc-8135-4d19-909e-94c744dd7798'
+ORDER BY
+  locale,
+  editions.updated_at ;
+```
+
+```sql
+-- Current edition of each document
+CREATE TABLE
+  test.editions_current AS (
+  SELECT
+    documents.content_id,
+    documents.locale,
+    editions.*
+  FROM
+    publishing_api.editions
+  INNER JOIN
+    publishing_api.documents
+  ON
+    documents.id = editions.document_id
+  WHERE
+    state <> 'draft' QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1 );
+```
+
+```sql
+-- Content items that currently have documents whose editions are different
+-- document_types.
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    document_type
+  FROM
+    test.editions_current )
+SELECT
+  content_id,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|             `content_id`             | `n_document_types` |
+|--------------------------------------+--------------------|
+| 004a6456-8fc6-4321-b60b-ca436a8486de |                  2 |
+| 5f5c20e9-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f56a533-7631-11e4-a3cb-005056011aef |                  2 |
+| 5d2b66f9-7631-11e4-a3cb-005056011aef |                  2 |
+| 54134a63-e693-4950-9f39-23d03ca6acf6 |                  2 |
+| 6055de47-7631-11e4-a3cb-005056011aef |                  2 |
+| 87646ce8-ef69-4014-980a-c63b8ccde645 |                  2 |
+| 5fa5bc26-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f568fb2-7631-11e4-a3cb-005056011aef |                  2 |
+| 944c3cde-0915-4dda-bcdb-729eb413d7cd |                  2 |
+
+```sql
+SELECT
+  locale,
+  document_type,
+  updated_at
+FROM
+  test.editions_current
+WHERE
+  content_id = '004a6456-8fc6-4321-b60b-ca436a8486de' ;
+```
+
+| `locale` | `document_type` |         `updated_at`       |
+|----------+-----------------+----------------------------|
+| cy       | placeholder     | 2017-02-02 14:34:56.063013 |
+| en       | foi_release     | 2022-05-09 11:03:34.143869 |
+
+```sql
+-- Editions that are currently online with their own URL
+CREATE TABLE
+  test.editions_online AS (
+  SELECT
+    editions_current.*
+  FROM
+    test.editions_current
+  LEFT JOIN
+    publishing_api.unpublishings
+  ON
+    unpublishings.edition_id = editions_current.id
+  WHERE
+    content_store = 'live'
+    AND state <> 'superseded'
+    AND COALESCE(unpublishings.type <> 'vanish', TRUE)
+    AND ( LEFT(schema_name, 11) <> 'placeholder'
+      OR (
+        -- schema_name must be checked again because short-circuit evaluation
+        -- isn't available in this clause.
+        LEFT(schema_name, 11) = 'placeholder'
+        AND COALESCE(unpublishings.type IN ('gone',
+            'redirect'), FALSE) ) ) ) ;
+```
+
+```sql
+-- Online content items that currently have documents whose editions are
+-- different document_types.
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    document_type
+  FROM
+    test.editions_online )
+SELECT
+  content_id,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|             `content_id`             | `n_document_types` |
+|--------------------------------------+--------------------|
+| 5e2cef4d-7631-11e4-a3cb-005056011aef |                  2 |
+| 5fa5bc26-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f568fb2-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f56a533-7631-11e4-a3cb-005056011aef |                  2 |
+| 54134a63-e693-4950-9f39-23d03ca6acf6 |                  2 |
+| 6055de47-7631-11e4-a3cb-005056011aef |                  2 |
+| 87646ce8-ef69-4014-980a-c63b8ccde645 |                  2 |
+| 6031bb8f-7631-11e4-a3cb-005056011aef |                  2 |
+| 8508f8c9-38d3-41d4-a274-8b4cfb7de61c |                  2 |
+| 944c3cde-0915-4dda-bcdb-729eb413d7cd |                  2 |
+
+```sql
+SELECT
+  locale,
+  document_type,
+  updated_at,
+  base_path
+FROM
+  test.editions_online
+WHERE
+  content_id = '5e2cef4d-7631-11e4-a3cb-005056011aef' ;
+```
+
+| `locale` |  `document_type`   |        `updated_at`        |
+|----------+--------------------+----------------------------|
+| en       | statutory_guidance | 2023-09-29 10:09:26.803491 |
+| cy       | policy_paper       | 2021-01-28 09:32:20.036697 |
+
+## Implementation
+
+It would be expensive to maintain this table in a straightforward batch query,
+because the source table is big. Costs are lowered by:
+
+* Partitioning large tables on `updated_at`.
+* Subsetting for only those editions that haven't been seen yet.
+* Wrapping several queries in a single transaction.
+
+We tell which editions are new since the last update by inspecting the field
+`updated_at`, rather than the field `id`, which isn't guaranteed to be
+sequential, and often isn't.
+
+Unfortunately, `updated_at` isn't unique.  See the following query.
+
+```sql
+SELECT
+  updated_at,
+  COUNT(*) AS n,
+  ARRAY_AGG(id) AS ids
+FROM
+  `publishing_api.editions`
+GROUP BY
+  updated_at
+HAVING
+  n > 1
+ORDER BY
+  updated_at desc ;
+```
+
+It might be possible for multiple rows of the editions table to have the same
+`updated_at` time, but not be inserted in the same transaction, which means that
+they might also not appear in the same nightly backup file.  In case this
+happens, we always delete the records in the `editions_current` and
+`editions_online` tables that have the most recent `updated_at` date. Then we
+can safely treat all records on or after that date as new ones.

--- a/terraform-staging/bigquery/README.md
+++ b/terraform-staging/bigquery/README.md
@@ -1,0 +1,11 @@
+# Queries for batch execution and user-defined functions
+
+This directory contains queries that are executed as part of a daily batch, or
+that define custom functions to be used in other queries.
+
+## `publishing-api-editions-current.sql`
+
+Maintains a table of one record per document that currently appears on the
+website.
+
+See [`README-publishing-api-editions-current.sql`](README-publishing-api-editions-current.sql).

--- a/terraform-staging/bigquery/publishing-api-editions-current.sql
+++ b/terraform-staging/bigquery/publishing-api-editions-current.sql
@@ -1,0 +1,79 @@
+-- Maintains a table `public.publishing_api_editions_current` of one record per
+-- document as it currently appears on the GOV.UK website and in the Content
+-- API.
+--
+-- 1. Filter editions for ones since max(editions_current.updated_at).
+-- 2. Query those editions for the current editions of those documents.
+-- 3. Delete corresponding editions from editions_current and editions_online.
+-- 4. Insert the new current editions into editions_current.
+-- 5. Insert the new online editions into editions_online.
+
+-- All documents of schema_name='redirect' define a redirect in the 'redirect'
+-- column.  None do that aren't, so schema_name='redirect' is necessary and sufficient to
+-- identify redirects.
+
+BEGIN
+
+-- The timestamp of the most recent edition so far
+DECLARE max_updated_at TIMESTAMP DEFAULT (
+  -- Coalesce for the case when editions_current is empty
+  SELECT coalesce(max(updated_at), '0001-01-01 00:00:00+00')
+  FROM public.publishing_api_editions_current
+);
+
+-- In case the same timestamp also exists in a so-far unseen record, delete that
+-- record.  Then all records of that timestamp will be treated as though so-far
+-- unseen.
+DELETE FROM public.publishing_api_editions_current WHERE updated_at = max_updated_at;
+-- A set of so-far unseen editions.
+TRUNCATE TABLE private.publishing_api_editions_new;
+INSERT INTO private.publishing_api_editions_new
+  SELECT * FROM publishing_api.editions WHERE updated_at >= max_updated_at
+;
+
+-- Derive from the new editions a table of the latest edition per document, and
+-- a flag indicating whether it has a presence online (whether a redirect,
+  -- or embedded in other pages, or a page in its own right).
+TRUNCATE TABLE public.publishing_api_editions_new_current;
+INSERT INTO public.publishing_api_editions_new_current
+  SELECT
+    documents.content_id,
+    documents.locale,
+    publishing_api_editions_new.*,
+    -- TODO: derive other values here
+    (
+      coalesce(content_store = 'live', false) -- Includes items that are only embedded in others.
+      AND state <> 'superseded' -- Exclude this rare and illogical case
+      AND coalesce(unpublishings.type <> 'vanish', true)
+      AND (
+        coalesce(left(schema_name, 11) <> 'placeholder', true)
+        OR (
+          -- schema_name must be checked again because short-circuit evaluation
+          -- isn't available in this clause.
+          coalesce(left(schema_name, 11) = 'placeholder', false)
+          AND coalesce(unpublishings.type IN ('gone', 'redirect'), false)
+        )
+      )
+    ) AS is_online
+  FROM private.publishing_api_editions_new
+  INNER JOIN publishing_api.documents ON documents.id = publishing_api_editions_new.document_id
+  LEFT JOIN publishing_api.unpublishings ON unpublishings.edition_id = publishing_api_editions_new.id
+  WHERE state <> 'draft'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
+;
+
+-- Delete rows from the editions_current table where a newer edition of the same
+-- document is now available.
+MERGE INTO
+public.publishing_api_editions_current AS target
+USING public.publishing_api_editions_new_current AS source
+ON source.content_id = target.content_id AND source.locale = target.locale
+WHEN matched THEN DELETE
+;
+
+-- Insert the new editions into the editions_current table
+INSERT INTO public.publishing_api_editions_current
+SELECT * FROM public.publishing_api_editions_new_current
+;
+
+END

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -290,6 +290,7 @@ data "google_iam_policy" "project" {
     members = concat(
       [
         google_service_account.bigquery_page_views.member,
+        google_service_account.bigquery_scheduled_queries.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_content.member,
         google_service_account.gce_content_api.member,

--- a/terraform-staging/schemas/private/publishing-api-editions-new.json
+++ b/terraform-staging/schemas/private/publishing-api-editions-new.json
@@ -1,0 +1,147 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  }
+]

--- a/terraform-staging/schemas/public/publishing-api-editions-current.json
+++ b/terraform-staging/schemas/public/publishing-api-editions-current.json
@@ -1,0 +1,162 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_online",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform-staging/schemas/public/publishing-api-editions-new-current.json
+++ b/terraform-staging/schemas/public/publishing-api-editions-new-current.json
@@ -1,0 +1,162 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_online",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform/bigquery-private.tf
+++ b/terraform/bigquery-private.tf
@@ -15,6 +15,7 @@ data "google_iam_policy" "bigquery_dataset_private" {
     members = [
       "projectWriters",
       google_service_account.bigquery_page_views.member,
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -47,4 +48,12 @@ resource "google_bigquery_table" "page_views" {
   friendly_name = "Page views"
   description   = "Number of views of GOV.UK pages over 7 days"
   schema        = file("schemas/private/page-views.json")
+}
+
+resource "google_bigquery_table" "private_publishing_api_editions_new" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  table_id      = "publishing_api_editions_new"
+  friendly_name = "Publishing API editions (new)"
+  description   = "Publishing API editions from the latest batch update"
+  schema        = file("schemas/private/publishing-api-editions-new.json")
 }

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -14,6 +14,7 @@ data "google_iam_policy" "bigquery_dataset_public" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -36,4 +37,20 @@ data "google_iam_policy" "bigquery_dataset_public" {
 resource "google_bigquery_dataset_iam_policy" "public" {
   dataset_id  = google_bigquery_dataset.public.dataset_id
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
+}
+
+resource "google_bigquery_table" "public_publishing_api_editions_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_current"
+  friendly_name = "Publishing API editions (current)"
+  description   = "The most-recent edition of each document of each content item"
+  schema        = file("schemas/public/publishing-api-editions-current.json")
+}
+
+resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current"
+  schema        = file("schemas/public/publishing-api-editions-new-current.json")
 }

--- a/terraform/bigquery-publishing-api.tf
+++ b/terraform/bigquery-publishing-api.tf
@@ -13,6 +13,7 @@ data "google_iam_policy" "bigquery_dataset_publishing_api" {
     role = "roles/bigquery.dataEditor"
     members = [
       "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
       google_service_account.gce_publishing_api.member,
     ]
   }

--- a/terraform/bigquery-scheduled-queries.tf
+++ b/terraform/bigquery-scheduled-queries.tf
@@ -1,0 +1,19 @@
+# Scheduled queries that don't belong in terraform configurations of particular
+# datasets.
+
+resource "google_service_account" "bigquery_scheduled_queries" {
+  account_id   = "bigquery-scheduled"
+  display_name = "Bigquery scheduled queries"
+  description  = "Service account for scheduled BigQuery queries"
+}
+
+resource "google_bigquery_data_transfer_config" "publishing_api_editions_current" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Publishing API editions current"
+  location       = var.region
+  schedule       = "every day 00:00"
+  params = {
+    query = file("bigquery/publishing-api-editions-current.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform/bigquery/README-publishing-api-editions-current.md
+++ b/terraform/bigquery/README-publishing-api-editions-current.md
@@ -1,0 +1,321 @@
+# `publishing-api-editions-current.sql`
+
+This query maintains a table of one record per document as it currently appears
+on the GOV.UK website and in the Content API.
+
+## Source: `publishing-api.editions`
+
+The source data is from the Publishing API database, which contains a record of
+every version of every document that has ever been published or drafted (at
+least since the Publishing API was implemented).
+
+## Target `public.publishing-api-editions-current`
+
+The target is a table of editions of documents as they currently appear on the
+GOV.UK website and in the Content API.  Because this information is already
+publicly available, the table is in the `public` dataset.
+
+## Context
+
+An edition can appear on the GOV.UK website and in the Content API if there is a
+URL where that particular document is available in its own right, or if the
+document is rendered as part of another document that has a URL, such as a
+`person` rendered as part of an `organisation`.
+
+### Editions vs documents
+
+A "content item" (a piece of content) is purely conceptual. It doesn't
+necessarily map to a particular web page. It may represent an organisation, a
+person, a role, a set of contact details such as addresses and telephone
+numbers.  It also isn't versioned.  In the publishing database, it is
+represented only by its `content_id`.  It doesn't even have a 'type'.  There is no
+`content` table, because its only column would be its primary key: `content_id`.
+
+Each content item (unique key: `content_id`) has one or more "documents" (unique
+key: `content_id`, `locale`).  A piece of content has at most one document per
+locale.
+
+One document has one or more "editions" (key: `document_id`, `updated_at`).  The
+edition has a `document_type`, which describes what the edition's content
+item represents.  It is an odd name, and an odd place to record it.  The fact
+that the `document_type` belongs to the edition rather than to either the
+document or the content item means that the schema doesn't guarantee any of
+the following:
+
+* that every edition of the same content item has the same `document_type`
+* that every edition of the same document has the same `document_type`
+* that every _current_ edition of the same content item or document has the
+same `document_type`
+
+We must allow for the `document_type` to vary between:
+
+* different editions of a document, which means the `document_type` of an
+edition can change over time
+* most-recent editions of each document of a given content item, which means
+that different translations of the same content item might have different
+`document_type`s.
+
+A typical example is a consultation, which is represented by a different
+`document_type` in each part of its lifecycle, such as the one whose
+`content_id` is `9884ebdc-8135-4d19-909e-94c744dd7798`.
+
+1. `coming_soon`
+2. `consultation`
+3. `open_consultation`
+4. `closed_consultation`
+5. `consultation_outcome`
+
+Perhaps it would have made more sense to vary the `schema_name`, rather than
+the `document_type`.  Never mind.
+
+```sql
+-- Content items that have had more than one document type
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    locale,
+    document_type
+  FROM
+    publishing_api.editions
+  INNER JOIN
+    publishing_api.documents
+  ON
+    documents.id = editions.document_id )
+SELECT
+  content_id,
+  locale,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id,
+  locale
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|            `content_id`              | `locale` | `n_document_types` |
+|--------------------------------------+----------+--------------------|
+| 0000600f-265d-46b9-9deb-016405b7f369 | en       |                  3 |
+| 000061c8-671f-4d51-8e77-16431e827575 | en       |                  2 |
+| 0001f1a9-3285-4897-baa9-f6663aeb1e8a | en       |                  2 |
+| 00022740-0ba7-4fd0-8ca8-f0c3d6156fec | en       |                  2 |
+| 000227a8-f0d2-417d-8ce4-27a18d62d442 | en       |                  2 |
+| 00026064-784c-4eca-b24b-0f4b092a329a | en       |                  2 |
+| 0002b328-cf71-4271-8360-e0bcc4b6f8fb | en       |                  2 |
+| 000308e8-c04c-4416-89ac-f1d2442f77b6 | en       |                  2 |
+| 00037b70-5b08-44c2-bf0a-fa8eb636a60b | en       |                  2 |
+| 000601a7-19b7-5e92-984a-c2c87ab4d704 | en       |                  2 |
+
+```sql
+SELECT
+  locale,
+  editions.updated_at,
+  document_type,
+  schema_name
+FROM
+  publishing_api.editions
+INNER JOIN
+  publishing_api.documents
+ON
+  documents.id = editions.document_id
+WHERE
+  content_id = '9884ebdc-8135-4d19-909e-94c744dd7798'
+ORDER BY
+  locale,
+  editions.updated_at ;
+```
+
+```sql
+-- Current edition of each document
+CREATE TABLE
+  test.editions_current AS (
+  SELECT
+    documents.content_id,
+    documents.locale,
+    editions.*
+  FROM
+    publishing_api.editions
+  INNER JOIN
+    publishing_api.documents
+  ON
+    documents.id = editions.document_id
+  WHERE
+    state <> 'draft' QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1 );
+```
+
+```sql
+-- Content items that currently have documents whose editions are different
+-- document_types.
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    document_type
+  FROM
+    test.editions_current )
+SELECT
+  content_id,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|             `content_id`             | `n_document_types` |
+|--------------------------------------+--------------------|
+| 004a6456-8fc6-4321-b60b-ca436a8486de |                  2 |
+| 5f5c20e9-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f56a533-7631-11e4-a3cb-005056011aef |                  2 |
+| 5d2b66f9-7631-11e4-a3cb-005056011aef |                  2 |
+| 54134a63-e693-4950-9f39-23d03ca6acf6 |                  2 |
+| 6055de47-7631-11e4-a3cb-005056011aef |                  2 |
+| 87646ce8-ef69-4014-980a-c63b8ccde645 |                  2 |
+| 5fa5bc26-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f568fb2-7631-11e4-a3cb-005056011aef |                  2 |
+| 944c3cde-0915-4dda-bcdb-729eb413d7cd |                  2 |
+
+```sql
+SELECT
+  locale,
+  document_type,
+  updated_at
+FROM
+  test.editions_current
+WHERE
+  content_id = '004a6456-8fc6-4321-b60b-ca436a8486de' ;
+```
+
+| `locale` | `document_type` |         `updated_at`       |
+|----------+-----------------+----------------------------|
+| cy       | placeholder     | 2017-02-02 14:34:56.063013 |
+| en       | foi_release     | 2022-05-09 11:03:34.143869 |
+
+```sql
+-- Editions that are currently online with their own URL
+CREATE TABLE
+  test.editions_online AS (
+  SELECT
+    editions_current.*
+  FROM
+    test.editions_current
+  LEFT JOIN
+    publishing_api.unpublishings
+  ON
+    unpublishings.edition_id = editions_current.id
+  WHERE
+    content_store = 'live'
+    AND state <> 'superseded'
+    AND COALESCE(unpublishings.type <> 'vanish', TRUE)
+    AND ( LEFT(schema_name, 11) <> 'placeholder'
+      OR (
+        -- schema_name must be checked again because short-circuit evaluation
+        -- isn't available in this clause.
+        LEFT(schema_name, 11) = 'placeholder'
+        AND COALESCE(unpublishings.type IN ('gone',
+            'redirect'), FALSE) ) ) ) ;
+```
+
+```sql
+-- Online content items that currently have documents whose editions are
+-- different document_types.
+WITH
+  doc_types AS (
+  SELECT
+    DISTINCT content_id,
+    document_type
+  FROM
+    test.editions_online )
+SELECT
+  content_id,
+  COUNT(*) AS n_document_types
+FROM
+  doc_types
+GROUP BY
+  content_id
+HAVING
+  COUNT(*) > 1
+ORDER BY
+  COUNT(*) DESC
+LIMIT
+  10 ;
+```
+
+|             `content_id`             | `n_document_types` |
+|--------------------------------------+--------------------|
+| 5e2cef4d-7631-11e4-a3cb-005056011aef |                  2 |
+| 5fa5bc26-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f568fb2-7631-11e4-a3cb-005056011aef |                  2 |
+| 5f56a533-7631-11e4-a3cb-005056011aef |                  2 |
+| 54134a63-e693-4950-9f39-23d03ca6acf6 |                  2 |
+| 6055de47-7631-11e4-a3cb-005056011aef |                  2 |
+| 87646ce8-ef69-4014-980a-c63b8ccde645 |                  2 |
+| 6031bb8f-7631-11e4-a3cb-005056011aef |                  2 |
+| 8508f8c9-38d3-41d4-a274-8b4cfb7de61c |                  2 |
+| 944c3cde-0915-4dda-bcdb-729eb413d7cd |                  2 |
+
+```sql
+SELECT
+  locale,
+  document_type,
+  updated_at,
+  base_path
+FROM
+  test.editions_online
+WHERE
+  content_id = '5e2cef4d-7631-11e4-a3cb-005056011aef' ;
+```
+
+| `locale` |  `document_type`   |        `updated_at`        |
+|----------+--------------------+----------------------------|
+| en       | statutory_guidance | 2023-09-29 10:09:26.803491 |
+| cy       | policy_paper       | 2021-01-28 09:32:20.036697 |
+
+## Implementation
+
+It would be expensive to maintain this table in a straightforward batch query,
+because the source table is big. Costs are lowered by:
+
+* Partitioning large tables on `updated_at`.
+* Subsetting for only those editions that haven't been seen yet.
+* Wrapping several queries in a single transaction.
+
+We tell which editions are new since the last update by inspecting the field
+`updated_at`, rather than the field `id`, which isn't guaranteed to be
+sequential, and often isn't.
+
+Unfortunately, `updated_at` isn't unique.  See the following query.
+
+```sql
+SELECT
+  updated_at,
+  COUNT(*) AS n,
+  ARRAY_AGG(id) AS ids
+FROM
+  `publishing_api.editions`
+GROUP BY
+  updated_at
+HAVING
+  n > 1
+ORDER BY
+  updated_at desc ;
+```
+
+It might be possible for multiple rows of the editions table to have the same
+`updated_at` time, but not be inserted in the same transaction, which means that
+they might also not appear in the same nightly backup file.  In case this
+happens, we always delete the records in the `editions_current` and
+`editions_online` tables that have the most recent `updated_at` date. Then we
+can safely treat all records on or after that date as new ones.

--- a/terraform/bigquery/README.md
+++ b/terraform/bigquery/README.md
@@ -1,0 +1,11 @@
+# Queries for batch execution and user-defined functions
+
+This directory contains queries that are executed as part of a daily batch, or
+that define custom functions to be used in other queries.
+
+## `publishing-api-editions-current.sql`
+
+Maintains a table of one record per document that currently appears on the
+website.
+
+See [`README-publishing-api-editions-current.sql`](README-publishing-api-editions-current.sql).

--- a/terraform/bigquery/publishing-api-editions-current.sql
+++ b/terraform/bigquery/publishing-api-editions-current.sql
@@ -1,0 +1,79 @@
+-- Maintains a table `public.publishing_api_editions_current` of one record per
+-- document as it currently appears on the GOV.UK website and in the Content
+-- API.
+--
+-- 1. Filter editions for ones since max(editions_current.updated_at).
+-- 2. Query those editions for the current editions of those documents.
+-- 3. Delete corresponding editions from editions_current and editions_online.
+-- 4. Insert the new current editions into editions_current.
+-- 5. Insert the new online editions into editions_online.
+
+-- All documents of schema_name='redirect' define a redirect in the 'redirect'
+-- column.  None do that aren't, so schema_name='redirect' is necessary and sufficient to
+-- identify redirects.
+
+BEGIN
+
+-- The timestamp of the most recent edition so far
+DECLARE max_updated_at TIMESTAMP DEFAULT (
+  -- Coalesce for the case when editions_current is empty
+  SELECT coalesce(max(updated_at), '0001-01-01 00:00:00+00')
+  FROM public.publishing_api_editions_current
+);
+
+-- In case the same timestamp also exists in a so-far unseen record, delete that
+-- record.  Then all records of that timestamp will be treated as though so-far
+-- unseen.
+DELETE FROM public.publishing_api_editions_current WHERE updated_at = max_updated_at;
+-- A set of so-far unseen editions.
+TRUNCATE TABLE private.publishing_api_editions_new;
+INSERT INTO private.publishing_api_editions_new
+  SELECT * FROM publishing_api.editions WHERE updated_at >= max_updated_at
+;
+
+-- Derive from the new editions a table of the latest edition per document, and
+-- a flag indicating whether it has a presence online (whether a redirect,
+  -- or embedded in other pages, or a page in its own right).
+TRUNCATE TABLE public.publishing_api_editions_new_current;
+INSERT INTO public.publishing_api_editions_new_current
+  SELECT
+    documents.content_id,
+    documents.locale,
+    publishing_api_editions_new.*,
+    -- TODO: derive other values here
+    (
+      coalesce(content_store = 'live', false) -- Includes items that are only embedded in others.
+      AND state <> 'superseded' -- Exclude this rare and illogical case
+      AND coalesce(unpublishings.type <> 'vanish', true)
+      AND (
+        coalesce(left(schema_name, 11) <> 'placeholder', true)
+        OR (
+          -- schema_name must be checked again because short-circuit evaluation
+          -- isn't available in this clause.
+          coalesce(left(schema_name, 11) = 'placeholder', false)
+          AND coalesce(unpublishings.type IN ('gone', 'redirect'), false)
+        )
+      )
+    ) AS is_online
+  FROM private.publishing_api_editions_new
+  INNER JOIN publishing_api.documents ON documents.id = publishing_api_editions_new.document_id
+  LEFT JOIN publishing_api.unpublishings ON unpublishings.edition_id = publishing_api_editions_new.id
+  WHERE state <> 'draft'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
+;
+
+-- Delete rows from the editions_current table where a newer edition of the same
+-- document is now available.
+MERGE INTO
+public.publishing_api_editions_current AS target
+USING public.publishing_api_editions_new_current AS source
+ON source.content_id = target.content_id AND source.locale = target.locale
+WHEN matched THEN DELETE
+;
+
+-- Insert the new editions into the editions_current table
+INSERT INTO public.publishing_api_editions_current
+SELECT * FROM public.publishing_api_editions_new_current
+;
+
+END

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -290,6 +290,7 @@ data "google_iam_policy" "project" {
     members = concat(
       [
         google_service_account.bigquery_page_views.member,
+        google_service_account.bigquery_scheduled_queries.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_content.member,
         google_service_account.gce_content_api.member,

--- a/terraform/schemas/private/publishing-api-editions-new.json
+++ b/terraform/schemas/private/publishing-api-editions-new.json
@@ -1,0 +1,147 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  }
+]

--- a/terraform/schemas/public/publishing-api-editions-current.json
+++ b/terraform/schemas/public/publishing-api-editions-current.json
@@ -1,0 +1,162 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_online",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform/schemas/public/publishing-api-editions-new-current.json
+++ b/terraform/schemas/public/publishing-api-editions-new-current.json
@@ -1,0 +1,162 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_facing_version",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_store",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_request_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "major_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_api_last_edited_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "auth_bypass_ids",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_online",
+    "type": "BOOLEAN"
+  }
+]


### PR DESCRIPTION
[Trello](https://trello.com/c/e3nrmnPn/123-use-the-publishing-api-instead-of-the-content-api)

- Schedule a query to derive current editions of documents that may be
  on the GOV.UK website and in the Content API.
- Execute it with a new service account for generic queries that don't
  belong to particular datasets.  Currently the only account for
  scheduled queries is specifically for the `search` dataset for the
  GovSearch app.
