### PR TITLE
fix: duplicates in search.page

### DIFF
--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -137,6 +137,11 @@ pages AS (
     "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
   FROM editions
   LEFT JOIN public.content ON content.edition_id = editions.id
+  -- Exclude pages that duplicate the first part of a multipart document.
+  -- Equivalent statements are:
+  -- `content.part_index IS NULL OR content.part_index > 1`
+  -- `(NOT content.is_part) OR content.part_index > 1`
+  WHERE content.is_part OR (content.part_index IS NULL)
 )
 SELECT
   pages.url,

--- a/terraform-dev/schemas/public/content.json
+++ b/terraform-dev/schemas/public/content.json
@@ -17,7 +17,8 @@
   {
     "mode": "NULLABLE",
     "name": "base_path",
-    "type": "STRING"
+    "type": "STRING",
+    "description": "Includes the part_slug if is_part=TRUE"
   },
   {
     "mode": "NULLABLE",
@@ -27,7 +28,8 @@
   {
     "mode": "REQUIRED",
     "name": "is_part",
-    "type": "BOOLEAN"
+    "type": "BOOLEAN",
+    "description": "The first part of a multipage document has two records. One record is_part=TRUE and once with is_part = FALSE. This represents the fact that the first part can be reached from a URL with or without the part_slug."
   },
   {
     "mode": "NULLABLE",

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -137,6 +137,11 @@ pages AS (
     "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
   FROM editions
   LEFT JOIN public.content ON content.edition_id = editions.id
+  -- Exclude pages that duplicate the first part of a multipart document.
+  -- Equivalent statements are:
+  -- `content.part_index IS NULL OR content.part_index > 1`
+  -- `(NOT content.is_part) OR content.part_index > 1`
+  WHERE content.is_part OR (content.part_index IS NULL)
 )
 SELECT
   pages.url,

--- a/terraform-staging/schemas/public/content.json
+++ b/terraform-staging/schemas/public/content.json
@@ -17,7 +17,8 @@
   {
     "mode": "NULLABLE",
     "name": "base_path",
-    "type": "STRING"
+    "type": "STRING",
+    "description": "Includes the part_slug if is_part=TRUE"
   },
   {
     "mode": "NULLABLE",
@@ -27,7 +28,8 @@
   {
     "mode": "REQUIRED",
     "name": "is_part",
-    "type": "BOOLEAN"
+    "type": "BOOLEAN",
+    "description": "The first part of a multipage document has two records. One record is_part=TRUE and once with is_part = FALSE. This represents the fact that the first part can be reached from a URL with or without the part_slug."
   },
   {
     "mode": "NULLABLE",

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -137,6 +137,11 @@ pages AS (
     "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
   FROM editions
   LEFT JOIN public.content ON content.edition_id = editions.id
+  -- Exclude pages that duplicate the first part of a multipart document.
+  -- Equivalent statements are:
+  -- `content.part_index IS NULL OR content.part_index > 1`
+  -- `(NOT content.is_part) OR content.part_index > 1`
+  WHERE content.is_part OR (content.part_index IS NULL)
 )
 SELECT
   pages.url,

--- a/terraform/schemas/public/content.json
+++ b/terraform/schemas/public/content.json
@@ -17,7 +17,8 @@
   {
     "mode": "NULLABLE",
     "name": "base_path",
-    "type": "STRING"
+    "type": "STRING",
+    "description": "Includes the part_slug if is_part=TRUE"
   },
   {
     "mode": "NULLABLE",
@@ -27,7 +28,8 @@
   {
     "mode": "REQUIRED",
     "name": "is_part",
-    "type": "BOOLEAN"
+    "type": "BOOLEAN",
+    "description": "The first part of a multipage document has two records. One record is_part=TRUE and once with is_part = FALSE. This represents the fact that the first part can be reached from a URL with or without the part_slug."
   },
   {
     "mode": "NULLABLE",


### PR DESCRIPTION
Caused by a faulty join against parts of multipart pages.
