### PR TITLE
refactor: define dedup as a permanent function

### DIFF
--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -89,6 +89,21 @@ resource "google_bigquery_routine" "extract_phone_numbers" {
   }
 }
 
+resource "google_bigquery_routine" "dedup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "dedup"
+  routine_type = "SCALAR_FUNCTION"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/dedup.sql",
+    { project_id = var.project_id }
+  )
+  arguments {
+    name          = "val"
+    argument_kind = "ANY_TYPE"
+  }
+}
+
 resource "google_bigquery_routine" "publishing_api_editions_current" {
   dataset_id      = google_bigquery_dataset.functions.dataset_id
   routine_id      = "publishing_api_editions_current"
@@ -125,11 +140,14 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
 }
 
 resource "google_bigquery_routine" "taxonomy" {
-  dataset_id      = google_bigquery_dataset.functions.dataset_id
-  routine_id      = "taxonomy"
-  routine_type    = "PROCEDURE"
-  language        = "SQL"
-  definition_body = file("bigquery/taxonomy.sql")
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "taxonomy"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/taxonomy.sql",
+    { project_id = var.project_id }
+  )
 }
 
 resource "google_bigquery_routine" "contact_phone_numbers" {

--- a/terraform-dev/bigquery/dedup.sql
+++ b/terraform-dev/bigquery/dedup.sql
@@ -1,0 +1,14 @@
+-- Uncomment at the top and bottom of this file to manually define the function
+-- outside of terraform.
+
+-- A function like DISTINCT but works on an array of any type, including STRUCT
+-- https://stackoverflow.com/a/55778635
+
+-- CREATE FUNCTION
+--   functions.dedup(val ANY TYPE)
+--   AS (
+  (
+    SELECT ARRAY_AGG(t)
+    FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
+  )
+-- );

--- a/terraform-dev/bigquery/extract-content-from-editions.sql
+++ b/terraform-dev/bigquery/extract-content-from-editions.sql
@@ -37,13 +37,6 @@ CREATE TEMP FUNCTION markup_from_json_array(array_of_json JSON) AS ((
     )
 ));
 
--- A function like DISTINCT but works on an array of any type, including STRUCT
--- https://stackoverflow.com/a/55778635
-CREATE TEMP FUNCTION dedup(val ANY TYPE) AS ((
-  SELECT ARRAY_AGG(t)
-  FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
-));
-
 TRUNCATE TABLE public.content_new;
 INSERT INTO public.content_new
 -- schema_map ought to be a table, but it would take a lot of configuration.  If
