### PR TITLE
feat: extract govspeak and/or html from editions

### DIFF
--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -54,3 +54,19 @@ resource "google_bigquery_table" "public_publishing_api_editions_current" {
   description   = "The most-recent edition of each document of each content item"
   schema        = file("schemas/public/publishing-api-editions-current.json")
 }
+
+resource "google_bigquery_table" "public_markup_new" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "markup_new"
+  friendly_name = "Markup (new records)"
+  description   = "Markeup extracted from editions in the latest batch"
+  schema        = file("schemas/public/markup-new.json")
+}
+
+resource "google_bigquery_table" "public_markup" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "markup"
+  friendly_name = "Markup"
+  description   = "Markeup extracted from editions in the latest batch"
+  schema        = file("schemas/public/markup.json")
+}

--- a/terraform-dev/bigquery-scheduled-queries.tf
+++ b/terraform-dev/bigquery-scheduled-queries.tf
@@ -17,3 +17,14 @@ resource "google_bigquery_data_transfer_config" "publishing_api_editions_current
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
+
+resource "google_bigquery_data_transfer_config" "extract_markup" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Extract markup"
+  location       = var.region
+  schedule       = "every day 01:00"
+  params = {
+    query = file("bigquery/extract-markup-from-editions.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform-dev/bigquery/README-extract-markup-from-editions.md
+++ b/terraform-dev/bigquery/README-extract-markup-from-editions.md
@@ -1,0 +1,18 @@
+# `extract-markup-from-editions.sql`
+
+This query extracts the govspeak and/or HTML content of editions, according to their
+[`schema_name`](https://docs.publishing.service.gov.uk/content-schemas.html). If only govspeak is available, then it is rendered into HTML.
+
+[Not all schemas are supported](https://docs.google.com/spreadsheets/d/16AoHrcp5Wn9gyEhLFf1psPNJYn59VX0WEzNN7u54CZM/edit#gid=190179367).  Ones that aren't supported are usually ones that don't contain anything resembling "content".  Some of the ones that aren't supported contain links to other documents, so it would be good to extract those links one day to support the 'link search' function in the GovSearch app.
+
+Intermediate steps are stored in tables for subsequent processing, such as extracting elements of HTML.
+
+## Rendering govspeak to HTML
+
+[GovSpeak](https://github.com/alphagov/govspeak) is a markdown extension for GOV.UK editors, implemented in a Ruby gem.
+
+Some GovSpeak is rendered to HTML before it is received by the Publishing API. Most GovSpeak is rendered between the Publishing API and the Content API. Because not all GovSpeak is rendered by the same app, it might not be rendered by the same version of the GovSpeak ruby gem.
+
+We define a BigQuery remote function that calls a Cloud Function that is implemented in Cloud Run, which hosts a docker image containing the GovSpeak ruby gem. See the implementation in the [initial pull request](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/561).
+
+Theoretically BigQuery and Cloud Run automatically scale to render govspeak in bulk on hundreds of thousands of documents, but in practice it isn't very quick. Not as many instances of the virtual machine are created as are configured, and some of them are idle some of the time.  This doesn't matter much, because on most days there are only a handful of new editions to render.  In a test, a hundred thousand documents were rendered in 20 minutes.

--- a/terraform-dev/bigquery/README.md
+++ b/terraform-dev/bigquery/README.md
@@ -9,3 +9,10 @@ Maintains a table of one record per document that currently appears on the
 website.
 
 See [`README-publishing-api-editions-current.sql`](README-publishing-api-editions-current.sql).
+
+## `extract-markup-from-editions.sql`
+
+Maintains a table of one record per document that currently appears on the
+website.
+
+See [`README-extract-markup-from-editions.sql`](README-extract-markup-from-editions.sql).

--- a/terraform-dev/bigquery/extract-markup-from-editions.sql
+++ b/terraform-dev/bigquery/extract-markup-from-editions.sql
@@ -1,0 +1,310 @@
+-- Maintains a table `public.markup` of
+-- * one record per document if the document has a single part
+-- * one record per part of multipart documents, whare the ones with schema_name
+--   IN ('guide', 'travel_advice')
+--
+-- 1. Fetch new editions since the last batch update from
+--    public.publishing_api_editions_new_current.
+-- 2. Extract markup from those editions according to their schema.
+-- 3. Where HTML is null, render the GovSpeak to HTML.
+-- 4. Delete outdated editions from public.markup.
+-- 4. Insert new markup into public.markup.
+
+BEGIN
+
+-- Extract the govspeak and/or html versions of content from a JSON array
+--
+-- Example input:
+-- [
+--  {"content":"# Govspeak Content","content_type":"text/govspeak"},
+--  {"content":"<h1>HTML Content</h1>","content_type":"text/html"}
+-- ]
+--
+-- Output: STRUCT(govspeak, html)
+CREATE TEMP FUNCTION markup_from_json_array(array_of_json JSON) AS ((
+    WITH keyvalues AS (
+      SELECT
+        STRING(JSON_QUERY(item, '$.content')) AS content,
+        STRING(JSON_QUERY(item, '$.content_type')) AS content_type
+      FROM UNNEST(JSON_QUERY_ARRAY(array_of_json)) AS item
+    )
+    SELECT (SELECT AS STRUCT govspeak AS govspeak, html AS html)
+    FROM keyvalues
+    PIVOT(
+      ANY_VALUE(content)
+      FOR content_type IN ('text/govspeak' as govspeak, 'text/html' as html)
+    )
+));
+
+TRUNCATE TABLE public.markup_new;
+INSERT INTO public.markup_new
+-- schema_map ought to be a table, but it would take a lot of configuration.  If
+-- we used DBT or SQLMesh then it would be easier, as a seed, but those tools
+-- also require a lot of configuration.
+WITH schema_map AS (
+  SELECT 'calendar' AS schema_name, 'body' AS govspeak_location
+  UNION ALL SELECT 'call_for_evidence', 'body'
+  UNION ALL SELECT 'case_study', 'body'
+  UNION ALL SELECT 'consultation', 'body'
+  UNION ALL SELECT 'corporate_information_page', 'body'
+  UNION ALL SELECT 'detailed_guide', 'body'
+  UNION ALL SELECT 'document_collection', 'body'
+  UNION ALL SELECT 'fatality_notice', 'body'
+  UNION ALL SELECT 'historic_appointment', 'body'
+  UNION ALL SELECT 'history', 'body'
+  UNION ALL SELECT 'hmrc_manual_section', 'body'
+  UNION ALL SELECT 'html_publication', 'body'
+  UNION ALL SELECT 'news_article', 'body'
+  UNION ALL SELECT 'organisation', 'body'
+  UNION ALL SELECT 'publication', 'body'
+  UNION ALL SELECT 'service_manual_guide', 'body'
+  UNION ALL SELECT 'service_manual_service_standard', 'body'
+  UNION ALL SELECT 'speech', 'body'
+  UNION ALL SELECT 'step_by_step_nav', 'body'
+  UNION ALL SELECT 'statistical_data_set', 'body'
+  UNION ALL SELECT 'take_part', 'body'
+  UNION ALL SELECT 'topical_event', 'body'
+  UNION ALL SELECT 'topical_event_about_page', 'body'
+  UNION ALL SELECT 'working_group', 'body'
+  UNION ALL SELECT 'worldwide_corporate_information_page', 'body'
+  UNION ALL SELECT 'worldwide_organisation', 'body'
+
+  UNION ALL SELECT 'answer', 'body_content'
+  UNION ALL SELECT 'help_page', 'body_content'
+  UNION ALL SELECT 'manual', 'body_content'
+  UNION ALL SELECT 'manual_section', 'body_content'
+  UNION ALL SELECT 'person', 'body_content'
+  UNION ALL SELECT 'role', 'body_content'
+  UNION ALL SELECT 'simple_smart_answer', 'body_content'
+  UNION ALL SELECT 'specialist_document', 'body_content'
+
+  UNION ALL SELECT 'guide', 'part'
+  UNION ALL SELECT 'travel_advice', 'part'
+
+  UNION ALL SELECT 'place', 'general'
+  UNION ALL SELECT 'licence', 'general'
+  UNION ALL SELECT 'local_transaction', 'general'
+  UNION ALL SELECT 'transaction', 'general'
+  UNION ALL SELECT 'statistics_announcement', 'general'
+  UNION ALL SELECT 'smart_answer', 'general'
+),
+
+-- HTML content of document types that have it in the "body" field.
+body AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    CAST(NULL AS STRING) AS govspeak,
+    STRING(JSON_QUERY(editions.details, '$.body')) AS html,
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'body'
+  AND JSON_TYPE(JSON_QUERY(details, '$.body')) = 'string'
+),
+
+-- govspeak and HTML content of document types that have it in the "body.content[]" array.
+body_content_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.body')) AS content
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'body_content'
+  AND JSON_TYPE(JSON_QUERY(editions.details, '$.body')) = 'array'
+),
+body_content AS (
+  SELECT
+    * EXCEPT (content),
+    content.govspeak AS govspeak,
+    content.html AS html
+  FROM body_content_content
+),
+
+general_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.introduction')) AS introduction,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.information')) AS information,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.need_to_know')) AS need_to_know,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.introductory_paragraph')) AS introductory_paragraph,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.licence_overview')) AS licence_overview,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.start_button_text')) AS start_button_text,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.will_continue_on')) AS will_continue_on,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.more_information')) AS more_information,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.what_you_need_to_know')) AS what_you_need_to_know,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.other_ways_to_apply')) AS other_ways_to_apply,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.cancellation_reason')) AS cancellation_reason,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.hidden_search_terms')) AS hidden_search_terms
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'general'
+),
+general AS (
+  SELECT
+    * EXCEPT (
+      introduction,
+      information,
+      need_to_know,
+      introductory_paragraph,
+      licence_overview,
+      start_button_text,
+      will_continue_on,
+      more_information,
+      what_you_need_to_know,
+      other_ways_to_apply,
+      cancellation_reason,
+      hidden_search_terms
+    ),
+    ARRAY_TO_STRING([
+      introduction.govspeak,
+      information.govspeak,
+      need_to_know.govspeak,
+      introductory_paragraph.govspeak,
+      licence_overview.govspeak,
+      start_button_text.govspeak,
+      will_continue_on.govspeak,
+      more_information.govspeak,
+      what_you_need_to_know.govspeak,
+      other_ways_to_apply.govspeak,
+      cancellation_reason.govspeak,
+      hidden_search_terms.govspeak
+    ], '\n\n') AS govspeak,
+    ARRAY_TO_STRING([
+      introduction.html,
+      information.html,
+      need_to_know.html,
+      introductory_paragraph.html,
+      licence_overview.html,
+      start_button_text.html,
+      will_continue_on.html,
+      more_information.html,
+      what_you_need_to_know.html,
+      other_ways_to_apply.html,
+      cancellation_reason.html,
+      hidden_search_terms.html
+    ], '\n\n') AS html,
+  FROM general_content
+),
+
+-- govspeak and HTML content of document types that have content in the details.parts array
+parts_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    part_index, -- zero-based
+    STRING(JSON_QUERY(part, '$.slug')) AS part_slug,
+    STRING(JSON_QUERY(part, '$.title')) AS part_title,
+    markup_from_json_array(JSON_QUERY(part, '$.body')) AS content
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  CROSS JOIN UNNEST(JSON_QUERY_ARRAY(editions.details, '$.parts')) AS part WITH OFFSET AS part_index
+  WHERE schema_map.govspeak_location = 'part'
+  AND JSON_TYPE(JSON_QUERY(editions.details, '$.parts')) = 'array'
+  AND JSON_TYPE(JSON_QUERY(part, '$.body')) = 'array'
+),
+parts AS (
+  SELECT
+    * EXCEPT (content),
+    content.govspeak AS govspeak,
+    content.html AS html
+  FROM parts_content
+),
+
+-- The first part of each document is available at two URLs: with and without
+-- its slug. So duplicate the first part without its slug.
+first_parts AS (
+  SELECT
+    edition_id,
+    document_id,
+    schema_name,
+    base_path,
+    title,
+    FALSE AS is_part,
+    part_index, -- The part that this record is derived from
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    govspeak,
+    html
+  FROM parts
+),
+-- Make parts like pages in their own right (concatenating the base_path and slug),
+-- but leave enough metadata to be able to deconstruct them back to a true part.
+all_parts AS (
+  SELECT
+    edition_id,
+    document_id,
+    schema_name,
+    CONCAT(base_path, '/', part_slug) AS base_path,
+    CONCAT(title, ': ', part_title) AS title,
+    TRUE AS is_part,
+    part_index, -- This being non-null isn't sufficient to identify parts
+    part_slug, -- This being non-null is sufficient to identify parts
+    part_title,
+    govspeak,
+    html
+  FROM parts
+),
+
+combined AS (
+  SELECT * FROM body
+  UNION ALL SELECT * FROM body_content
+  UNION ALL SELECT * FROM general
+
+  -- Only the first part of each guide/travel_advice document, using only the base_path
+  UNION ALL SELECT * FROM first_parts
+  -- Every part of each guide/travel_advice document, concatenating the base_path and the slug
+  UNION ALL SELECT * FROM all_parts
+),
+
+rendered AS (
+  SELECT * REPLACE(
+    COALESCE(html, JSON_VALUE(functions.govspeak_to_html(govspeak), '$.html')) AS html
+  )
+  FROM combined
+)
+
+SELECT * FROM rendered
+;
+
+-- Delete rows from the public.markup table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.markup AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.document_id = target.document_id
+WHEN matched THEN DELETE
+;
+
+-- Insert the markup of new editions into the public.markup table.
+INSERT INTO public.markup
+SELECT * FROM public.markup_new
+;
+
+END

