### PR TITLE
refactor: add an intermediate step before public

### DIFF
--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -39,6 +39,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current and public"
+  schema        = file("schemas/public/publishing-api-editions-new-current.json")
+}
+
 resource "google_bigquery_table" "public_publishing_api_editions_current" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "publishing_api_editions_current"

--- a/terraform-dev/bigquery/publishing-api-editions-current.sql
+++ b/terraform-dev/bigquery/publishing-api-editions-current.sql
@@ -63,21 +63,49 @@ INSERT INTO private.publishing_api_editions_new_current
   QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
 ;
 
--- Delete rows from the editions_current table where a newer edition of the same
--- document is now available.
-MERGE INTO
-public.publishing_api_editions_current AS target
-USING private.publishing_api_editions_new_current AS source
-ON source.content_id = target.content_id AND source.locale = target.locale
-WHEN matched THEN DELETE
+-- Derive from the new editions a table of the latest edition per document, and
+-- a flag indicating whether it has a presence online (whether a redirect,
+-- or embedded in other pages, or a page in its own right).
+TRUNCATE TABLE private.publishing_api_editions_new_current;
+INSERT INTO private.publishing_api_editions_new_current
+  SELECT
+    documents.content_id,
+    documents.locale,
+    publishing_api_editions_new.*,
+    unpublishings.type AS unpublishing_type,
+    -- TODO: derive other values here
+    (
+      coalesce(content_store = 'live', false) -- Includes items that are only embedded in others.
+      AND state <> 'superseded' -- Exclude this rare and illogical case
+      AND coalesce(unpublishings.type <> 'vanish', true)
+      AND (
+        coalesce(left(schema_name, 11) <> 'placeholder', true)
+        OR (
+          -- schema_name must be checked again because short-circuit evaluation
+          -- isn't available in this clause.
+          coalesce(left(schema_name, 11) = 'placeholder', false)
+          AND coalesce(unpublishings.type IN ('gone', 'redirect'), false)
+        )
+      )
+    ) AS is_online
+  FROM private.publishing_api_editions_new
+  INNER JOIN publishing_api.documents ON documents.id = publishing_api_editions_new.document_id
+  LEFT JOIN publishing_api.unpublishings ON unpublishings.edition_id = publishing_api_editions_new.id
+  WHERE state <> 'draft'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
 ;
 
--- Insert new editions into the editions_current table, if they are also
--- 'online', which means that they are publicly available via the website or the
--- Content API. Scrub certain columns of editions that are redirected or
+-- Insert new editions into the public.editions_new_current table, if they are
+-- also 'online', which means that they are publicly available via the website
+-- or the Content API. Scrub certain columns of editions that are redirected or
 -- 'gone', and omit columns that aren't in the Content API at all.
 -- https://github.com/alphagov/publishing-api/tree/d041ae94a48fec9bd623bbb36ae6e87820ea0b06/app/presenters
-INSERT INTO public.publishing_api_editions_current
+--
+-- These could go straigt into public.publishing_api_editions_current, but it's
+-- more efficient to put them here, so that we can do downstream processing of
+-- only the new editions, without querying all the existing editions.
+TRUNCATE TABLE public.publishing_api_editions_new_current;
+INSERT INTO public.publishing_api_editions_new_current
 SELECT *
     EXCEPT (
       created_at,
@@ -94,17 +122,33 @@ SELECT *
       is_online
     )
     REPLACE (
-      IF (unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,
-      IF (unpublishing_type IN ('redirect', 'gone'), unpublishing_type, schema_name) AS schema_name,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, title) AS title,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, rendering_app) AS rendering_app,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, analytics_identifier) AS analytics_identifier,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, first_published_at) AS first_published_at,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, description) AS description,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, details) AS details
+      IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,
+      IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, schema_name) AS schema_name,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, title) AS title,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, rendering_app) AS rendering_app,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, analytics_identifier) AS analytics_identifier,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, first_published_at) AS first_published_at,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, description) AS description,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, details) AS details
     )
 FROM private.publishing_api_editions_new_current
 WHERE is_online
+;
+
+-- Delete rows from the editions_current table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.publishing_api_editions_current AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.content_id = target.content_id AND source.locale = target.locale
+WHEN matched THEN DELETE
+;
+
+-- Insert new, public editions into the
+-- public.publishing_api_editions_new_current table.
+INSERT INTO public.publishing_api_editions_current
+SELECT * FROM public.publishing_api_editions_new_current
 ;
 
 END

--- a/terraform-dev/schemas/public/publishing-api-editions-new-current.json
+++ b/terraform-dev/schemas/public/publishing-api-editions-new-current.json
@@ -1,0 +1,107 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
+  }
+]

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -39,6 +39,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current and public"
+  schema        = file("schemas/public/publishing-api-editions-new-current.json")
+}
+
 resource "google_bigquery_table" "public_publishing_api_editions_current" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "publishing_api_editions_current"

