### PR TITLE
fix: several bugfixes

### DIFF
--- a/.github/workflows/docker-parse-html-dev.yml
+++ b/.github/workflows/docker-parse-html-dev.yml
@@ -77,4 +77,5 @@ jobs:
       uses: 'google-github-actions/deploy-cloudrun@v2'
       with:
         service: 'parse-html'
+        region: 'europe-west2'
         image: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker/parse-html:latest'

--- a/.github/workflows/docker-parse-html-dev.yml
+++ b/.github/workflows/docker-parse-html-dev.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - dev
     paths:
-      - 'docker/parse-html/Dockerfile'
-      - 'docker/parse-html/entrypoint.sh'
+      - 'docker/parse-html/*'
       - '.github/workflows/docker-parse-html-dev.yml'
 
 defaults:

--- a/.github/workflows/docker-parse-html-staging.yml
+++ b/.github/workflows/docker-parse-html-staging.yml
@@ -71,3 +71,12 @@ jobs:
         docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
         docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
         docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+
+    # Create a new revision of the Cloud Run service using the new image
+    - name: 'Cloud Run deploy'
+      id: 'deploy'
+      uses: 'google-github-actions/deploy-cloudrun@v2'
+      with:
+        service: 'parse-html'
+        region: 'europe-west2'
+        image: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker/parse-html:latest'

--- a/.github/workflows/docker-parse-html.yml
+++ b/.github/workflows/docker-parse-html.yml
@@ -71,3 +71,12 @@ jobs:
         docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
         docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
         docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+
+    # Create a new revision of the Cloud Run service using the new image
+    - name: 'Cloud Run deploy'
+      id: 'deploy'
+      uses: 'google-github-actions/deploy-cloudrun@v2'
+      with:
+        service: 'parse-html'
+        region: 'europe-west2'
+        image: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/parse-html:latest'

--- a/docker/parse-html/Dockerfile
+++ b/docker/parse-html/Dockerfile
@@ -9,11 +9,11 @@ ENV CHROMEDRIVER_PATH /usr/bin/chromedriver
 ENV CHROME_BIN /usr/bin/chromium-browser
 
 WORKDIR /usr/src/app
-COPY Gemfile* .
+COPY Gemfile* ./
 
 RUN bundle install
 
-COPY . .
+COPY . ./
 
 # Run the web service on container startup.
 ENTRYPOINT ["bundle", "exec", "functions-framework-ruby", "--target", "parse_html"]

--- a/terraform-dev/bigquery/extract-markup-from-editions.sql
+++ b/terraform-dev/bigquery/extract-markup-from-editions.sql
@@ -252,6 +252,7 @@ first_parts AS (
     govspeak,
     html
   FROM parts
+  WHERE part_index = 0
 ),
 -- Make parts like pages in their own right (concatenating the base_path and slug),
 -- but leave enough metadata to be able to deconstruct them back to a true part.

--- a/terraform-dev/embed-text.tf
+++ b/terraform-dev/embed-text.tf
@@ -11,7 +11,7 @@ resource "google_cloud_run_v2_service" "embed_text" {
       resources {
         limits = {
           cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
-          memory = "2056Mi"
+          memory = "2048Mi"
         }
       }
     }

