### PR TITLE
refactor: don't restore postgres database

### DIFF
--- a/docker/publishing-api/Dockerfile
+++ b/docker/publishing-api/Dockerfile
@@ -2,13 +2,15 @@ FROM postgres:16.0-alpine3.18
 
 # Install the gcloud CLI, a specific version from a long-term archive
 # Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
-# Also install make
+# Also install make, and GNU sed (for Q command) and coreutils (for faster wc)
 ENV CLOUD_SDK_VERSION=452.0.1
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN addgroup -g 1000 -S cloudsdk && \
     adduser -u 1000 -S cloudsdk -G cloudsdk
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && apk --no-cache add \
+        sed \
+        coreutils \
         curl \
         python3 \
         py3-crcmod \

--- a/src/publishing-api/Makefile
+++ b/src/publishing-api/Makefile
@@ -15,34 +15,36 @@ EXPORT = actions change_notes documents editions events expanded_links link_chan
 all: $(EXPORT)
 
 actions:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 change_notes:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 documents:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
+# This task takes longer than all the others put together, so there's no point
+# running with more than two cores.
 editions:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 events:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 expanded_links:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 link_changes:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 link_sets:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 links:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 path_reservations:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
 
 unpublishings:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@

--- a/src/publishing-api/run.sh
+++ b/src/publishing-api/run.sh
@@ -1,31 +1,12 @@
 #!/bin/bash
 
-# Increase the amount of shared memory available.
-# This requires the containe to run in privileged mode.
-# It prevents a postgres error
-# "could not resize shared memory segment: No space left on device"
-mount -o remount,size=8G /dev/shm
-
-# Run both postgres and scripts that interact with the database
-
 # Obtain the latest state of the repository
 gcloud storage cp -r "gs://${PROJECT_ID}-repository/*" .
 
 # turn on bash's job control
 set -m
 
-# Start postgres in the background.  The docker-entrypoint.sh script is on the
-# path, and handles users and permissions
-# https://stackoverflow.com/a/48880635/937932
-cp src/publishing-api/postgresql.conf.write-optimised src/publishing-api/postgresql.conf
-docker-entrypoint.sh postgres -c config_file=src/publishing-api/postgresql.conf &
-
-# Wait for postgres to start
-sleep 5
-
-# Restore the Publishing API database from its backup file in GCP Storage
-
-# Construct the file's URL
+# Fetch the Publishing API database backup file from GCP Storage
 BUCKET=$(
   gcloud compute instances describe publishing-api \
     --project $PROJECT_ID \
@@ -39,10 +20,10 @@ gcloud compute instances describe publishing-api \
   --format="value(metadata.items.object_name)"
 )
 OBJECT_URL="gs://$BUCKET/$OBJECT"
-FILE_PATH="data/$OBJECT"
+# Export a variable so that the Makefile can use it
+export FILE_PATH="/data/$OBJECT"
 
 # https://stackoverflow.com/questions/6575221
-date
 gcloud storage cp "$OBJECT_URL" "$FILE_PATH"
 
 # Check that the file size is larger than an arbitrary size of 2GiB.
@@ -58,25 +39,12 @@ if [ $actualsize -le $minimumsize ]; then
   exit 1
 fi
 
-date
-pg_restore \
-  -U postgres \
-  --verbose \
-  --create \
-  --clean \
-  --dbname=postgres \
-  --no-owner \
-  --jobs=2 \
-  "$FILE_PATH"
-date
-rm "$FILE_PATH"
-
-# Restart postgres with a less-crashable configuration
-cp src/publishing-api/postgresql.conf.safe src/publishing-api/postgresql.conf
-psql -U postgres -c "SELECT pg_reload_conf();"
-
-# 1. Export each table to compressed CSV and upload to a bucket
-# 2. Import each file from the bucket into BigQuery
+# pg_dump each table into a file, upload it to BigQuery, and delete the file.
+#
+# Use a Makefile to do this in parallel.
+#
+# Two cores are sufficient, because the editions table takes longer than all the
+# other tables together.
 cd src/publishing-api
 make
 

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -104,7 +104,6 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
-      google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,
     ]
   }

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -104,7 +104,6 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
-      google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,
     ]
   }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -104,7 +104,6 @@ data "google_iam_policy" "bucket_data_processed" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
-      google_service_account.gce_publishing_api.member,
       google_service_account.gce_publisher.member,
     ]
   }


### PR DESCRIPTION
It's so slow to restore the database, and is much quicker to use pg_dump to extract the data in a form that is nearly TSV, then clean it with sed for importing into BigQuery.  It takes about an hour, instead of about three and a half hours.
