### PR TITLE
fix: Scrub non-public content from editions

### DIFF
--- a/terraform-dev/bigquery-private.tf
+++ b/terraform-dev/bigquery-private.tf
@@ -57,3 +57,11 @@ resource "google_bigquery_table" "private_publishing_api_editions_new" {
   description   = "Publishing API editions from the latest batch update"
   schema        = file("schemas/private/publishing-api-editions-new.json")
 }
+
+resource "google_bigquery_table" "private_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current"
+  schema        = file("schemas/private/publishing-api-editions-new-current.json")
+}

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -46,11 +46,3 @@ resource "google_bigquery_table" "public_publishing_api_editions_current" {
   description   = "The most-recent edition of each document of each content item"
   schema        = file("schemas/public/publishing-api-editions-current.json")
 }
-
-resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
-  dataset_id    = google_bigquery_dataset.public.dataset_id
-  table_id      = "publishing_api_editions_new_current"
-  friendly_name = "Publishing API editions (new and current)"
-  description   = "Publishing API editions from the latest batch update, that are also current"
-  schema        = file("schemas/public/publishing-api-editions-new-current.json")
-}

--- a/terraform-dev/schemas/private/publishing-api-editions-new-current.json
+++ b/terraform-dev/schemas/private/publishing-api-editions-new-current.json
@@ -155,6 +155,11 @@
     "type": "JSON"
   },
   {
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
+  },
+  {
     "mode": "REQUIRED",
     "name": "is_online",
     "type": "BOOLEAN"

--- a/terraform-dev/schemas/public/publishing-api-editions-current.json
+++ b/terraform-dev/schemas/public/publishing-api-editions-current.json
@@ -51,11 +51,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "created_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "updated_at",
     "type": "TIMESTAMP"
   },
@@ -76,33 +71,8 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "last_edited_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "state",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "user_facing_version",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "base_path",
     "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "content_store",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "document_id",
-    "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",
@@ -111,33 +81,8 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "publishing_request_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "major_published_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "published_at",
     "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publishing_api_first_published_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publishing_api_last_edited_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "auth_bypass_ids",
-    "type": "STRING"
   },
   {
     "mode": "NULLABLE",
@@ -155,8 +100,8 @@
     "type": "JSON"
   },
   {
-    "mode": "REQUIRED",
-    "name": "is_online",
-    "type": "BOOLEAN"
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
   }
 ]

--- a/terraform-staging/bigquery-private.tf
+++ b/terraform-staging/bigquery-private.tf
@@ -57,3 +57,11 @@ resource "google_bigquery_table" "private_publishing_api_editions_new" {
   description   = "Publishing API editions from the latest batch update"
   schema        = file("schemas/private/publishing-api-editions-new.json")
 }
+
+resource "google_bigquery_table" "private_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current"
+  schema        = file("schemas/private/publishing-api-editions-new-current.json")
+}

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -46,11 +46,3 @@ resource "google_bigquery_table" "public_publishing_api_editions_current" {
   description   = "The most-recent edition of each document of each content item"
   schema        = file("schemas/public/publishing-api-editions-current.json")
 }
-
-resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
-  dataset_id    = google_bigquery_dataset.public.dataset_id
-  table_id      = "publishing_api_editions_new_current"
-  friendly_name = "Publishing API editions (new and current)"
-  description   = "Publishing API editions from the latest batch update, that are also current"
-  schema        = file("schemas/public/publishing-api-editions-new-current.json")
-}

--- a/terraform-staging/schemas/private/publishing-api-editions-new-current.json
+++ b/terraform-staging/schemas/private/publishing-api-editions-new-current.json
@@ -155,6 +155,11 @@
     "type": "JSON"
   },
   {
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
+  },
+  {
     "mode": "REQUIRED",
     "name": "is_online",
     "type": "BOOLEAN"

--- a/terraform-staging/schemas/public/publishing-api-editions-current.json
+++ b/terraform-staging/schemas/public/publishing-api-editions-current.json
@@ -51,11 +51,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "created_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "updated_at",
     "type": "TIMESTAMP"
   },
@@ -76,33 +71,8 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "last_edited_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "state",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "user_facing_version",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "base_path",
     "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "content_store",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "document_id",
-    "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",
@@ -111,33 +81,8 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "publishing_request_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "major_published_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "published_at",
     "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publishing_api_first_published_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publishing_api_last_edited_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "auth_bypass_ids",
-    "type": "STRING"
   },
   {
     "mode": "NULLABLE",
@@ -155,8 +100,8 @@
     "type": "JSON"
   },
   {
-    "mode": "REQUIRED",
-    "name": "is_online",
-    "type": "BOOLEAN"
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
   }
 ]

--- a/terraform/bigquery-private.tf
+++ b/terraform/bigquery-private.tf
@@ -57,3 +57,11 @@ resource "google_bigquery_table" "private_publishing_api_editions_new" {
   description   = "Publishing API editions from the latest batch update"
   schema        = file("schemas/private/publishing-api-editions-new.json")
 }
+
+resource "google_bigquery_table" "private_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current"
+  schema        = file("schemas/private/publishing-api-editions-new-current.json")
+}

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -46,11 +46,3 @@ resource "google_bigquery_table" "public_publishing_api_editions_current" {
   description   = "The most-recent edition of each document of each content item"
   schema        = file("schemas/public/publishing-api-editions-current.json")
 }
-
-resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
-  dataset_id    = google_bigquery_dataset.public.dataset_id
-  table_id      = "publishing_api_editions_new_current"
-  friendly_name = "Publishing API editions (new and current)"
-  description   = "Publishing API editions from the latest batch update, that are also current"
-  schema        = file("schemas/public/publishing-api-editions-new-current.json")
-}

--- a/terraform/schemas/private/publishing-api-editions-new-current.json
+++ b/terraform/schemas/private/publishing-api-editions-new-current.json
@@ -155,6 +155,11 @@
     "type": "JSON"
   },
   {
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
+  },
+  {
     "mode": "REQUIRED",
     "name": "is_online",
     "type": "BOOLEAN"

--- a/terraform/schemas/public/publishing-api-editions-current.json
+++ b/terraform/schemas/public/publishing-api-editions-current.json
@@ -51,11 +51,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "created_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "updated_at",
     "type": "TIMESTAMP"
   },
@@ -76,33 +71,8 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "last_edited_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "state",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "user_facing_version",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "base_path",
     "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "content_store",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "document_id",
-    "type": "INTEGER"
   },
   {
     "mode": "NULLABLE",
@@ -111,33 +81,8 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "publishing_request_id",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "major_published_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "published_at",
     "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publishing_api_first_published_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publishing_api_last_edited_at",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "auth_bypass_ids",
-    "type": "STRING"
   },
   {
     "mode": "NULLABLE",
@@ -155,8 +100,8 @@
     "type": "JSON"
   },
   {
-    "mode": "REQUIRED",
-    "name": "is_online",
-    "type": "BOOLEAN"
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
   }
 ]


### PR DESCRIPTION
- Omit editions that aren't public
- Scrub information about editions that are public but that are
  'redirect' or 'gone'
- Move a pre-public table into the private dataset