--- a/terraform-dev/bigquery/govspeak-to-html.sql
+++ b/terraform-dev/bigquery/govspeak-to-html.sql
@@ -1,3 +1,4 @@
+-- returns JSON: { "html" => html, "error" => error_message }
 CREATE OR REPLACE FUNCTION `${project_id}.functions.govspeak_to_html`(govspeak STRING)
 RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`

--- a/terraform-dev/schemas/public/markup-new.json
+++ b/terraform-dev/schemas/public/markup-new.json
@@ -1,0 +1,57 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "edition_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_part",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "govspeak",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "html",
+    "type": "STRING"
+  }
+]

--- a/terraform-dev/schemas/public/markup.json
+++ b/terraform-dev/schemas/public/markup.json
@@ -1,0 +1,57 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "edition_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_part",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "govspeak",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "html",
+    "type": "STRING"
+  }
+]

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -54,3 +54,19 @@ resource "google_bigquery_table" "public_publishing_api_editions_current" {
   description   = "The most-recent edition of each document of each content item"
   schema        = file("schemas/public/publishing-api-editions-current.json")
 }
+
+resource "google_bigquery_table" "public_markup_new" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "markup_new"
+  friendly_name = "Markup (new records)"
+  description   = "Markeup extracted from editions in the latest batch"
+  schema        = file("schemas/public/markup-new.json")
+}
+
+resource "google_bigquery_table" "public_markup" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "markup"
+  friendly_name = "Markup"
+  description   = "Markeup extracted from editions in the latest batch"
+  schema        = file("schemas/public/markup.json")
+}

--- a/terraform-staging/bigquery-scheduled-queries.tf
+++ b/terraform-staging/bigquery-scheduled-queries.tf
@@ -17,3 +17,14 @@ resource "google_bigquery_data_transfer_config" "publishing_api_editions_current
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
+
+resource "google_bigquery_data_transfer_config" "extract_markup" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Extract markup"
+  location       = var.region
+  schedule       = "every day 01:00"
+  params = {
+    query = file("bigquery/extract-markup-from-editions.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform-staging/bigquery/README-extract-markup-from-editions.md
+++ b/terraform-staging/bigquery/README-extract-markup-from-editions.md
@@ -1,0 +1,18 @@
+# `extract-markup-from-editions.sql`
+
+This query extracts the govspeak and/or HTML content of editions, according to their
+[`schema_name`](https://docs.publishing.service.gov.uk/content-schemas.html). If only govspeak is available, then it is rendered into HTML.
+
+[Not all schemas are supported](https://docs.google.com/spreadsheets/d/16AoHrcp5Wn9gyEhLFf1psPNJYn59VX0WEzNN7u54CZM/edit#gid=190179367).  Ones that aren't supported are usually ones that don't contain anything resembling "content".  Some of the ones that aren't supported contain links to other documents, so it would be good to extract those links one day to support the 'link search' function in the GovSearch app.
+
+Intermediate steps are stored in tables for subsequent processing, such as extracting elements of HTML.
+
+## Rendering govspeak to HTML
+
+[GovSpeak](https://github.com/alphagov/govspeak) is a markdown extension for GOV.UK editors, implemented in a Ruby gem.
+
+Some GovSpeak is rendered to HTML before it is received by the Publishing API. Most GovSpeak is rendered between the Publishing API and the Content API. Because not all GovSpeak is rendered by the same app, it might not be rendered by the same version of the GovSpeak ruby gem.
+
+We define a BigQuery remote function that calls a Cloud Function that is implemented in Cloud Run, which hosts a docker image containing the GovSpeak ruby gem. See the implementation in the [initial pull request](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/561).
+
+Theoretically BigQuery and Cloud Run automatically scale to render govspeak in bulk on hundreds of thousands of documents, but in practice it isn't very quick. Not as many instances of the virtual machine are created as are configured, and some of them are idle some of the time.  This doesn't matter much, because on most days there are only a handful of new editions to render.  In a test, a hundred thousand documents were rendered in 20 minutes.

--- a/terraform-staging/bigquery/README.md
+++ b/terraform-staging/bigquery/README.md
@@ -9,3 +9,10 @@ Maintains a table of one record per document that currently appears on the
 website.
 
 See [`README-publishing-api-editions-current.sql`](README-publishing-api-editions-current.sql).
+
+## `extract-markup-from-editions.sql`
+
+Maintains a table of one record per document that currently appears on the
+website.
+
+See [`README-extract-markup-from-editions.sql`](README-extract-markup-from-editions.sql).

--- a/terraform-staging/bigquery/extract-markup-from-editions.sql
+++ b/terraform-staging/bigquery/extract-markup-from-editions.sql
@@ -1,0 +1,310 @@
+-- Maintains a table `public.markup` of
+-- * one record per document if the document has a single part
+-- * one record per part of multipart documents, whare the ones with schema_name
+--   IN ('guide', 'travel_advice')
+--
+-- 1. Fetch new editions since the last batch update from
+--    public.publishing_api_editions_new_current.
+-- 2. Extract markup from those editions according to their schema.
+-- 3. Where HTML is null, render the GovSpeak to HTML.
+-- 4. Delete outdated editions from public.markup.
+-- 4. Insert new markup into public.markup.
+
+BEGIN
+
+-- Extract the govspeak and/or html versions of content from a JSON array
+--
+-- Example input:
+-- [
+--  {"content":"# Govspeak Content","content_type":"text/govspeak"},
+--  {"content":"<h1>HTML Content</h1>","content_type":"text/html"}
+-- ]
+--
+-- Output: STRUCT(govspeak, html)
+CREATE TEMP FUNCTION markup_from_json_array(array_of_json JSON) AS ((
+    WITH keyvalues AS (
+      SELECT
+        STRING(JSON_QUERY(item, '$.content')) AS content,
+        STRING(JSON_QUERY(item, '$.content_type')) AS content_type
+      FROM UNNEST(JSON_QUERY_ARRAY(array_of_json)) AS item
+    )
+    SELECT (SELECT AS STRUCT govspeak AS govspeak, html AS html)
+    FROM keyvalues
+    PIVOT(
+      ANY_VALUE(content)
+      FOR content_type IN ('text/govspeak' as govspeak, 'text/html' as html)
+    )
+));
+
+TRUNCATE TABLE public.markup_new;
+INSERT INTO public.markup_new
+-- schema_map ought to be a table, but it would take a lot of configuration.  If
+-- we used DBT or SQLMesh then it would be easier, as a seed, but those tools
+-- also require a lot of configuration.
+WITH schema_map AS (
+  SELECT 'calendar' AS schema_name, 'body' AS govspeak_location
+  UNION ALL SELECT 'call_for_evidence', 'body'
+  UNION ALL SELECT 'case_study', 'body'
+  UNION ALL SELECT 'consultation', 'body'
+  UNION ALL SELECT 'corporate_information_page', 'body'
+  UNION ALL SELECT 'detailed_guide', 'body'
+  UNION ALL SELECT 'document_collection', 'body'
+  UNION ALL SELECT 'fatality_notice', 'body'
+  UNION ALL SELECT 'historic_appointment', 'body'
+  UNION ALL SELECT 'history', 'body'
+  UNION ALL SELECT 'hmrc_manual_section', 'body'
+  UNION ALL SELECT 'html_publication', 'body'
+  UNION ALL SELECT 'news_article', 'body'
+  UNION ALL SELECT 'organisation', 'body'
+  UNION ALL SELECT 'publication', 'body'
+  UNION ALL SELECT 'service_manual_guide', 'body'
+  UNION ALL SELECT 'service_manual_service_standard', 'body'
+  UNION ALL SELECT 'speech', 'body'
+  UNION ALL SELECT 'step_by_step_nav', 'body'
+  UNION ALL SELECT 'statistical_data_set', 'body'
+  UNION ALL SELECT 'take_part', 'body'
+  UNION ALL SELECT 'topical_event', 'body'
+  UNION ALL SELECT 'topical_event_about_page', 'body'
+  UNION ALL SELECT 'working_group', 'body'
+  UNION ALL SELECT 'worldwide_corporate_information_page', 'body'
+  UNION ALL SELECT 'worldwide_organisation', 'body'
+
+  UNION ALL SELECT 'answer', 'body_content'
+  UNION ALL SELECT 'help_page', 'body_content'
+  UNION ALL SELECT 'manual', 'body_content'
+  UNION ALL SELECT 'manual_section', 'body_content'
+  UNION ALL SELECT 'person', 'body_content'
+  UNION ALL SELECT 'role', 'body_content'
+  UNION ALL SELECT 'simple_smart_answer', 'body_content'
+  UNION ALL SELECT 'specialist_document', 'body_content'
+
+  UNION ALL SELECT 'guide', 'part'
+  UNION ALL SELECT 'travel_advice', 'part'
+
+  UNION ALL SELECT 'place', 'general'
+  UNION ALL SELECT 'licence', 'general'
+  UNION ALL SELECT 'local_transaction', 'general'
+  UNION ALL SELECT 'transaction', 'general'
+  UNION ALL SELECT 'statistics_announcement', 'general'
+  UNION ALL SELECT 'smart_answer', 'general'
+),
+
+-- HTML content of document types that have it in the "body" field.
+body AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    CAST(NULL AS STRING) AS govspeak,
+    STRING(JSON_QUERY(editions.details, '$.body')) AS html,
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'body'
+  AND JSON_TYPE(JSON_QUERY(details, '$.body')) = 'string'
+),
+
+-- govspeak and HTML content of document types that have it in the "body.content[]" array.
+body_content_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.body')) AS content
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'body_content'
+  AND JSON_TYPE(JSON_QUERY(editions.details, '$.body')) = 'array'
+),
+body_content AS (
+  SELECT
+    * EXCEPT (content),
+    content.govspeak AS govspeak,
+    content.html AS html
+  FROM body_content_content
+),
+
+general_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.introduction')) AS introduction,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.information')) AS information,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.need_to_know')) AS need_to_know,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.introductory_paragraph')) AS introductory_paragraph,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.licence_overview')) AS licence_overview,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.start_button_text')) AS start_button_text,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.will_continue_on')) AS will_continue_on,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.more_information')) AS more_information,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.what_you_need_to_know')) AS what_you_need_to_know,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.other_ways_to_apply')) AS other_ways_to_apply,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.cancellation_reason')) AS cancellation_reason,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.hidden_search_terms')) AS hidden_search_terms
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'general'
+),
+general AS (
+  SELECT
+    * EXCEPT (
+      introduction,
+      information,
+      need_to_know,
+      introductory_paragraph,
+      licence_overview,
+      start_button_text,
+      will_continue_on,
+      more_information,
+      what_you_need_to_know,
+      other_ways_to_apply,
+      cancellation_reason,
+      hidden_search_terms
+    ),
+    ARRAY_TO_STRING([
+      introduction.govspeak,
+      information.govspeak,
+      need_to_know.govspeak,
+      introductory_paragraph.govspeak,
+      licence_overview.govspeak,
+      start_button_text.govspeak,
+      will_continue_on.govspeak,
+      more_information.govspeak,
+      what_you_need_to_know.govspeak,
+      other_ways_to_apply.govspeak,
+      cancellation_reason.govspeak,
+      hidden_search_terms.govspeak
+    ], '\n\n') AS govspeak,
+    ARRAY_TO_STRING([
+      introduction.html,
+      information.html,
+      need_to_know.html,
+      introductory_paragraph.html,
+      licence_overview.html,
+      start_button_text.html,
+      will_continue_on.html,
+      more_information.html,
+      what_you_need_to_know.html,
+      other_ways_to_apply.html,
+      cancellation_reason.html,
+      hidden_search_terms.html
+    ], '\n\n') AS html,
+  FROM general_content
+),
+
+-- govspeak and HTML content of document types that have content in the details.parts array
+parts_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    part_index, -- zero-based
+    STRING(JSON_QUERY(part, '$.slug')) AS part_slug,
+    STRING(JSON_QUERY(part, '$.title')) AS part_title,
+    markup_from_json_array(JSON_QUERY(part, '$.body')) AS content
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  CROSS JOIN UNNEST(JSON_QUERY_ARRAY(editions.details, '$.parts')) AS part WITH OFFSET AS part_index
+  WHERE schema_map.govspeak_location = 'part'
+  AND JSON_TYPE(JSON_QUERY(editions.details, '$.parts')) = 'array'
+  AND JSON_TYPE(JSON_QUERY(part, '$.body')) = 'array'
+),
+parts AS (
+  SELECT
+    * EXCEPT (content),
+    content.govspeak AS govspeak,
+    content.html AS html
+  FROM parts_content
+),
+
+-- The first part of each document is available at two URLs: with and without
+-- its slug. So duplicate the first part without its slug.
+first_parts AS (
+  SELECT
+    edition_id,
+    document_id,
+    schema_name,
+    base_path,
+    title,
+    FALSE AS is_part,
+    part_index, -- The part that this record is derived from
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    govspeak,
+    html
+  FROM parts
+),
+-- Make parts like pages in their own right (concatenating the base_path and slug),
+-- but leave enough metadata to be able to deconstruct them back to a true part.
+all_parts AS (
+  SELECT
+    edition_id,
+    document_id,
+    schema_name,
+    CONCAT(base_path, '/', part_slug) AS base_path,
+    CONCAT(title, ': ', part_title) AS title,
+    TRUE AS is_part,
+    part_index, -- This being non-null isn't sufficient to identify parts
+    part_slug, -- This being non-null is sufficient to identify parts
+    part_title,
+    govspeak,
+    html
+  FROM parts
+),
+
+combined AS (
+  SELECT * FROM body
+  UNION ALL SELECT * FROM body_content
+  UNION ALL SELECT * FROM general
+
+  -- Only the first part of each guide/travel_advice document, using only the base_path
+  UNION ALL SELECT * FROM first_parts
+  -- Every part of each guide/travel_advice document, concatenating the base_path and the slug
+  UNION ALL SELECT * FROM all_parts
+),
+
+rendered AS (
+  SELECT * REPLACE(
+    COALESCE(html, JSON_VALUE(functions.govspeak_to_html(govspeak), '$.html')) AS html
+  )
+  FROM combined
+)
+
+SELECT * FROM rendered
+;
+
+-- Delete rows from the public.markup table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.markup AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.document_id = target.document_id
+WHEN matched THEN DELETE
+;
+
+-- Insert the markup of new editions into the public.markup table.
+INSERT INTO public.markup
+SELECT * FROM public.markup_new
+;
+
+END

--- a/terraform-staging/bigquery/govspeak-to-html.sql
+++ b/terraform-staging/bigquery/govspeak-to-html.sql
@@ -1,3 +1,4 @@
+-- returns JSON: { "html" => html, "error" => error_message }
 CREATE OR REPLACE FUNCTION `${project_id}.functions.govspeak_to_html`(govspeak STRING)
 RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`