--- a/terraform-staging/bigquery/publishing-api-editions-current.sql
+++ b/terraform-staging/bigquery/publishing-api-editions-current.sql
@@ -63,21 +63,49 @@ INSERT INTO private.publishing_api_editions_new_current
   QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
 ;
 
--- Delete rows from the editions_current table where a newer edition of the same
--- document is now available.
-MERGE INTO
-public.publishing_api_editions_current AS target
-USING private.publishing_api_editions_new_current AS source
-ON source.content_id = target.content_id AND source.locale = target.locale
-WHEN matched THEN DELETE
+-- Derive from the new editions a table of the latest edition per document, and
+-- a flag indicating whether it has a presence online (whether a redirect,
+-- or embedded in other pages, or a page in its own right).
+TRUNCATE TABLE private.publishing_api_editions_new_current;
+INSERT INTO private.publishing_api_editions_new_current
+  SELECT
+    documents.content_id,
+    documents.locale,
+    publishing_api_editions_new.*,
+    unpublishings.type AS unpublishing_type,
+    -- TODO: derive other values here
+    (
+      coalesce(content_store = 'live', false) -- Includes items that are only embedded in others.
+      AND state <> 'superseded' -- Exclude this rare and illogical case
+      AND coalesce(unpublishings.type <> 'vanish', true)
+      AND (
+        coalesce(left(schema_name, 11) <> 'placeholder', true)
+        OR (
+          -- schema_name must be checked again because short-circuit evaluation
+          -- isn't available in this clause.
+          coalesce(left(schema_name, 11) = 'placeholder', false)
+          AND coalesce(unpublishings.type IN ('gone', 'redirect'), false)
+        )
+      )
+    ) AS is_online
+  FROM private.publishing_api_editions_new
+  INNER JOIN publishing_api.documents ON documents.id = publishing_api_editions_new.document_id
+  LEFT JOIN publishing_api.unpublishings ON unpublishings.edition_id = publishing_api_editions_new.id
+  WHERE state <> 'draft'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
 ;
 
--- Insert new editions into the editions_current table, if they are also
--- 'online', which means that they are publicly available via the website or the
--- Content API. Scrub certain columns of editions that are redirected or
+-- Insert new editions into the public.editions_new_current table, if they are
+-- also 'online', which means that they are publicly available via the website
+-- or the Content API. Scrub certain columns of editions that are redirected or
 -- 'gone', and omit columns that aren't in the Content API at all.
 -- https://github.com/alphagov/publishing-api/tree/d041ae94a48fec9bd623bbb36ae6e87820ea0b06/app/presenters
-INSERT INTO public.publishing_api_editions_current
+--
+-- These could go straigt into public.publishing_api_editions_current, but it's
+-- more efficient to put them here, so that we can do downstream processing of
+-- only the new editions, without querying all the existing editions.
+TRUNCATE TABLE public.publishing_api_editions_new_current;
+INSERT INTO public.publishing_api_editions_new_current
 SELECT *
     EXCEPT (
       created_at,
@@ -94,17 +122,33 @@ SELECT *
       is_online
     )
     REPLACE (
-      IF (unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,
-      IF (unpublishing_type IN ('redirect', 'gone'), unpublishing_type, schema_name) AS schema_name,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, title) AS title,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, rendering_app) AS rendering_app,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, analytics_identifier) AS analytics_identifier,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, first_published_at) AS first_published_at,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, description) AS description,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, details) AS details
+      IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,
+      IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, schema_name) AS schema_name,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, title) AS title,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, rendering_app) AS rendering_app,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, analytics_identifier) AS analytics_identifier,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, first_published_at) AS first_published_at,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, description) AS description,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, details) AS details
     )
 FROM private.publishing_api_editions_new_current
 WHERE is_online
+;
+
+-- Delete rows from the editions_current table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.publishing_api_editions_current AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.content_id = target.content_id AND source.locale = target.locale
+WHEN matched THEN DELETE
+;
+
+-- Insert new, public editions into the
+-- public.publishing_api_editions_new_current table.
+INSERT INTO public.publishing_api_editions_current
+SELECT * FROM public.publishing_api_editions_new_current
 ;
 
 END

--- a/terraform-staging/schemas/public/publishing-api-editions-new-current.json
+++ b/terraform-staging/schemas/public/publishing-api-editions-new-current.json
@@ -1,0 +1,107 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
+  }
+]

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -39,6 +39,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "public_publishing_api_editions_new_current" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "publishing_api_editions_new_current"
+  friendly_name = "Publishing API editions (new and current)"
+  description   = "Publishing API editions from the latest batch update, that are also current and public"
+  schema        = file("schemas/public/publishing-api-editions-new-current.json")
+}
+
 resource "google_bigquery_table" "public_publishing_api_editions_current" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "publishing_api_editions_current"

--- a/terraform/bigquery/publishing-api-editions-current.sql
+++ b/terraform/bigquery/publishing-api-editions-current.sql
@@ -63,21 +63,49 @@ INSERT INTO private.publishing_api_editions_new_current
   QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
 ;
 