@@ -316,7 +309,7 @@ SELECT
       )
     FROM UNNEST(SPLIT(text, "\n")) AS line WITH OFFSET AS line_number
   ) AS lines,
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY(
       SELECT
         STRUCT(
@@ -327,7 +320,7 @@ SELECT
       FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.hyperlinks")) AS link
     )
   ) AS hyperlinks,
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY(
       SELECT
         STRUCT(

--- a/terraform-dev/bigquery/taxonomy.sql
+++ b/terraform-dev/bigquery/taxonomy.sql
@@ -4,11 +4,6 @@
 -- Top-level taxons are included.
 -- Assumes each taxon has at most one parent, and at most one associated taxon.
 
--- https://stackoverflow.com/a/55778635
-CREATE TEMP FUNCTION dedup(val ANY TYPE) AS ((
-  SELECT ARRAY_AGG(t)
-  FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
-));
 TRUNCATE TABLE public.taxonomy;
 INSERT INTO public.taxonomy
 WITH RECURSIVE
@@ -154,7 +149,7 @@ SELECT
     [(STRUCT(taxons.edition_id, parentage_tree.level))], -- itself
     association_tree.ancestors -- ancestors of its associated taxon, if any
   ) AS ancestors_via_association, -- includes itself
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY_CONCAT(
       parentage_tree.ancestors,
       association_tree.ancestors

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -89,6 +89,21 @@ resource "google_bigquery_routine" "extract_phone_numbers" {
   }
 }
 
+resource "google_bigquery_routine" "dedup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "dedup"
+  routine_type = "SCALAR_FUNCTION"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/dedup.sql",
+    { project_id = var.project_id }
+  )
+  arguments {
+    name          = "val"
+    argument_kind = "ANY_TYPE"
+  }
+}
+
 resource "google_bigquery_routine" "publishing_api_editions_current" {
   dataset_id      = google_bigquery_dataset.functions.dataset_id
   routine_id      = "publishing_api_editions_current"
@@ -125,11 +140,14 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
 }
 
 resource "google_bigquery_routine" "taxonomy" {
-  dataset_id      = google_bigquery_dataset.functions.dataset_id
-  routine_id      = "taxonomy"
-  routine_type    = "PROCEDURE"
-  language        = "SQL"
-  definition_body = file("bigquery/taxonomy.sql")
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "taxonomy"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/taxonomy.sql",
+    { project_id = var.project_id }
+  )
 }
 
 resource "google_bigquery_routine" "contact_phone_numbers" {

--- a/terraform-staging/bigquery/dedup.sql
+++ b/terraform-staging/bigquery/dedup.sql
@@ -1,0 +1,14 @@
+-- Uncomment at the top and bottom of this file to manually define the function
+-- outside of terraform.
+
+-- A function like DISTINCT but works on an array of any type, including STRUCT
+-- https://stackoverflow.com/a/55778635
+
+-- CREATE FUNCTION
+--   functions.dedup(val ANY TYPE)
+--   AS (
+  (
+    SELECT ARRAY_AGG(t)
+    FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
+  )
+-- );

--- a/terraform-staging/bigquery/extract-content-from-editions.sql
+++ b/terraform-staging/bigquery/extract-content-from-editions.sql
@@ -37,13 +37,6 @@ CREATE TEMP FUNCTION markup_from_json_array(array_of_json JSON) AS ((
     )
 ));
 
--- A function like DISTINCT but works on an array of any type, including STRUCT
--- https://stackoverflow.com/a/55778635
-CREATE TEMP FUNCTION dedup(val ANY TYPE) AS ((
-  SELECT ARRAY_AGG(t)
-  FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
-));
-
 TRUNCATE TABLE public.content_new;
 INSERT INTO public.content_new
 -- schema_map ought to be a table, but it would take a lot of configuration.  If