--- a/terraform-staging/schemas/public/markup-new.json
+++ b/terraform-staging/schemas/public/markup-new.json
@@ -1,0 +1,57 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "edition_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_part",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "govspeak",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "html",
+    "type": "STRING"
+  }
+]

--- a/terraform-staging/schemas/public/markup.json
+++ b/terraform-staging/schemas/public/markup.json
@@ -1,0 +1,57 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "edition_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_part",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "govspeak",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "html",
+    "type": "STRING"
+  }
+]

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -54,3 +54,19 @@ resource "google_bigquery_table" "public_publishing_api_editions_current" {
   description   = "The most-recent edition of each document of each content item"
   schema        = file("schemas/public/publishing-api-editions-current.json")
 }
+
+resource "google_bigquery_table" "public_markup_new" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "markup_new"
+  friendly_name = "Markup (new records)"
+  description   = "Markeup extracted from editions in the latest batch"
+  schema        = file("schemas/public/markup-new.json")
+}
+
+resource "google_bigquery_table" "public_markup" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "markup"
+  friendly_name = "Markup"
+  description   = "Markeup extracted from editions in the latest batch"
+  schema        = file("schemas/public/markup.json")
+}

--- a/terraform/bigquery-scheduled-queries.tf
+++ b/terraform/bigquery-scheduled-queries.tf
@@ -17,3 +17,14 @@ resource "google_bigquery_data_transfer_config" "publishing_api_editions_current
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
+
+resource "google_bigquery_data_transfer_config" "extract_markup" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Extract markup"
+  location       = var.region
+  schedule       = "every day 01:00"
+  params = {
+    query = file("bigquery/extract-markup-from-editions.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform/bigquery/README-extract-markup-from-editions.md
+++ b/terraform/bigquery/README-extract-markup-from-editions.md
@@ -1,0 +1,18 @@
+# `extract-markup-from-editions.sql`
+
+This query extracts the govspeak and/or HTML content of editions, according to their
+[`schema_name`](https://docs.publishing.service.gov.uk/content-schemas.html). If only govspeak is available, then it is rendered into HTML.
+
+[Not all schemas are supported](https://docs.google.com/spreadsheets/d/16AoHrcp5Wn9gyEhLFf1psPNJYn59VX0WEzNN7u54CZM/edit#gid=190179367).  Ones that aren't supported are usually ones that don't contain anything resembling "content".  Some of the ones that aren't supported contain links to other documents, so it would be good to extract those links one day to support the 'link search' function in the GovSearch app.
+
+Intermediate steps are stored in tables for subsequent processing, such as extracting elements of HTML.
+
+## Rendering govspeak to HTML
+
+[GovSpeak](https://github.com/alphagov/govspeak) is a markdown extension for GOV.UK editors, implemented in a Ruby gem.
+
+Some GovSpeak is rendered to HTML before it is received by the Publishing API. Most GovSpeak is rendered between the Publishing API and the Content API. Because not all GovSpeak is rendered by the same app, it might not be rendered by the same version of the GovSpeak ruby gem.
+
+We define a BigQuery remote function that calls a Cloud Function that is implemented in Cloud Run, which hosts a docker image containing the GovSpeak ruby gem. See the implementation in the [initial pull request](https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/561).
+
+Theoretically BigQuery and Cloud Run automatically scale to render govspeak in bulk on hundreds of thousands of documents, but in practice it isn't very quick. Not as many instances of the virtual machine are created as are configured, and some of them are idle some of the time.  This doesn't matter much, because on most days there are only a handful of new editions to render.  In a test, a hundred thousand documents were rendered in 20 minutes.

--- a/terraform/bigquery/README.md
+++ b/terraform/bigquery/README.md
@@ -9,3 +9,10 @@ Maintains a table of one record per document that currently appears on the
 website.
 
 See [`README-publishing-api-editions-current.sql`](README-publishing-api-editions-current.sql).
+
+## `extract-markup-from-editions.sql`
+
+Maintains a table of one record per document that currently appears on the
+website.
+
+See [`README-extract-markup-from-editions.sql`](README-extract-markup-from-editions.sql).

--- a/terraform/bigquery/extract-markup-from-editions.sql
+++ b/terraform/bigquery/extract-markup-from-editions.sql
@@ -1,0 +1,310 @@
+-- Maintains a table `public.markup` of
+-- * one record per document if the document has a single part
+-- * one record per part of multipart documents, whare the ones with schema_name
+--   IN ('guide', 'travel_advice')
+--
+-- 1. Fetch new editions since the last batch update from
+--    public.publishing_api_editions_new_current.
+-- 2. Extract markup from those editions according to their schema.
+-- 3. Where HTML is null, render the GovSpeak to HTML.
+-- 4. Delete outdated editions from public.markup.
+-- 4. Insert new markup into public.markup.
+
+BEGIN
+
+-- Extract the govspeak and/or html versions of content from a JSON array
+--
+-- Example input:
+-- [
+--  {"content":"# Govspeak Content","content_type":"text/govspeak"},
+--  {"content":"<h1>HTML Content</h1>","content_type":"text/html"}
+-- ]
+--
+-- Output: STRUCT(govspeak, html)
+CREATE TEMP FUNCTION markup_from_json_array(array_of_json JSON) AS ((
+    WITH keyvalues AS (
+      SELECT
+        STRING(JSON_QUERY(item, '$.content')) AS content,
+        STRING(JSON_QUERY(item, '$.content_type')) AS content_type
+      FROM UNNEST(JSON_QUERY_ARRAY(array_of_json)) AS item
+    )
+    SELECT (SELECT AS STRUCT govspeak AS govspeak, html AS html)
+    FROM keyvalues
+    PIVOT(
+      ANY_VALUE(content)
+      FOR content_type IN ('text/govspeak' as govspeak, 'text/html' as html)
+    )
+));
+
+TRUNCATE TABLE public.markup_new;
+INSERT INTO public.markup_new
+-- schema_map ought to be a table, but it would take a lot of configuration.  If
+-- we used DBT or SQLMesh then it would be easier, as a seed, but those tools
+-- also require a lot of configuration.
+WITH schema_map AS (
+  SELECT 'calendar' AS schema_name, 'body' AS govspeak_location
+  UNION ALL SELECT 'call_for_evidence', 'body'
+  UNION ALL SELECT 'case_study', 'body'
+  UNION ALL SELECT 'consultation', 'body'
+  UNION ALL SELECT 'corporate_information_page', 'body'
+  UNION ALL SELECT 'detailed_guide', 'body'
+  UNION ALL SELECT 'document_collection', 'body'
+  UNION ALL SELECT 'fatality_notice', 'body'
+  UNION ALL SELECT 'historic_appointment', 'body'
+  UNION ALL SELECT 'history', 'body'
+  UNION ALL SELECT 'hmrc_manual_section', 'body'
+  UNION ALL SELECT 'html_publication', 'body'
+  UNION ALL SELECT 'news_article', 'body'
+  UNION ALL SELECT 'organisation', 'body'
+  UNION ALL SELECT 'publication', 'body'
+  UNION ALL SELECT 'service_manual_guide', 'body'
+  UNION ALL SELECT 'service_manual_service_standard', 'body'
+  UNION ALL SELECT 'speech', 'body'
+  UNION ALL SELECT 'step_by_step_nav', 'body'
+  UNION ALL SELECT 'statistical_data_set', 'body'
+  UNION ALL SELECT 'take_part', 'body'
+  UNION ALL SELECT 'topical_event', 'body'
+  UNION ALL SELECT 'topical_event_about_page', 'body'
+  UNION ALL SELECT 'working_group', 'body'
+  UNION ALL SELECT 'worldwide_corporate_information_page', 'body'
+  UNION ALL SELECT 'worldwide_organisation', 'body'
+
+  UNION ALL SELECT 'answer', 'body_content'
+  UNION ALL SELECT 'help_page', 'body_content'
+  UNION ALL SELECT 'manual', 'body_content'
+  UNION ALL SELECT 'manual_section', 'body_content'
+  UNION ALL SELECT 'person', 'body_content'
+  UNION ALL SELECT 'role', 'body_content'
+  UNION ALL SELECT 'simple_smart_answer', 'body_content'
+  UNION ALL SELECT 'specialist_document', 'body_content'
+
+  UNION ALL SELECT 'guide', 'part'
+  UNION ALL SELECT 'travel_advice', 'part'
+
+  UNION ALL SELECT 'place', 'general'
+  UNION ALL SELECT 'licence', 'general'
+  UNION ALL SELECT 'local_transaction', 'general'
+  UNION ALL SELECT 'transaction', 'general'
+  UNION ALL SELECT 'statistics_announcement', 'general'
+  UNION ALL SELECT 'smart_answer', 'general'
+),
+
+-- HTML content of document types that have it in the "body" field.
+body AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    CAST(NULL AS STRING) AS govspeak,
+    STRING(JSON_QUERY(editions.details, '$.body')) AS html,
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'body'
+  AND JSON_TYPE(JSON_QUERY(details, '$.body')) = 'string'
+),
+
+-- govspeak and HTML content of document types that have it in the "body.content[]" array.
+body_content_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.body')) AS content
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'body_content'
+  AND JSON_TYPE(JSON_QUERY(editions.details, '$.body')) = 'array'
+),
+body_content AS (
+  SELECT
+    * EXCEPT (content),
+    content.govspeak AS govspeak,
+    content.html AS html
+  FROM body_content_content
+),
+
+general_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    FALSE AS is_part,
+    CAST(NULL AS INT64) AS part_index,
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.introduction')) AS introduction,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.information')) AS information,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.need_to_know')) AS need_to_know,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.introductory_paragraph')) AS introductory_paragraph,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.licence_overview')) AS licence_overview,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.start_button_text')) AS start_button_text,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.will_continue_on')) AS will_continue_on,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.more_information')) AS more_information,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.what_you_need_to_know')) AS what_you_need_to_know,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.other_ways_to_apply')) AS other_ways_to_apply,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.cancellation_reason')) AS cancellation_reason,
+    markup_from_json_array(JSON_QUERY(editions.details, '$.hidden_search_terms')) AS hidden_search_terms
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  WHERE schema_map.govspeak_location = 'general'
+),
+general AS (
+  SELECT
+    * EXCEPT (
+      introduction,
+      information,
+      need_to_know,
+      introductory_paragraph,
+      licence_overview,
+      start_button_text,
+      will_continue_on,
+      more_information,
+      what_you_need_to_know,
+      other_ways_to_apply,
+      cancellation_reason,
+      hidden_search_terms
+    ),
+    ARRAY_TO_STRING([
+      introduction.govspeak,
+      information.govspeak,
+      need_to_know.govspeak,
+      introductory_paragraph.govspeak,
+      licence_overview.govspeak,
+      start_button_text.govspeak,
+      will_continue_on.govspeak,
+      more_information.govspeak,
+      what_you_need_to_know.govspeak,
+      other_ways_to_apply.govspeak,
+      cancellation_reason.govspeak,
+      hidden_search_terms.govspeak
+    ], '\n\n') AS govspeak,
+    ARRAY_TO_STRING([
+      introduction.html,
+      information.html,
+      need_to_know.html,
+      introductory_paragraph.html,
+      licence_overview.html,
+      start_button_text.html,
+      will_continue_on.html,
+      more_information.html,
+      what_you_need_to_know.html,
+      other_ways_to_apply.html,
+      cancellation_reason.html,
+      hidden_search_terms.html
+    ], '\n\n') AS html,
+  FROM general_content
+),
+
+-- govspeak and HTML content of document types that have content in the details.parts array
+parts_content AS (
+  SELECT
+    editions.id AS edition_id,
+    editions.document_id,
+    editions.schema_name,
+    editions.base_path,
+    editions.title,
+    part_index, -- zero-based
+    STRING(JSON_QUERY(part, '$.slug')) AS part_slug,
+    STRING(JSON_QUERY(part, '$.title')) AS part_title,
+    markup_from_json_array(JSON_QUERY(part, '$.body')) AS content
+  FROM public.publishing_api_editions_new_current AS editions
+  INNER JOIN schema_map USING (schema_name)
+  CROSS JOIN UNNEST(JSON_QUERY_ARRAY(editions.details, '$.parts')) AS part WITH OFFSET AS part_index
+  WHERE schema_map.govspeak_location = 'part'
+  AND JSON_TYPE(JSON_QUERY(editions.details, '$.parts')) = 'array'
+  AND JSON_TYPE(JSON_QUERY(part, '$.body')) = 'array'
+),
+parts AS (
+  SELECT
+    * EXCEPT (content),
+    content.govspeak AS govspeak,
+    content.html AS html
+  FROM parts_content
+),
+
+-- The first part of each document is available at two URLs: with and without
+-- its slug. So duplicate the first part without its slug.
+first_parts AS (
+  SELECT
+    edition_id,
+    document_id,
+    schema_name,
+    base_path,
+    title,
+    FALSE AS is_part,
+    part_index, -- The part that this record is derived from
+    CAST(NULL AS STRING) AS part_slug,
+    CAST(NULL AS STRING) AS part_title,
+    govspeak,
+    html
+  FROM parts
+),
+-- Make parts like pages in their own right (concatenating the base_path and slug),
+-- but leave enough metadata to be able to deconstruct them back to a true part.
+all_parts AS (
+  SELECT
+    edition_id,
+    document_id,
+    schema_name,
+    CONCAT(base_path, '/', part_slug) AS base_path,
+    CONCAT(title, ': ', part_title) AS title,
+    TRUE AS is_part,
+    part_index, -- This being non-null isn't sufficient to identify parts
+    part_slug, -- This being non-null is sufficient to identify parts
+    part_title,
+    govspeak,
+    html
+  FROM parts
+),
+
+combined AS (
+  SELECT * FROM body
+  UNION ALL SELECT * FROM body_content
+  UNION ALL SELECT * FROM general
+
+  -- Only the first part of each guide/travel_advice document, using only the base_path
+  UNION ALL SELECT * FROM first_parts
+  -- Every part of each guide/travel_advice document, concatenating the base_path and the slug
+  UNION ALL SELECT * FROM all_parts
+),
+
+rendered AS (
+  SELECT * REPLACE(
+    COALESCE(html, JSON_VALUE(functions.govspeak_to_html(govspeak), '$.html')) AS html
+  )
+  FROM combined
+)
+
+SELECT * FROM rendered
+;
+
+-- Delete rows from the public.markup table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.markup AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.document_id = target.document_id
+WHEN matched THEN DELETE
+;
+
+-- Insert the markup of new editions into the public.markup table.
+INSERT INTO public.markup
+SELECT * FROM public.markup_new
+;
+
+END