--- Delete rows from the editions_current table where a newer edition of the same
--- document is now available.
-MERGE INTO
-public.publishing_api_editions_current AS target
-USING private.publishing_api_editions_new_current AS source
-ON source.content_id = target.content_id AND source.locale = target.locale
-WHEN matched THEN DELETE
+-- Derive from the new editions a table of the latest edition per document, and
+-- a flag indicating whether it has a presence online (whether a redirect,
+-- or embedded in other pages, or a page in its own right).
+TRUNCATE TABLE private.publishing_api_editions_new_current;
+INSERT INTO private.publishing_api_editions_new_current
+  SELECT
+    documents.content_id,
+    documents.locale,
+    publishing_api_editions_new.*,
+    unpublishings.type AS unpublishing_type,
+    -- TODO: derive other values here
+    (
+      coalesce(content_store = 'live', false) -- Includes items that are only embedded in others.
+      AND state <> 'superseded' -- Exclude this rare and illogical case
+      AND coalesce(unpublishings.type <> 'vanish', true)
+      AND (
+        coalesce(left(schema_name, 11) <> 'placeholder', true)
+        OR (
+          -- schema_name must be checked again because short-circuit evaluation
+          -- isn't available in this clause.
+          coalesce(left(schema_name, 11) = 'placeholder', false)
+          AND coalesce(unpublishings.type IN ('gone', 'redirect'), false)
+        )
+      )
+    ) AS is_online
+  FROM private.publishing_api_editions_new
+  INNER JOIN publishing_api.documents ON documents.id = publishing_api_editions_new.document_id
+  LEFT JOIN publishing_api.unpublishings ON unpublishings.edition_id = publishing_api_editions_new.id
+  WHERE state <> 'draft'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY content_id, locale ORDER BY updated_at DESC) = 1
 ;
 
--- Insert new editions into the editions_current table, if they are also
--- 'online', which means that they are publicly available via the website or the
--- Content API. Scrub certain columns of editions that are redirected or
+-- Insert new editions into the public.editions_new_current table, if they are
+-- also 'online', which means that they are publicly available via the website
+-- or the Content API. Scrub certain columns of editions that are redirected or
 -- 'gone', and omit columns that aren't in the Content API at all.
 -- https://github.com/alphagov/publishing-api/tree/d041ae94a48fec9bd623bbb36ae6e87820ea0b06/app/presenters
-INSERT INTO public.publishing_api_editions_current
+--
+-- These could go straigt into public.publishing_api_editions_current, but it's
+-- more efficient to put them here, so that we can do downstream processing of
+-- only the new editions, without querying all the existing editions.
+TRUNCATE TABLE public.publishing_api_editions_new_current;
+INSERT INTO public.publishing_api_editions_new_current
 SELECT *
     EXCEPT (
       created_at,
@@ -94,17 +122,33 @@ SELECT *
       is_online
     )
     REPLACE (
-      IF (unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,
-      IF (unpublishing_type IN ('redirect', 'gone'), unpublishing_type, schema_name) AS schema_name,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, title) AS title,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, rendering_app) AS rendering_app,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, analytics_identifier) AS analytics_identifier,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, first_published_at) AS first_published_at,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, description) AS description,
-      IF (unpublishing_type IN ('redirect', 'gone'), NULL, details) AS details
+      IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,
+      IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, schema_name) AS schema_name,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, title) AS title,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, rendering_app) AS rendering_app,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, analytics_identifier) AS analytics_identifier,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, first_published_at) AS first_published_at,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, description) AS description,
+      IF(unpublishing_type IN ('redirect', 'gone'), NULL, details) AS details
     )
 FROM private.publishing_api_editions_new_current
 WHERE is_online
+;
+
+-- Delete rows from the editions_current table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.publishing_api_editions_current AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.content_id = target.content_id AND source.locale = target.locale
+WHEN matched THEN DELETE
+;
+
+-- Insert new, public editions into the
+-- public.publishing_api_editions_new_current table.
+INSERT INTO public.publishing_api_editions_current
+SELECT * FROM public.publishing_api_editions_new_current
 ;
 
 END

--- a/terraform/schemas/public/publishing-api-editions-new-current.json
+++ b/terraform/schemas/public/publishing-api-editions-new-current.json
@@ -1,0 +1,107 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "public_updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publishing_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "rendering_app",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "phase",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "analytics_identifier",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "document_type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "schema_name",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "description",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "routes",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "redirects",
+    "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "unpublishing_type",
+    "type": "STRING"
+  }
+]


### PR DESCRIPTION
New, current, online editions aren't just appended to a table. They are
also processed further, to extract the content. That means that it is
useful to keep an intermediate step between scrubbing them of non-public
data, and appending them to the main table.  That way, further
processing can use the small intermediate step, rather than
re-processing the whole main table.
