### PR TITLE
feat: control query execution order via routines

### DIFF
--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -27,6 +27,7 @@ data "google_iam_policy" "bigquery_dataset_functions" {
       [
         "projectReaders",
         google_service_account.gce_mongodb.member,
+        google_service_account.bigquery_scheduled_queries.member,
       ],
       var.bigquery_functions_data_viewer_members,
     )
@@ -86,4 +87,23 @@ resource "google_bigquery_routine" "extract_phone_numbers" {
     )
     name = "text"
   }
+}
+
+resource "google_bigquery_routine" "publishing_api_editions_current" {
+  dataset_id      = google_bigquery_dataset.functions.dataset_id
+  routine_id      = "publishing_api_editions_current"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/publishing-api-editions-current.sql")
+}
+
+resource "google_bigquery_routine" "extract_markup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "extract_markup"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/extract-markup-from-editions.sql",
+    { project_id = var.project_id }
+  )
 }

--- a/terraform-dev/bigquery-scheduled-queries.tf
+++ b/terraform-dev/bigquery-scheduled-queries.tf
@@ -7,24 +7,13 @@ resource "google_service_account" "bigquery_scheduled_queries" {
   description  = "Service account for scheduled BigQuery queries"
 }
 
-resource "google_bigquery_data_transfer_config" "publishing_api_editions_current" {
+resource "google_bigquery_data_transfer_config" "publishing_api_batch" {
   data_source_id = "scheduled_query" # This is a magic word
-  display_name   = "Publishing API editions current"
+  display_name   = "Publishing API batch"
   location       = var.region
   schedule       = "every day 00:00"
   params = {
-    query = file("bigquery/publishing-api-editions-current.sql")
-  }
-  service_account_name = google_service_account.bigquery_scheduled_queries.email
-}
-
-resource "google_bigquery_data_transfer_config" "extract_markup" {
-  data_source_id = "scheduled_query" # This is a magic word
-  display_name   = "Extract markup"
-  location       = var.region
-  schedule       = "every day 01:00"
-  params = {
-    query = file("bigquery/extract-markup-from-editions.sql")
+    query = file("bigquery/publishing-api-batch.sql")
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }

--- a/terraform-dev/bigquery/extract-content-from-html.sql
+++ b/terraform-dev/bigquery/extract-content-from-html.sql
@@ -1,0 +1,45 @@
+-- Maintains a table `public.content`, derived from `public.markup`
+--
+-- 1. Fetch new markup since the last batch update from
+--    public.markup_new.
+-- 2. Extract plain text and other HTML elements.
+-- 4. Delete outdated records from public.content.
+-- 4. Insert new content into public.content.
+
+BEGIN
+
+TRUNCATE TABLE public.content_new;
+INSERT INTO public.content_new
+WITH extracts AS (
+  SELECT
+    edition_id,
+    document_id,
+    part_index,
+    functions.parse_html(html, 'https://www.gov.uk' || base_path) AS extracted_content
+  FROM public.markup_new
+)
+SELECT
+  edition_id,
+  document_id,
+  extracted_content.text,
+  extracted_content.hyperlinks,
+  extracted_content.abbreviations
+FROM extracts
+;
+
+-- Delete rows from the public.content table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.content AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.document_id = target.document_id
+WHEN matched THEN DELETE
+;
+
+-- Insert the content of new editions into the public.content table.
+INSERT INTO public.content
+SELECT * FROM public.content_new
+;
+
+END

--- a/terraform-dev/bigquery/extract-markup-from-editions.sql
+++ b/terraform-dev/bigquery/extract-markup-from-editions.sql
@@ -284,7 +284,7 @@ combined AS (
 
 rendered AS (
   SELECT * REPLACE(
-    COALESCE(html, JSON_VALUE(functions.govspeak_to_html(govspeak), '$.html')) AS html
+    COALESCE(html, JSON_VALUE(`${project_id}.functions.govspeak_to_html`(govspeak), '$.html')) AS html
   )
   FROM combined
 )

--- a/terraform-dev/bigquery/publishing-api-batch.sql
+++ b/terraform-dev/bigquery/publishing-api-batch.sql
@@ -1,0 +1,8 @@
+-- Call a sequence of routines that process updated documents from the
+-- Publishing API database.
+
+-- Fetch new editions
+CALL functions.publishing_api_editions_current();
+
+-- Extract content markup, and render GovSpeak to HTML when necessary.
+CALL functions.extract_markup();

--- a/terraform-dev/cloud-function.tf
+++ b/terraform-dev/cloud-function.tf
@@ -145,6 +145,20 @@ resource "google_bigquery_connection" "govspeak_to_html" {
   cloud_resource {}
 }
 
+data "google_iam_policy" "bigquery_connection_govspeak_to_html" {
+  binding {
+    role = "roles/bigquery.connectionUser"
+    members = [
+      google_service_account.bigquery_scheduled_queries.member,
+    ]
+  }
+}
+
+resource "google_bigquery_connection_iam_policy" "govspeak_to_html" {
+  connection_id = google_bigquery_connection.govspeak_to_html.connection_id
+  policy_data   = data.google_iam_policy.bigquery_connection_govspeak_to_html.policy_data
+}
+
 # generate a random string suffix for a bigquery job to deploy the function
 resource "random_string" "deploy_govspeak_to_html" {
   length  = 20

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -27,6 +27,7 @@ data "google_iam_policy" "bigquery_dataset_functions" {
       [
         "projectReaders",
         google_service_account.gce_mongodb.member,
+        google_service_account.bigquery_scheduled_queries.member,
       ],
       var.bigquery_functions_data_viewer_members,
     )
@@ -86,4 +87,23 @@ resource "google_bigquery_routine" "extract_phone_numbers" {
     )
     name = "text"
   }
+}
+
+resource "google_bigquery_routine" "publishing_api_editions_current" {
+  dataset_id      = google_bigquery_dataset.functions.dataset_id
+  routine_id      = "publishing_api_editions_current"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/publishing-api-editions-current.sql")
+}
+
+resource "google_bigquery_routine" "extract_markup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "extract_markup"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/extract-markup-from-editions.sql",
+    { project_id = var.project_id }
+  )
 }

