### PR TITLE
refactor: permissions via Google Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ People are granted access by membership of Google Groups.  Other Google Cloud Pl
 
 ### Google Groups
 
-* [govsearch-data-viewers][govsearch-data-viewers] has `roles/bigquery.dataViewer` in relation to each BigQuery dataset, and `roles/bigquery.jobUser` to be able to run queries that are billed to the billing account of the `govuk-knowledge-graph*` projects.
-* [govsearch-developers][govsearch-developers] has the `roles/owner` role in relation to each `govuk-knowledge-graph*` project.
+* [govgraph-private-data-viewers](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govsearch-data-viewers/about) has `roles/bigquery.dataViewer` in relation to each BigQuery dataset except 'test', and `roles/bigquery.jobUser` to be able to run queries that are billed to the billing account of the `govuk-knowledge-graph*` projects.
+* [govgraph-developers](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govsearch-developers/members) has the `roles/owner` role in relation to each `govuk-knowledge-graph*` project.
 
 ## Tests
 

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -80,11 +80,11 @@ resource "google_bigquery_data_transfer_config" "check_tables_metadata" {
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
 
-resource "google_monitoring_notification_channel" "govsearch_developers" {
-  display_name = "GovSearch Developers"
+resource "google_monitoring_notification_channel" "govgraph_developers" {
+  display_name = "GovGraph Developers"
   type         = "email"
   labels = {
-    email_address = "govsearch-developers@digital.cabinet-office.gov.uk"
+    email_address = "govgraph-developers@digital.cabinet-office.gov.uk"
   }
 }
 
@@ -98,7 +98,7 @@ resource "google_monitoring_alert_policy" "tables_metadata" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.govsearch_developers.name]
+  notification_channels = [google_monitoring_notification_channel.govgraph_developers.name]
   alert_strategy {
     notification_rate_limit {
       // One day

--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -25,7 +25,7 @@ enable_redis_session_store_instance = true
 # should be the same in every environment.
 
 project_owner_members = [
-  "group:govsearch-developers@digital.cabinet-office.gov.uk",
+  "group:govgraph-developers@digital.cabinet-office.gov.uk",
 ]
 
 iap_govgraphsearch_members = [

--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -31,7 +31,7 @@ resource "google_service_account_iam_policy" "govgraphsearch" {
 resource "google_iap_brand" "project_brand" {
   # The support_email must be your own email address, or a Google Group that you
   # manage.
-  support_email     = "govsearch-developers@digital.cabinet-office.gov.uk"
+  support_email     = "govgraph-developers@digital.cabinet-office.gov.uk"
   application_title = var.application_title
 }
 

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -80,11 +80,11 @@ resource "google_bigquery_data_transfer_config" "check_tables_metadata" {
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
 
-resource "google_monitoring_notification_channel" "govsearch_developers" {
-  display_name = "GovSearch Developers"
+resource "google_monitoring_notification_channel" "govgraph_developers" {
+  display_name = "GovGraph Developers"
   type         = "email"
   labels = {
-    email_address = "govsearch-developers@digital.cabinet-office.gov.uk"
+    email_address = "govgraph-developers@digital.cabinet-office.gov.uk"
   }
 }
 
@@ -98,7 +98,7 @@ resource "google_monitoring_alert_policy" "tables_metadata" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.govsearch_developers.name]
+  notification_channels = [google_monitoring_notification_channel.govgraph_developers.name]
   alert_strategy {
     notification_rate_limit {
       // One day

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -25,11 +25,11 @@ gtm_id                              = "PLACEHOLDER"
 # should be the same in every environment.
 
 project_owner_members = [
-  "group:govsearch-developers@digital.cabinet-office.gov.uk",
+  "group:govgraph-developers@digital.cabinet-office.gov.uk",
 ]
 
 iap_govgraphsearch_members = [
-  "group:govsearch-developers@digital.cabinet-office.gov.uk",
+  "group:govgraph-developers@digital.cabinet-office.gov.uk",
   "user:govsearchtest@gmail.com",
   "user:govsearchtestdac@gmail.com",
 ]

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -31,7 +31,7 @@ resource "google_service_account_iam_policy" "govgraphsearch" {
 resource "google_iap_brand" "project_brand" {
   # The support_email must be your own email address, or a Google Group that you
   # manage.
-  support_email     = "govsearch-developers@digital.cabinet-office.gov.uk"
+  support_email     = "govgraph-developers@digital.cabinet-office.gov.uk"
   application_title = var.application_title
 }
 

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -80,11 +80,11 @@ resource "google_bigquery_data_transfer_config" "check_tables_metadata" {
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
 
-resource "google_monitoring_notification_channel" "govsearch_developers" {
-  display_name = "GovSearch Developers"
+resource "google_monitoring_notification_channel" "govgraph_developers" {
+  display_name = "GovGraph Developers"
   type         = "email"
   labels = {
-    email_address = "govsearch-developers@digital.cabinet-office.gov.uk"
+    email_address = "govgraph-developers@digital.cabinet-office.gov.uk"
   }
 }
 
@@ -98,7 +98,7 @@ resource "google_monitoring_alert_policy" "tables_metadata" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.govsearch_developers.name]
+  notification_channels = [google_monitoring_notification_channel.govgraph_developers.name]
   alert_strategy {
     notification_rate_limit {
       // One day

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -25,7 +25,7 @@ gtm_auth                            = "aWEg5ABBTyIPcsSg1cJWxg"
 # should be the same in every environment.
 
 project_owner_members = [
-  "group:govsearch-developers@digital.cabinet-office.gov.uk",
+  "group:govgraph-developers@digital.cabinet-office.gov.uk",
 ]
 
 iap_govgraphsearch_members = [
@@ -33,25 +33,25 @@ iap_govgraphsearch_members = [
 ]
 
 bigquery_job_user_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk"
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
 ]
 
 # Bucket: {project_id}-data-processed
 storage_data_processed_object_viewer_members = [
-  "group:data-engineering@digital.cabinet-office.gov.uk",
-  "group:data-products@digital.cabinet-office.gov.uk",
 ]
 
 # BigQuery dataset: private
 bigquery_private_data_viewer_members = [
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
 ]
 
 # BigQuery dataset: public
 bigquery_public_data_viewer_members = [
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
 ]
 
 bigquery_content_data_viewer_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
   "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
   "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
   "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
@@ -60,17 +60,17 @@ bigquery_content_data_viewer_members = [
 
 # BigQuery dataset: publisher
 bigquery_publisher_data_viewer_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
 ]
 
 # BigQuery dataset: functions
 bigquery_functions_data_viewer_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
 ]
 
 # BigQuery dataset: graph
 bigquery_graph_data_viewer_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
   "serviceAccount:ner-bulk-inference@cpto-content-metadata.iam.gserviceaccount.com",
   "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
   "serviceAccount:wif-ner-new-content-inference@cpto-content-metadata.iam.gserviceaccount.com",
@@ -79,13 +79,13 @@ bigquery_graph_data_viewer_members = [
 
 # BigQuery dataset: publishing
 bigquery_publishing_api_data_viewer_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
   "serviceAccount:service-419945323196@gcp-sa-dataform.iam.gserviceaccount.com",
 ]
 
 # BigQuery dataset: search
 bigquery_search_data_viewer_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
   "serviceAccount:service-419945323196@gcp-sa-dataform.iam.gserviceaccount.com",
   "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
   "serviceAccount:wif-vectorstore@govuk-llm-question-answering.iam.gserviceaccount.com",
@@ -93,5 +93,4 @@ bigquery_search_data_viewer_members = [
 
 # BigQuery dataset: test
 bigquery_test_data_viewer_members = [
-  "group:govsearch-data-viewers@digital.cabinet-office.gov.uk",
 ]

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -31,7 +31,7 @@ resource "google_service_account_iam_policy" "govgraphsearch" {
 resource "google_iap_brand" "project_brand" {
   # The support_email must be your own email address, or a Google Group that you
   # manage.
-  support_email     = "govsearch-developers@digital.cabinet-office.gov.uk"
+  support_email     = "govgraph-developers@digital.cabinet-office.gov.uk"
   application_title = var.application_title
 }
 


### PR DESCRIPTION
New groups:

* `govgraph-developers` replaces `govsearch-developers` as project
  owners in GCP.
* `govgraph-private-data-viewers` gives read-only access to all BigQuery
  datasets other than 'test', and also permission to run queries within
  the projects, with the projects paying the bill.

Old groups:

* `govsearch-developers` will be deleted.
* `govsearch-data-viewers` will be deleted.