--- a/terraform/bigquery/govspeak-to-html.sql
+++ b/terraform/bigquery/govspeak-to-html.sql
@@ -1,3 +1,4 @@
+-- returns JSON: { "html" => html, "error" => error_message }
 CREATE OR REPLACE FUNCTION `${project_id}.functions.govspeak_to_html`(govspeak STRING)
 RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.govspeak-to-html`

--- a/terraform/schemas/public/markup-new.json
+++ b/terraform/schemas/public/markup-new.json
@@ -1,0 +1,57 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "edition_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_part",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "govspeak",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "html",
+    "type": "STRING"
+  }
+]

--- a/terraform/schemas/public/markup.json
+++ b/terraform/schemas/public/markup.json
@@ -1,0 +1,57 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "edition_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "is_part",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "govspeak",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "html",
+    "type": "STRING"
+  }
+]


### PR DESCRIPTION
Each edition has a [`schema_name`](https://docs.publishing.service.gov.uk/content-schemas.html) that governs where its content is in the 'details' column (JSON), and whether it is govspeak, or html, or both.

TODO:
- [x] Where html does not exist and govspeak does, use `functions.govspeak_to_html()` to derive html from govspeak.
- [x] Make the query incremental to only process new editions, otherwise it costs 6GB in BigQuery and goodness-knows-what in Cloud Run for the function.
- [x] Implement all schemas