--- a/terraform-staging/bigquery-scheduled-queries.tf
+++ b/terraform-staging/bigquery-scheduled-queries.tf
@@ -7,24 +7,13 @@ resource "google_service_account" "bigquery_scheduled_queries" {
   description  = "Service account for scheduled BigQuery queries"
 }
 
-resource "google_bigquery_data_transfer_config" "publishing_api_editions_current" {
+resource "google_bigquery_data_transfer_config" "publishing_api_batch" {
   data_source_id = "scheduled_query" # This is a magic word
-  display_name   = "Publishing API editions current"
+  display_name   = "Publishing API batch"
   location       = var.region
   schedule       = "every day 00:00"
   params = {
-    query = file("bigquery/publishing-api-editions-current.sql")
-  }
-  service_account_name = google_service_account.bigquery_scheduled_queries.email
-}
-
-resource "google_bigquery_data_transfer_config" "extract_markup" {
-  data_source_id = "scheduled_query" # This is a magic word
-  display_name   = "Extract markup"
-  location       = var.region
-  schedule       = "every day 01:00"
-  params = {
-    query = file("bigquery/extract-markup-from-editions.sql")
+    query = file("bigquery/publishing-api-batch.sql")
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }

--- a/terraform-staging/bigquery/extract-content-from-html.sql
+++ b/terraform-staging/bigquery/extract-content-from-html.sql
@@ -1,0 +1,45 @@
+-- Maintains a table `public.content`, derived from `public.markup`
+--
+-- 1. Fetch new markup since the last batch update from
+--    public.markup_new.
+-- 2. Extract plain text and other HTML elements.
+-- 4. Delete outdated records from public.content.
+-- 4. Insert new content into public.content.
+
+BEGIN
+
+TRUNCATE TABLE public.content_new;
+INSERT INTO public.content_new
+WITH extracts AS (
+  SELECT
+    edition_id,
+    document_id,
+    part_index,
+    functions.parse_html(html, 'https://www.gov.uk' || base_path) AS extracted_content
+  FROM public.markup_new
+)
+SELECT
+  edition_id,
+  document_id,
+  extracted_content.text,
+  extracted_content.hyperlinks,
+  extracted_content.abbreviations
+FROM extracts
+;
+
+-- Delete rows from the public.content table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.content AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.document_id = target.document_id
+WHEN matched THEN DELETE
+;
+
+-- Insert the content of new editions into the public.content table.
+INSERT INTO public.content
+SELECT * FROM public.content_new
+;
+
+END

--- a/terraform-staging/bigquery/extract-markup-from-editions.sql
+++ b/terraform-staging/bigquery/extract-markup-from-editions.sql
@@ -284,7 +284,7 @@ combined AS (
 
 rendered AS (
   SELECT * REPLACE(
-    COALESCE(html, JSON_VALUE(functions.govspeak_to_html(govspeak), '$.html')) AS html
+    COALESCE(html, JSON_VALUE(`${project_id}.functions.govspeak_to_html`(govspeak), '$.html')) AS html
   )
   FROM combined
 )

--- a/terraform-staging/bigquery/publishing-api-batch.sql
+++ b/terraform-staging/bigquery/publishing-api-batch.sql
@@ -1,0 +1,8 @@
+-- Call a sequence of routines that process updated documents from the
+-- Publishing API database.
+
+-- Fetch new editions
+CALL functions.publishing_api_editions_current();
+
+-- Extract content markup, and render GovSpeak to HTML when necessary.
+CALL functions.extract_markup();

--- a/terraform-staging/cloud-function.tf
+++ b/terraform-staging/cloud-function.tf
@@ -145,6 +145,20 @@ resource "google_bigquery_connection" "govspeak_to_html" {
   cloud_resource {}
 }
 
+data "google_iam_policy" "bigquery_connection_govspeak_to_html" {
+  binding {
+    role = "roles/bigquery.connectionUser"
+    members = [
+      google_service_account.bigquery_scheduled_queries.member,
+    ]
+  }
+}
+
+resource "google_bigquery_connection_iam_policy" "govspeak_to_html" {
+  connection_id = google_bigquery_connection.govspeak_to_html.connection_id
+  policy_data   = data.google_iam_policy.bigquery_connection_govspeak_to_html.policy_data
+}
+
 # generate a random string suffix for a bigquery job to deploy the function
 resource "random_string" "deploy_govspeak_to_html" {
   length  = 20

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -27,6 +27,7 @@ data "google_iam_policy" "bigquery_dataset_functions" {
       [
         "projectReaders",
         google_service_account.gce_mongodb.member,
+        google_service_account.bigquery_scheduled_queries.member,
       ],
       var.bigquery_functions_data_viewer_members,
     )
@@ -86,4 +87,23 @@ resource "google_bigquery_routine" "extract_phone_numbers" {
     )
     name = "text"
   }
+}
+
+resource "google_bigquery_routine" "publishing_api_editions_current" {
+  dataset_id      = google_bigquery_dataset.functions.dataset_id
+  routine_id      = "publishing_api_editions_current"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/publishing-api-editions-current.sql")
+}
+
+resource "google_bigquery_routine" "extract_markup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "extract_markup"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/extract-markup-from-editions.sql",
+    { project_id = var.project_id }
+  )
 }