@@ -316,7 +309,7 @@ SELECT
       )
     FROM UNNEST(SPLIT(text, "\n")) AS line WITH OFFSET AS line_number
   ) AS lines,
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY(
       SELECT
         STRUCT(
@@ -327,7 +320,7 @@ SELECT
       FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.hyperlinks")) AS link
     )
   ) AS hyperlinks,
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY(
       SELECT
         STRUCT(

--- a/terraform-staging/bigquery/taxonomy.sql
+++ b/terraform-staging/bigquery/taxonomy.sql
@@ -4,11 +4,6 @@
 -- Top-level taxons are included.
 -- Assumes each taxon has at most one parent, and at most one associated taxon.
 
--- https://stackoverflow.com/a/55778635
-CREATE TEMP FUNCTION dedup(val ANY TYPE) AS ((
-  SELECT ARRAY_AGG(t)
-  FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
-));
 TRUNCATE TABLE public.taxonomy;
 INSERT INTO public.taxonomy
 WITH RECURSIVE
@@ -154,7 +149,7 @@ SELECT
     [(STRUCT(taxons.edition_id, parentage_tree.level))], -- itself
     association_tree.ancestors -- ancestors of its associated taxon, if any
   ) AS ancestors_via_association, -- includes itself
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY_CONCAT(
       parentage_tree.ancestors,
       association_tree.ancestors

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -89,6 +89,21 @@ resource "google_bigquery_routine" "extract_phone_numbers" {
   }
 }
 
+resource "google_bigquery_routine" "dedup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "dedup"
+  routine_type = "SCALAR_FUNCTION"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/dedup.sql",
+    { project_id = var.project_id }
+  )
+  arguments {
+    name          = "val"
+    argument_kind = "ANY_TYPE"
+  }
+}
+
 resource "google_bigquery_routine" "publishing_api_editions_current" {
   dataset_id      = google_bigquery_dataset.functions.dataset_id
   routine_id      = "publishing_api_editions_current"
@@ -125,11 +140,14 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
 }
 
 resource "google_bigquery_routine" "taxonomy" {
-  dataset_id      = google_bigquery_dataset.functions.dataset_id
-  routine_id      = "taxonomy"
-  routine_type    = "PROCEDURE"
-  language        = "SQL"
-  definition_body = file("bigquery/taxonomy.sql")
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "taxonomy"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/taxonomy.sql",
+    { project_id = var.project_id }
+  )
 }
 
 resource "google_bigquery_routine" "contact_phone_numbers" {

--- a/terraform/bigquery/dedup.sql
+++ b/terraform/bigquery/dedup.sql
@@ -1,0 +1,14 @@
+-- Uncomment at the top and bottom of this file to manually define the function
+-- outside of terraform.
+
+-- A function like DISTINCT but works on an array of any type, including STRUCT
+-- https://stackoverflow.com/a/55778635
+
+-- CREATE FUNCTION
+--   functions.dedup(val ANY TYPE)
+--   AS (
+  (
+    SELECT ARRAY_AGG(t)
+    FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
+  )
+-- );

--- a/terraform/bigquery/extract-content-from-editions.sql
+++ b/terraform/bigquery/extract-content-from-editions.sql
@@ -37,13 +37,6 @@ CREATE TEMP FUNCTION markup_from_json_array(array_of_json JSON) AS ((
     )
 ));
 
--- A function like DISTINCT but works on an array of any type, including STRUCT
--- https://stackoverflow.com/a/55778635
-CREATE TEMP FUNCTION dedup(val ANY TYPE) AS ((
-  SELECT ARRAY_AGG(t)
-  FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
-));
-
 TRUNCATE TABLE public.content_new;
 INSERT INTO public.content_new
 -- schema_map ought to be a table, but it would take a lot of configuration.  If
@@ -316,7 +309,7 @@ SELECT
       )
     FROM UNNEST(SPLIT(text, "\n")) AS line WITH OFFSET AS line_number
   ) AS lines,
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY(
       SELECT
         STRUCT(
@@ -327,7 +320,7 @@ SELECT
       FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.hyperlinks")) AS link
     )
   ) AS hyperlinks,
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY(
       SELECT
         STRUCT(

--- a/terraform/bigquery/taxonomy.sql
+++ b/terraform/bigquery/taxonomy.sql
@@ -4,11 +4,6 @@
 -- Top-level taxons are included.
 -- Assumes each taxon has at most one parent, and at most one associated taxon.
 
--- https://stackoverflow.com/a/55778635
-CREATE TEMP FUNCTION dedup(val ANY TYPE) AS ((
-  SELECT ARRAY_AGG(t)
-  FROM (SELECT DISTINCT * FROM UNNEST(val) v) t
-));
 TRUNCATE TABLE public.taxonomy;
 INSERT INTO public.taxonomy
 WITH RECURSIVE
@@ -154,7 +149,7 @@ SELECT
     [(STRUCT(taxons.edition_id, parentage_tree.level))], -- itself
     association_tree.ancestors -- ancestors of its associated taxon, if any
   ) AS ancestors_via_association, -- includes itself
-  dedup(
+  `${project_id}.functions.dedup`(
     ARRAY_CONCAT(
       parentage_tree.ancestors,
       association_tree.ancestors


### PR DESCRIPTION
Otherwise we run into trouble defining it multiple times in different
queries that are called in the same batch.