--- a/terraform-dev/parse-html.tf
+++ b/terraform-dev/parse-html.tf
@@ -10,7 +10,7 @@ resource "google_cloud_run_v2_service" "parse_html" {
       image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
       resources {
         limits = {
-          cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
+          cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.
           memory = "2048Mi" # By experiment, necessary and sufficient.
         }
       }

--- a/terraform-dev/parse-html.tf
+++ b/terraform-dev/parse-html.tf
@@ -8,7 +8,17 @@ resource "google_cloud_run_v2_service" "parse_html" {
   template {
     containers {
       image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+      resources {
+        limits = {
+          cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
+          memory = "2048Mi" # By experiment, necessary and sufficient.
+        }
+      }
     }
+    # The function only handles one request at a time, which it enforces by
+    # using a filesystem lock as a mutex. It might be worth telling GCP
+    # explicitly, so that it might try to create more instances of the function.
+    max_instance_request_concurrency = 1
   }
 }
 

--- a/terraform-staging/bigquery/extract-markup-from-editions.sql
+++ b/terraform-staging/bigquery/extract-markup-from-editions.sql
@@ -252,6 +252,7 @@ first_parts AS (
     govspeak,
     html
   FROM parts
+  WHERE part_index = 0
 ),
 -- Make parts like pages in their own right (concatenating the base_path and slug),
 -- but leave enough metadata to be able to deconstruct them back to a true part.

--- a/terraform-staging/embed-text.tf
+++ b/terraform-staging/embed-text.tf
@@ -11,7 +11,7 @@ resource "google_cloud_run_v2_service" "embed_text" {
       resources {
         limits = {
           cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
-          memory = "2056Mi"
+          memory = "2048Mi"
         }
       }
     }

--- a/terraform-staging/parse-html.tf
+++ b/terraform-staging/parse-html.tf
@@ -10,7 +10,7 @@ resource "google_cloud_run_v2_service" "parse_html" {
       image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
       resources {
         limits = {
-          cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
+          cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.
           memory = "2048Mi" # By experiment, necessary and sufficient.
         }
       }

--- a/terraform-staging/parse-html.tf
+++ b/terraform-staging/parse-html.tf
@@ -8,7 +8,17 @@ resource "google_cloud_run_v2_service" "parse_html" {
   template {
     containers {
       image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+      resources {
+        limits = {
+          cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
+          memory = "2048Mi" # By experiment, necessary and sufficient.
+        }
+      }
     }
+    # The function only handles one request at a time, which it enforces by
+    # using a filesystem lock as a mutex. It might be worth telling GCP
+    # explicitly, so that it might try to create more instances of the function.
+    max_instance_request_concurrency = 1
   }
 }
 

--- a/terraform/bigquery/extract-markup-from-editions.sql
+++ b/terraform/bigquery/extract-markup-from-editions.sql
@@ -252,6 +252,7 @@ first_parts AS (
     govspeak,
     html
   FROM parts
+  WHERE part_index = 0
 ),
 -- Make parts like pages in their own right (concatenating the base_path and slug),
 -- but leave enough metadata to be able to deconstruct them back to a true part.

--- a/terraform/embed-text.tf
+++ b/terraform/embed-text.tf
@@ -11,7 +11,7 @@ resource "google_cloud_run_v2_service" "embed_text" {
       resources {
         limits = {
           cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
-          memory = "2056Mi"
+          memory = "2048Mi"
         }
       }
     }

--- a/terraform/parse-html.tf
+++ b/terraform/parse-html.tf
@@ -10,7 +10,7 @@ resource "google_cloud_run_v2_service" "parse_html" {
       image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
       resources {
         limits = {
-          cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
+          cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.
           memory = "2048Mi" # By experiment, necessary and sufficient.
         }
       }

--- a/terraform/parse-html.tf
+++ b/terraform/parse-html.tf
@@ -8,7 +8,17 @@ resource "google_cloud_run_v2_service" "parse_html" {
   template {
     containers {
       image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+      resources {
+        limits = {
+          cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.
+          memory = "2048Mi" # By experiment, necessary and sufficient.
+        }
+      }
     }
+    # The function only handles one request at a time, which it enforces by
+    # using a filesystem lock as a mutex. It might be worth telling GCP
+    # explicitly, so that it might try to create more instances of the function.
+    max_instance_request_concurrency = 1
   }
 }
 


### PR DESCRIPTION
See individual commit messages.

- fix: trigger docker rebuild correctly
- fix: deploy parse-html function correctly
- fix: parse-html function correctness and speed
- chore: configure an idiomatic amount of memory
- fix: only duplicate the first part of each doc