--- a/terraform/bigquery-scheduled-queries.tf
+++ b/terraform/bigquery-scheduled-queries.tf
@@ -7,24 +7,13 @@ resource "google_service_account" "bigquery_scheduled_queries" {
   description  = "Service account for scheduled BigQuery queries"
 }
 
-resource "google_bigquery_data_transfer_config" "publishing_api_editions_current" {
+resource "google_bigquery_data_transfer_config" "publishing_api_batch" {
   data_source_id = "scheduled_query" # This is a magic word
-  display_name   = "Publishing API editions current"
+  display_name   = "Publishing API batch"
   location       = var.region
   schedule       = "every day 00:00"
   params = {
-    query = file("bigquery/publishing-api-editions-current.sql")
-  }
-  service_account_name = google_service_account.bigquery_scheduled_queries.email
-}
-
-resource "google_bigquery_data_transfer_config" "extract_markup" {
-  data_source_id = "scheduled_query" # This is a magic word
-  display_name   = "Extract markup"
-  location       = var.region
-  schedule       = "every day 01:00"
-  params = {
-    query = file("bigquery/extract-markup-from-editions.sql")
+    query = file("bigquery/publishing-api-batch.sql")
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }

--- a/terraform/bigquery/extract-content-from-html.sql
+++ b/terraform/bigquery/extract-content-from-html.sql
@@ -1,0 +1,45 @@
+-- Maintains a table `public.content`, derived from `public.markup`
+--
+-- 1. Fetch new markup since the last batch update from
+--    public.markup_new.
+-- 2. Extract plain text and other HTML elements.
+-- 4. Delete outdated records from public.content.
+-- 4. Insert new content into public.content.
+
+BEGIN
+
+TRUNCATE TABLE public.content_new;
+INSERT INTO public.content_new
+WITH extracts AS (
+  SELECT
+    edition_id,
+    document_id,
+    part_index,
+    functions.parse_html(html, 'https://www.gov.uk' || base_path) AS extracted_content
+  FROM public.markup_new
+)
+SELECT
+  edition_id,
+  document_id,
+  extracted_content.text,
+  extracted_content.hyperlinks,
+  extracted_content.abbreviations
+FROM extracts
+;
+
+-- Delete rows from the public.content table where a newer edition of the same
+-- document is now available.  The newer edition might be private, so use the
+-- private editions as the source of the merge.
+MERGE INTO
+public.content AS target
+USING private.publishing_api_editions_new_current AS source
+ON source.document_id = target.document_id
+WHEN matched THEN DELETE
+;
+
+-- Insert the content of new editions into the public.content table.
+INSERT INTO public.content
+SELECT * FROM public.content_new
+;
+
+END

--- a/terraform/bigquery/extract-markup-from-editions.sql
+++ b/terraform/bigquery/extract-markup-from-editions.sql
@@ -284,7 +284,7 @@ combined AS (
 
 rendered AS (
   SELECT * REPLACE(
-    COALESCE(html, JSON_VALUE(functions.govspeak_to_html(govspeak), '$.html')) AS html
+    COALESCE(html, JSON_VALUE(`${project_id}.functions.govspeak_to_html`(govspeak), '$.html')) AS html
   )
   FROM combined
 )

--- a/terraform/bigquery/publishing-api-batch.sql
+++ b/terraform/bigquery/publishing-api-batch.sql
@@ -1,0 +1,8 @@
+-- Call a sequence of routines that process updated documents from the
+-- Publishing API database.
+
+-- Fetch new editions
+CALL functions.publishing_api_editions_current();
+
+-- Extract content markup, and render GovSpeak to HTML when necessary.
+CALL functions.extract_markup();

--- a/terraform/cloud-function.tf
+++ b/terraform/cloud-function.tf
@@ -145,6 +145,20 @@ resource "google_bigquery_connection" "govspeak_to_html" {
   cloud_resource {}
 }
 
+data "google_iam_policy" "bigquery_connection_govspeak_to_html" {
+  binding {
+    role = "roles/bigquery.connectionUser"
+    members = [
+      google_service_account.bigquery_scheduled_queries.member,
+    ]
+  }
+}
+
+resource "google_bigquery_connection_iam_policy" "govspeak_to_html" {
+  connection_id = google_bigquery_connection.govspeak_to_html.connection_id
+  policy_data   = data.google_iam_policy.bigquery_connection_govspeak_to_html.policy_data
+}
+
 # generate a random string suffix for a bigquery job to deploy the function
 resource "random_string" "deploy_govspeak_to_html" {
   length  = 20


### PR DESCRIPTION
Instead of controlling the order of execution by scheduling one to run
an hour later than the other (for example), and hoping that the first
one doesn't take longer than an hour.

Define each query as a routine, and then schedule an overall query that
calls each routine.

Closes #633
