### PR TITLE
refactor: derive legacy graph and content dataset tables from new data

### DIFF
--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -668,6 +668,14 @@ resource "google_bigquery_routine" "content_lines" {
   definition_body = file("bigquery/content-lines.sql")
 }
 
+resource "google_bigquery_routine" "content_title" {
+  dataset_id      = google_bigquery_dataset.content.dataset_id
+  routine_id      = "title"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/content-title.sql")
+}
+
 resource "google_bigquery_data_transfer_config" "content_batch" {
   data_source_id = "scheduled_query" # This is a magic word
   display_name   = "content batch"

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -660,6 +660,14 @@ resource "google_bigquery_table" "phone_number" {
 
 # Refresh legacy tables from data in the 'public' dataset.
 
+resource "google_bigquery_routine" "content_content" {
+  dataset_id      = google_bigquery_dataset.content.dataset_id
+  routine_id      = "content"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/content-content.sql")
+}
+
 resource "google_bigquery_routine" "content_description" {
   dataset_id      = google_bigquery_dataset.content.dataset_id
   routine_id      = "description"

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -676,6 +676,14 @@ resource "google_bigquery_routine" "content_description" {
   definition_body = file("bigquery/content-description.sql")
 }
 
+resource "google_bigquery_routine" "content_expanded_links" {
+  dataset_id      = google_bigquery_dataset.content.dataset_id
+  routine_id      = "expanded_links"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/content-expanded-links.sql")
+}
+
 resource "google_bigquery_routine" "content_lines" {
   dataset_id      = google_bigquery_dataset.content.dataset_id
   routine_id      = "lines"

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -660,6 +660,14 @@ resource "google_bigquery_table" "phone_number" {
 
 # Refresh legacy tables from data in the 'public' dataset.
 
+resource "google_bigquery_routine" "content_description" {
+  dataset_id      = google_bigquery_dataset.content.dataset_id
+  routine_id      = "description"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/content-description.sql")
+}
+
 resource "google_bigquery_routine" "content_lines" {
   dataset_id      = google_bigquery_dataset.content.dataset_id
   routine_id      = "lines"

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -16,6 +16,7 @@ data "google_iam_policy" "bigquery_dataset_content" {
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_content.member,
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -655,4 +656,25 @@ resource "google_bigquery_table" "phone_number" {
   friendly_name = "Phone number"
   description   = "Phone numbers. One row per number, per page that it appears on. These are phone numbers that are part of 'contact' documents."
   schema        = file("schemas/content/phone_number.json")
+}
+
+# Refresh legacy tables from data in the 'public' dataset.
+
+resource "google_bigquery_routine" "content_lines" {
+  dataset_id      = google_bigquery_dataset.content.dataset_id
+  routine_id      = "lines"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/content-lines.sql")
+}
+
+resource "google_bigquery_data_transfer_config" "content_batch" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "content batch"
+  location       = var.region
+  schedule       = "every day 07:00"
+  params = {
+    query = file("bigquery/content-batch.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
 }

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -15,7 +15,6 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "projectWriters",
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
-      google_service_account.bigquery_scheduled_queries_search.member,
       google_service_account.bigquery_scheduled_queries.member,
     ]
   }

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -195,6 +195,14 @@ resource "google_bigquery_table" "graph_phone_number" {
 }
 
 # Refresh legacy tables from data in the 'public' dataset.
+resource "google_bigquery_routine" "graph_is_tagged_to" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "is_tagged_to"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-is-tagged-to.sql")
+}
+
 resource "google_bigquery_routine" "graph_page" {
   dataset_id      = google_bigquery_dataset.graph.dataset_id
   routine_id      = "page"

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -203,6 +203,14 @@ resource "google_bigquery_routine" "graph_page" {
   definition_body = file("bigquery/graph-page.sql")
 }
 
+resource "google_bigquery_routine" "graph_taxon" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "taxon"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-taxon.sql")
+}
+
 resource "google_bigquery_data_transfer_config" "graph_batch" {
   data_source_id = "scheduled_query" # This is a magic word
   display_name   = "Graph batch"

--- a/terraform-dev/bigquery/content-batch.sql
+++ b/terraform-dev/bigquery/content-batch.sql
@@ -1,5 +1,6 @@
 -- Call a sequence of routines that refresh tables in the legacy `content`
 -- dataset.
 
+CALL content.description();
 CALL content.lines();
 CALL content.title();

--- a/terraform-dev/bigquery/content-batch.sql
+++ b/terraform-dev/bigquery/content-batch.sql
@@ -1,0 +1,4 @@
+-- Call a sequence of routines that refresh tables in the legacy `content`
+-- dataset.
+
+CALL content.lines();

--- a/terraform-dev/bigquery/content-batch.sql
+++ b/terraform-dev/bigquery/content-batch.sql
@@ -2,3 +2,4 @@
 -- dataset.
 
 CALL content.lines();
+CALL content.title();

--- a/terraform-dev/bigquery/content-batch.sql
+++ b/terraform-dev/bigquery/content-batch.sql
@@ -1,6 +1,7 @@
 -- Call a sequence of routines that refresh tables in the legacy `content`
 -- dataset.
 
+CALL content.content();
 CALL content.description();
 CALL content.lines();
 CALL content.title();

--- a/terraform-dev/bigquery/content-batch.sql
+++ b/terraform-dev/bigquery/content-batch.sql
@@ -3,5 +3,6 @@
 
 CALL content.content();
 CALL content.description();
+CALL content.expanded_links();
 CALL content.lines();
 CALL content.title();

--- a/terraform-dev/bigquery/content-content.sql
+++ b/terraform-dev/bigquery/content-content.sql
@@ -1,0 +1,17 @@
+-- Recreate the legacy content.content table from the 'public' dataset
+
+TRUNCATE TABLE content.content;
+INSERT INTO content.content
+SELECT
+  "https://www.gov.uk" || COALESCE(content.base_path, "/" || editions.content_id) AS url,
+  html,
+  text,
+  ARRAY_TO_STRING(ARRAY_AGG(line.line), "\n") AS text_without_blank_lines
+FROM public.content
+INNER JOIN public.publishing_api_editions_current AS editions ON editions.id = content.edition_id
+CROSS JOIN unnest(lines) AS line
+WHERE TRIM(line.line) <> ""
+GROUP BY
+  url,
+  html,
+  text

--- a/terraform-dev/bigquery/content-description.sql
+++ b/terraform-dev/bigquery/content-description.sql
@@ -1,0 +1,12 @@
+-- Recreate the legacy content.description table from the 'public' dataset
+
+TRUNCATE TABLE content.description;
+INSERT INTO content.description
+SELECT
+  "https://www.gov.uk" || COALESCE(base_path) AS url,
+  description
+FROM public.publishing_api_editions_current
+WHERE base_path IS NOT NULL
+AND description IS NOT NULL
+AND description <> ""
+;

--- a/terraform-dev/bigquery/content-expanded-links.sql
+++ b/terraform-dev/bigquery/content-expanded-links.sql
@@ -1,0 +1,30 @@
+-- Recreate the legacy content.expanded_links table from the 'public' dataset
+--
+-- This isn't even nearly the same, because the Content API names and structures
+-- several types of links differently.
+--
+-- The only known dependency of the original content.expanded_links table only
+-- uses the 'parent' link type, which is faithfully reproduced here.
+--
+-- One type that doesn't exist in the Publishing API is 'children', which seems
+-- to be derived as the inverse of 'parent.  Another is 'policy_areas', which is
+-- only used by the Email API, and perhaps is defined there.
+
+TRUNCATE TABLE content.expanded_links;
+INSERT INTO content.expanded_links
+WITH
+  editions AS (
+    SELECT *
+    FROM public.publishing_api_editions_current AS editions
+  )
+SELECT
+  links.type AS link_type,
+  "https://www.gov.uk" || sources.base_path as from_url,
+  "https://www.gov.uk" || targets.base_path as to_url
+FROM
+  public.publishing_api_links_current AS links
+INNER JOIN editions AS sources ON sources.id = links.source_edition_id
+INNER JOIN editions AS targets ON targets.id = links.target_edition_id
+WHERE TRUE
+  AND sources.base_path IS NOT NULL
+  AND targets.base_path IS NOT NULL

--- a/terraform-dev/bigquery/content-lines.sql
+++ b/terraform-dev/bigquery/content-lines.sql
@@ -1,0 +1,12 @@
+-- Recreate the legacy content.lines table from the 'public' dataset
+
+TRUNCATE TABLE content.lines;
+INSERT INTO content.lines
+SELECT
+  "https://www.gov.uk" || COALESCE(content.base_path, "/" || editions.content_id) AS url,
+  line.line_number,
+  line.line
+FROM public.content
+CROSS JOIN UNNEST(lines) AS line
+INNER JOIN public.publishing_api_editions_current AS editions ON editions.id = content.edition_id
+;

--- a/terraform-dev/bigquery/content-title.sql
+++ b/terraform-dev/bigquery/content-title.sql
@@ -1,0 +1,11 @@
+-- Recreate the legacy content.title table from the 'public' dataset
+
+TRUNCATE TABLE content.title;
+INSERT INTO content.title
+SELECT
+  "https://www.gov.uk" || COALESCE(base_path) AS url,
+  title
+FROM public.publishing_api_editions_current
+WHERE base_path IS NOT NULL
+AND title IS NOT NULL
+;

--- a/terraform-dev/bigquery/graph-batch.sql
+++ b/terraform-dev/bigquery/graph-batch.sql
@@ -1,5 +1,6 @@
 -- Call a sequence of routines that refresh tables in the legacy `graph`
 -- dataset.
 
+CALL graph.is_tagged_to();
 CALL graph.page();
 CALL graph.taxon();

--- a/terraform-dev/bigquery/graph-batch.sql
+++ b/terraform-dev/bigquery/graph-batch.sql
@@ -2,3 +2,4 @@
 -- dataset.
 
 CALL graph.page();
+CALL graph.taxon();

--- a/terraform-dev/bigquery/graph-batch.sql
+++ b/terraform-dev/bigquery/graph-batch.sql
@@ -1,0 +1,4 @@
+-- Call a sequence of routines that refresh tables in the legacy `graph`
+-- dataset.
+
+CALL graph.page();

--- a/terraform-dev/bigquery/graph-is-tagged-to.sql
+++ b/terraform-dev/bigquery/graph-is-tagged-to.sql
@@ -1,0 +1,13 @@
+-- Recreate the legacy graph.is_tagged_to table from the 'public' dataset
+
+TRUNCATE TABLE graph.is_tagged_to;
+INSERT INTO graph.is_tagged_to
+SELECT
+  "https://www.gov.uk/" || sources.content_id AS url,
+  "https://www.gov.uk/" || targets.content_id AS taxon_url
+FROM public.taxonomy
+INNER JOIN public.publishing_api_links_current AS links ON (links.target_edition_id = taxonomy.edition_id)
+INNER JOIN public.publishing_api_editions_current AS sources ON (sources.id = links.source_edition_id)
+INNER JOIN public.publishing_api_editions_current AS targets ON (targets.id = links.target_edition_id)
+WHERE links.type = 'taxons'
+;

--- a/terraform-dev/bigquery/graph-page.sql
+++ b/terraform-dev/bigquery/graph-page.sql
@@ -1,0 +1,65 @@
+-- Recreate the legacy graph.page table from the 'public' dataset
+--
+-- Differences:
+--
+-- * The legacy table included URLs derived from content that don't really exist
+--   and that can be omitted with `schema_name is not null`
+-- * The legacy table included redirects from the Content API that don't join to
+--   current editions from the Publishing API, but do exist on the web. The
+--   redirected URLs aren't discoverable, so we exclude them from the 'public'
+--   dataset, so they are omitted here.  A disadvantage is that it won't be
+--   possible to 'follow' some redirects without checking them with a GET
+--   request.
+
+TRUNCATE TABLE graph.page;
+INSERT INTO graph.page
+WITH
+  editions AS (
+    SELECT editions.*
+    FROM public.publishing_api_editions_current AS editions
+    WHERE editions.base_path IS NOT NULL
+  ),
+  withdrawals AS (
+    SELECT
+      edition_id,
+      unpublished_at AS withdrawn_at,
+      explanation AS withdrawn_explanation
+    FROM public.publishing_api_unpublishings_current
+    WHERE type = 'withdrawal'
+),
+pages AS (
+  SELECT
+    editions.id AS edition_id,
+    COALESCE(content.base_path, editions.base_path) AS base_path,
+    "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
+  FROM editions
+  LEFT JOIN public.content ON content.edition_id = editions.id
+)
+SELECT
+  pages.url,
+  editions.document_type,
+  editions.schema_name,
+  editions.phase,
+  editions.content_id,
+  editions.analytics_identifier,
+  JSON_value(editions.details, "$.acronym") AS acronym,
+  editions.locale,
+  editions.publishing_app,
+  editions.updated_at,
+  editions.first_published_at,
+  editions.public_updated_at,
+  withdrawals.withdrawn_at,
+  withdrawals.withdrawn_explanation,
+  editions.title,
+  JSON_value(editions.details, "$.internal_name") AS internal_name,
+  editions.description,
+  JSON_value(editions.details, "$.department_analytics_profile") AS department_analytics_profile,
+  content.text,
+  content.part_index,
+  content.part_slug AS slug
+FROM pages
+INNER JOIN editions ON editions.id = pages.edition_id -- one row per document
+LEFT JOIN withdrawals ON withdrawals.edition_id = pages.edition_id
+LEFT JOIN public.content -- one row per document or part
+  ON content.base_path = pages.base_path -- includes the slug of parts
+;

--- a/terraform-dev/bigquery/graph-taxon.sql
+++ b/terraform-dev/bigquery/graph-taxon.sql
@@ -1,0 +1,18 @@
+-- Recreate the legacy graph.page table from the 'public' dataset
+
+TRUNCATE TABLE graph.taxon;
+INSERT INTO graph.taxon
+SELECT
+  'https://www.gov.uk/' || editions.content_id AS url,
+  editions.title,
+  JSON_VALUE(editions.details, "$.internal_name") AS internal_name,
+  editions.description,
+  editions.content_id,
+  taxonomy.level
+FROM
+  public.taxonomy
+INNER JOIN
+  public.publishing_api_editions_current AS editions
+ON
+  editions.id = taxonomy.edition_id
+;

--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -90,6 +90,7 @@ all_links AS (
   FROM
     public.publishing_api_links_current AS links
   INNER JOIN editions ON editions.id = links.source_edition_id
+  WHERE editions.base_path IS NOT NULL
   UNION ALL
   SELECT
     "embedded" as link_type,
@@ -137,11 +138,13 @@ pages AS (
     "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
   FROM editions
   LEFT JOIN public.content ON content.edition_id = editions.id
+  WHERE TRUE
+  AND editions.base_path IS NOT NULL
   -- Exclude pages that duplicate the first part of a multipart document.
   -- Equivalent statements are:
   -- `content.part_index IS NULL OR content.part_index > 1`
   -- `(NOT content.is_part) OR content.part_index > 1`
-  WHERE content.is_part OR (content.part_index IS NULL)
+  AND content.is_part OR (content.part_index IS NULL)
 )
 SELECT
   pages.url,

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -15,7 +15,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "projectWriters",
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
-      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -191,4 +191,40 @@ resource "google_bigquery_table" "graph_phone_number" {
   friendly_name = "Phone number"
   description   = "Phone numbers from 'contact' documents or detected in page content by GovNER and libphonenumber"
   schema        = file("schemas/graph/phone-number.json")
+}
+
+# Refresh legacy tables from data in the 'public' dataset.
+resource "google_bigquery_routine" "graph_is_tagged_to" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "is_tagged_to"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-is-tagged-to.sql")
+}
+
+resource "google_bigquery_routine" "graph_page" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "page"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-page.sql")
+}
+
+resource "google_bigquery_routine" "graph_taxon" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "taxon"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-taxon.sql")
+}
+
+resource "google_bigquery_data_transfer_config" "graph_batch" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Graph batch"
+  location       = var.region
+  schedule       = "every day 07:00"
+  params = {
+    query = file("bigquery/graph-batch.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
 }

--- a/terraform-staging/bigquery/content-batch.sql
+++ b/terraform-staging/bigquery/content-batch.sql
@@ -1,0 +1,8 @@
+-- Call a sequence of routines that refresh tables in the legacy `content`
+-- dataset.
+
+CALL content.content();
+CALL content.description();
+CALL content.expanded_links();
+CALL content.lines();
+CALL content.title();

--- a/terraform-staging/bigquery/content-content.sql
+++ b/terraform-staging/bigquery/content-content.sql
@@ -1,0 +1,17 @@
+-- Recreate the legacy content.content table from the 'public' dataset
+
+TRUNCATE TABLE content.content;
+INSERT INTO content.content
+SELECT
+  "https://www.gov.uk" || COALESCE(content.base_path, "/" || editions.content_id) AS url,
+  html,
+  text,
+  ARRAY_TO_STRING(ARRAY_AGG(line.line), "\n") AS text_without_blank_lines
+FROM public.content
+INNER JOIN public.publishing_api_editions_current AS editions ON editions.id = content.edition_id
+CROSS JOIN unnest(lines) AS line
+WHERE TRIM(line.line) <> ""
+GROUP BY
+  url,
+  html,
+  text

--- a/terraform-staging/bigquery/content-description.sql
+++ b/terraform-staging/bigquery/content-description.sql
@@ -1,0 +1,12 @@
+-- Recreate the legacy content.description table from the 'public' dataset
+
+TRUNCATE TABLE content.description;
+INSERT INTO content.description
+SELECT
+  "https://www.gov.uk" || COALESCE(base_path) AS url,
+  description
+FROM public.publishing_api_editions_current
+WHERE base_path IS NOT NULL
+AND description IS NOT NULL
+AND description <> ""
+;

--- a/terraform-staging/bigquery/content-expanded-links.sql
+++ b/terraform-staging/bigquery/content-expanded-links.sql
@@ -1,0 +1,30 @@
+-- Recreate the legacy content.expanded_links table from the 'public' dataset
+--
+-- This isn't even nearly the same, because the Content API names and structures
+-- several types of links differently.
+--
+-- The only known dependency of the original content.expanded_links table only
+-- uses the 'parent' link type, which is faithfully reproduced here.
+--
+-- One type that doesn't exist in the Publishing API is 'children', which seems
+-- to be derived as the inverse of 'parent.  Another is 'policy_areas', which is
+-- only used by the Email API, and perhaps is defined there.
+
+TRUNCATE TABLE content.expanded_links;
+INSERT INTO content.expanded_links
+WITH
+  editions AS (
+    SELECT *
+    FROM public.publishing_api_editions_current AS editions
+  )
+SELECT
+  links.type AS link_type,
+  "https://www.gov.uk" || sources.base_path as from_url,
+  "https://www.gov.uk" || targets.base_path as to_url
+FROM
+  public.publishing_api_links_current AS links
+INNER JOIN editions AS sources ON sources.id = links.source_edition_id
+INNER JOIN editions AS targets ON targets.id = links.target_edition_id
+WHERE TRUE
+  AND sources.base_path IS NOT NULL
+  AND targets.base_path IS NOT NULL

--- a/terraform-staging/bigquery/content-lines.sql
+++ b/terraform-staging/bigquery/content-lines.sql
@@ -1,0 +1,12 @@
+-- Recreate the legacy content.lines table from the 'public' dataset
+
+TRUNCATE TABLE content.lines;
+INSERT INTO content.lines
+SELECT
+  "https://www.gov.uk" || COALESCE(content.base_path, "/" || editions.content_id) AS url,
+  line.line_number,
+  line.line
+FROM public.content
+CROSS JOIN UNNEST(lines) AS line
+INNER JOIN public.publishing_api_editions_current AS editions ON editions.id = content.edition_id
+;

--- a/terraform-staging/bigquery/content-title.sql
+++ b/terraform-staging/bigquery/content-title.sql
@@ -1,0 +1,11 @@
+-- Recreate the legacy content.title table from the 'public' dataset
+
+TRUNCATE TABLE content.title;
+INSERT INTO content.title
+SELECT
+  "https://www.gov.uk" || COALESCE(base_path) AS url,
+  title
+FROM public.publishing_api_editions_current
+WHERE base_path IS NOT NULL
+AND title IS NOT NULL
+;

--- a/terraform-staging/bigquery/graph-batch.sql
+++ b/terraform-staging/bigquery/graph-batch.sql
@@ -1,0 +1,6 @@
+-- Call a sequence of routines that refresh tables in the legacy `graph`
+-- dataset.
+
+CALL graph.is_tagged_to();
+CALL graph.page();
+CALL graph.taxon();

--- a/terraform-staging/bigquery/graph-is-tagged-to.sql
+++ b/terraform-staging/bigquery/graph-is-tagged-to.sql
@@ -1,0 +1,13 @@
+-- Recreate the legacy graph.is_tagged_to table from the 'public' dataset
+
+TRUNCATE TABLE graph.is_tagged_to;
+INSERT INTO graph.is_tagged_to
+SELECT
+  "https://www.gov.uk/" || sources.content_id AS url,
+  "https://www.gov.uk/" || targets.content_id AS taxon_url
+FROM public.taxonomy
+INNER JOIN public.publishing_api_links_current AS links ON (links.target_edition_id = taxonomy.edition_id)
+INNER JOIN public.publishing_api_editions_current AS sources ON (sources.id = links.source_edition_id)
+INNER JOIN public.publishing_api_editions_current AS targets ON (targets.id = links.target_edition_id)
+WHERE links.type = 'taxons'
+;

--- a/terraform-staging/bigquery/graph-page.sql
+++ b/terraform-staging/bigquery/graph-page.sql
@@ -1,0 +1,65 @@
+-- Recreate the legacy graph.page table from the 'public' dataset
+--
+-- Differences:
+--
+-- * The legacy table included URLs derived from content that don't really exist
+--   and that can be omitted with `schema_name is not null`
+-- * The legacy table included redirects from the Content API that don't join to
+--   current editions from the Publishing API, but do exist on the web. The
+--   redirected URLs aren't discoverable, so we exclude them from the 'public'
+--   dataset, so they are omitted here.  A disadvantage is that it won't be
+--   possible to 'follow' some redirects without checking them with a GET
+--   request.
+
+TRUNCATE TABLE graph.page;
+INSERT INTO graph.page
+WITH
+  editions AS (
+    SELECT editions.*
+    FROM public.publishing_api_editions_current AS editions
+    WHERE editions.base_path IS NOT NULL
+  ),
+  withdrawals AS (
+    SELECT
+      edition_id,
+      unpublished_at AS withdrawn_at,
+      explanation AS withdrawn_explanation
+    FROM public.publishing_api_unpublishings_current
+    WHERE type = 'withdrawal'
+),
+pages AS (
+  SELECT
+    editions.id AS edition_id,
+    COALESCE(content.base_path, editions.base_path) AS base_path,
+    "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
+  FROM editions
+  LEFT JOIN public.content ON content.edition_id = editions.id
+)
+SELECT
+  pages.url,
+  editions.document_type,
+  editions.schema_name,
+  editions.phase,
+  editions.content_id,
+  editions.analytics_identifier,
+  JSON_value(editions.details, "$.acronym") AS acronym,
+  editions.locale,
+  editions.publishing_app,
+  editions.updated_at,
+  editions.first_published_at,
+  editions.public_updated_at,
+  withdrawals.withdrawn_at,
+  withdrawals.withdrawn_explanation,
+  editions.title,
+  JSON_value(editions.details, "$.internal_name") AS internal_name,
+  editions.description,
+  JSON_value(editions.details, "$.department_analytics_profile") AS department_analytics_profile,
+  content.text,
+  content.part_index,
+  content.part_slug AS slug
+FROM pages
+INNER JOIN editions ON editions.id = pages.edition_id -- one row per document
+LEFT JOIN withdrawals ON withdrawals.edition_id = pages.edition_id
+LEFT JOIN public.content -- one row per document or part
+  ON content.base_path = pages.base_path -- includes the slug of parts
+;

--- a/terraform-staging/bigquery/graph-taxon.sql
+++ b/terraform-staging/bigquery/graph-taxon.sql
@@ -1,0 +1,18 @@
+-- Recreate the legacy graph.page table from the 'public' dataset
+
+TRUNCATE TABLE graph.taxon;
+INSERT INTO graph.taxon
+SELECT
+  'https://www.gov.uk/' || editions.content_id AS url,
+  editions.title,
+  JSON_VALUE(editions.details, "$.internal_name") AS internal_name,
+  editions.description,
+  editions.content_id,
+  taxonomy.level
+FROM
+  public.taxonomy
+INNER JOIN
+  public.publishing_api_editions_current AS editions
+ON
+  editions.id = taxonomy.edition_id
+;

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -90,6 +90,7 @@ all_links AS (
   FROM
     public.publishing_api_links_current AS links
   INNER JOIN editions ON editions.id = links.source_edition_id
+  WHERE editions.base_path IS NOT NULL
   UNION ALL
   SELECT
     "embedded" as link_type,
@@ -137,11 +138,13 @@ pages AS (
     "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
   FROM editions
   LEFT JOIN public.content ON content.edition_id = editions.id
+  WHERE TRUE
+  AND editions.base_path IS NOT NULL
   -- Exclude pages that duplicate the first part of a multipart document.
   -- Equivalent statements are:
   -- `content.part_index IS NULL OR content.part_index > 1`
   -- `(NOT content.is_part) OR content.part_index > 1`
-  WHERE content.is_part OR (content.part_index IS NULL)
+  AND content.is_part OR (content.part_index IS NULL)
 )
 SELECT
   pages.url,

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -15,7 +15,7 @@ data "google_iam_policy" "bigquery_dataset_graph" {
       "projectWriters",
       google_service_account.gce_mongodb.member,
       google_service_account.gce_publishing_api.member,
-      google_service_account.bigquery_scheduled_queries_search.member,
+      google_service_account.bigquery_scheduled_queries.member,
     ]
   }
   binding {
@@ -191,4 +191,40 @@ resource "google_bigquery_table" "graph_phone_number" {
   friendly_name = "Phone number"
   description   = "Phone numbers from 'contact' documents or detected in page content by GovNER and libphonenumber"
   schema        = file("schemas/graph/phone-number.json")
+}
+
+# Refresh legacy tables from data in the 'public' dataset.
+resource "google_bigquery_routine" "graph_is_tagged_to" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "is_tagged_to"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-is-tagged-to.sql")
+}
+
+resource "google_bigquery_routine" "graph_page" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "page"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-page.sql")
+}
+
+resource "google_bigquery_routine" "graph_taxon" {
+  dataset_id      = google_bigquery_dataset.graph.dataset_id
+  routine_id      = "taxon"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/graph-taxon.sql")
+}
+
+resource "google_bigquery_data_transfer_config" "graph_batch" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Graph batch"
+  location       = var.region
+  schedule       = "every day 07:00"
+  params = {
+    query = file("bigquery/graph-batch.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
 }

--- a/terraform/bigquery/content-batch.sql
+++ b/terraform/bigquery/content-batch.sql
@@ -1,0 +1,8 @@
+-- Call a sequence of routines that refresh tables in the legacy `content`
+-- dataset.
+
+CALL content.content();
+CALL content.description();
+CALL content.expanded_links();
+CALL content.lines();
+CALL content.title();

--- a/terraform/bigquery/content-content.sql
+++ b/terraform/bigquery/content-content.sql
@@ -1,0 +1,17 @@
+-- Recreate the legacy content.content table from the 'public' dataset
+
+TRUNCATE TABLE content.content;
+INSERT INTO content.content
+SELECT
+  "https://www.gov.uk" || COALESCE(content.base_path, "/" || editions.content_id) AS url,
+  html,
+  text,
+  ARRAY_TO_STRING(ARRAY_AGG(line.line), "\n") AS text_without_blank_lines
+FROM public.content
+INNER JOIN public.publishing_api_editions_current AS editions ON editions.id = content.edition_id
+CROSS JOIN unnest(lines) AS line
+WHERE TRIM(line.line) <> ""
+GROUP BY
+  url,
+  html,
+  text

--- a/terraform/bigquery/content-description.sql
+++ b/terraform/bigquery/content-description.sql
@@ -1,0 +1,12 @@
+-- Recreate the legacy content.description table from the 'public' dataset
+
+TRUNCATE TABLE content.description;
+INSERT INTO content.description
+SELECT
+  "https://www.gov.uk" || COALESCE(base_path) AS url,
+  description
+FROM public.publishing_api_editions_current
+WHERE base_path IS NOT NULL
+AND description IS NOT NULL
+AND description <> ""
+;

--- a/terraform/bigquery/content-expanded-links.sql
+++ b/terraform/bigquery/content-expanded-links.sql
@@ -1,0 +1,30 @@
+-- Recreate the legacy content.expanded_links table from the 'public' dataset
+--
+-- This isn't even nearly the same, because the Content API names and structures
+-- several types of links differently.
+--
+-- The only known dependency of the original content.expanded_links table only
+-- uses the 'parent' link type, which is faithfully reproduced here.
+--
+-- One type that doesn't exist in the Publishing API is 'children', which seems
+-- to be derived as the inverse of 'parent.  Another is 'policy_areas', which is
+-- only used by the Email API, and perhaps is defined there.
+
+TRUNCATE TABLE content.expanded_links;
+INSERT INTO content.expanded_links
+WITH
+  editions AS (
+    SELECT *
+    FROM public.publishing_api_editions_current AS editions
+  )
+SELECT
+  links.type AS link_type,
+  "https://www.gov.uk" || sources.base_path as from_url,
+  "https://www.gov.uk" || targets.base_path as to_url
+FROM
+  public.publishing_api_links_current AS links
+INNER JOIN editions AS sources ON sources.id = links.source_edition_id
+INNER JOIN editions AS targets ON targets.id = links.target_edition_id
+WHERE TRUE
+  AND sources.base_path IS NOT NULL
+  AND targets.base_path IS NOT NULL

--- a/terraform/bigquery/content-lines.sql
+++ b/terraform/bigquery/content-lines.sql
@@ -1,0 +1,12 @@
+-- Recreate the legacy content.lines table from the 'public' dataset
+
+TRUNCATE TABLE content.lines;
+INSERT INTO content.lines
+SELECT
+  "https://www.gov.uk" || COALESCE(content.base_path, "/" || editions.content_id) AS url,
+  line.line_number,
+  line.line
+FROM public.content
+CROSS JOIN UNNEST(lines) AS line
+INNER JOIN public.publishing_api_editions_current AS editions ON editions.id = content.edition_id
+;

--- a/terraform/bigquery/content-title.sql
+++ b/terraform/bigquery/content-title.sql
@@ -1,0 +1,11 @@
+-- Recreate the legacy content.title table from the 'public' dataset
+
+TRUNCATE TABLE content.title;
+INSERT INTO content.title
+SELECT
+  "https://www.gov.uk" || COALESCE(base_path) AS url,
+  title
+FROM public.publishing_api_editions_current
+WHERE base_path IS NOT NULL
+AND title IS NOT NULL
+;

--- a/terraform/bigquery/graph-batch.sql
+++ b/terraform/bigquery/graph-batch.sql
@@ -1,0 +1,6 @@
+-- Call a sequence of routines that refresh tables in the legacy `graph`
+-- dataset.
+
+CALL graph.is_tagged_to();
+CALL graph.page();
+CALL graph.taxon();

--- a/terraform/bigquery/graph-is-tagged-to.sql
+++ b/terraform/bigquery/graph-is-tagged-to.sql
@@ -1,0 +1,13 @@
+-- Recreate the legacy graph.is_tagged_to table from the 'public' dataset
+
+TRUNCATE TABLE graph.is_tagged_to;
+INSERT INTO graph.is_tagged_to
+SELECT
+  "https://www.gov.uk/" || sources.content_id AS url,
+  "https://www.gov.uk/" || targets.content_id AS taxon_url
+FROM public.taxonomy
+INNER JOIN public.publishing_api_links_current AS links ON (links.target_edition_id = taxonomy.edition_id)
+INNER JOIN public.publishing_api_editions_current AS sources ON (sources.id = links.source_edition_id)
+INNER JOIN public.publishing_api_editions_current AS targets ON (targets.id = links.target_edition_id)
+WHERE links.type = 'taxons'
+;

--- a/terraform/bigquery/graph-page.sql
+++ b/terraform/bigquery/graph-page.sql
@@ -1,0 +1,65 @@
+-- Recreate the legacy graph.page table from the 'public' dataset
+--
+-- Differences:
+--
+-- * The legacy table included URLs derived from content that don't really exist
+--   and that can be omitted with `schema_name is not null`
+-- * The legacy table included redirects from the Content API that don't join to
+--   current editions from the Publishing API, but do exist on the web. The
+--   redirected URLs aren't discoverable, so we exclude them from the 'public'
+--   dataset, so they are omitted here.  A disadvantage is that it won't be
+--   possible to 'follow' some redirects without checking them with a GET
+--   request.
+
+TRUNCATE TABLE graph.page;
+INSERT INTO graph.page
+WITH
+  editions AS (
+    SELECT editions.*
+    FROM public.publishing_api_editions_current AS editions
+    WHERE editions.base_path IS NOT NULL
+  ),
+  withdrawals AS (
+    SELECT
+      edition_id,
+      unpublished_at AS withdrawn_at,
+      explanation AS withdrawn_explanation
+    FROM public.publishing_api_unpublishings_current
+    WHERE type = 'withdrawal'
+),
+pages AS (
+  SELECT
+    editions.id AS edition_id,
+    COALESCE(content.base_path, editions.base_path) AS base_path,
+    "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
+  FROM editions
+  LEFT JOIN public.content ON content.edition_id = editions.id
+)
+SELECT
+  pages.url,
+  editions.document_type,
+  editions.schema_name,
+  editions.phase,
+  editions.content_id,
+  editions.analytics_identifier,
+  JSON_value(editions.details, "$.acronym") AS acronym,
+  editions.locale,
+  editions.publishing_app,
+  editions.updated_at,
+  editions.first_published_at,
+  editions.public_updated_at,
+  withdrawals.withdrawn_at,
+  withdrawals.withdrawn_explanation,
+  editions.title,
+  JSON_value(editions.details, "$.internal_name") AS internal_name,
+  editions.description,
+  JSON_value(editions.details, "$.department_analytics_profile") AS department_analytics_profile,
+  content.text,
+  content.part_index,
+  content.part_slug AS slug
+FROM pages
+INNER JOIN editions ON editions.id = pages.edition_id -- one row per document
+LEFT JOIN withdrawals ON withdrawals.edition_id = pages.edition_id
+LEFT JOIN public.content -- one row per document or part
+  ON content.base_path = pages.base_path -- includes the slug of parts
+;

--- a/terraform/bigquery/graph-taxon.sql
+++ b/terraform/bigquery/graph-taxon.sql
@@ -1,0 +1,18 @@
+-- Recreate the legacy graph.page table from the 'public' dataset
+
+TRUNCATE TABLE graph.taxon;
+INSERT INTO graph.taxon
+SELECT
+  'https://www.gov.uk/' || editions.content_id AS url,
+  editions.title,
+  JSON_VALUE(editions.details, "$.internal_name") AS internal_name,
+  editions.description,
+  editions.content_id,
+  taxonomy.level
+FROM
+  public.taxonomy
+INNER JOIN
+  public.publishing_api_editions_current AS editions
+ON
+  editions.id = taxonomy.edition_id
+;

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -90,6 +90,7 @@ all_links AS (
   FROM
     public.publishing_api_links_current AS links
   INNER JOIN editions ON editions.id = links.source_edition_id
+  WHERE editions.base_path IS NOT NULL
   UNION ALL
   SELECT
     "embedded" as link_type,
@@ -137,11 +138,13 @@ pages AS (
     "https://www.gov.uk" || COALESCE(content.base_path, editions.base_path) AS url
   FROM editions
   LEFT JOIN public.content ON content.edition_id = editions.id
+  WHERE TRUE
+  AND editions.base_path IS NOT NULL
   -- Exclude pages that duplicate the first part of a multipart document.
   -- Equivalent statements are:
   -- `content.part_index IS NULL OR content.part_index > 1`
   -- `(NOT content.is_part) OR content.part_index > 1`
-  WHERE content.is_part OR (content.part_index IS NULL)
+  AND content.is_part OR (content.part_index IS NULL)
 )
 SELECT
   pages.url,


### PR DESCRIPTION
To allow for the legacy Content API data pipeline to be removed. Until
downstream dependants are updated to use the new data in the 'private'
and 'public' datasets.

See individual commits for details.