### PR TITLE
feat: automatically delete old docker images

### DIFF
--- a/terraform-dev/artifact-registry.tf
+++ b/terraform-dev/artifact-registry.tf
@@ -2,10 +2,27 @@
 # See also: ./workload-identity-fededocker build.tf
 
 resource "google_artifact_registry_repository" "docker" {
-  location      = lower(var.location)
-  repository_id = "docker"
-  description   = "Docker repository"
-  format        = "DOCKER"
+  location               = lower(var.location)
+  repository_id          = "docker"
+  description            = "Docker repository"
+  format                 = "DOCKER"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    # Is overridden by a KEEP policy
+    id     = "delete-old-versions"
+    action = "DELETE"
+    condition {
+      older_than = "2678400s" # 31 days
+    }
+  }
+  cleanup_policies {
+    # Overrides a DELETE policy
+    id     = "keep-a-number-of-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 1
+    }
+  }
 }
 
 resource "google_service_account" "artifact_registry_docker" {

--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -126,10 +126,27 @@ resource "google_secret_manager_secret_iam_policy" "cookie-session-signature" {
 
 # Then create a place to put the app images
 resource "google_artifact_registry_repository" "cloud_run_source_deploy" {
-  description   = "Cloud Run Source Deployments"
-  format        = "DOCKER"
-  location      = var.region
-  repository_id = "cloud-run-source-deploy"
+  description            = "Cloud Run Source Deployments"
+  format                 = "DOCKER"
+  location               = var.region
+  repository_id          = "cloud-run-source-deploy"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    # Is overridden by a KEEP policy
+    id     = "delete-old-versions"
+    action = "DELETE"
+    condition {
+      older_than = "2678400s" # 31 days
+    }
+  }
+  cleanup_policies {
+    # Overrides a DELETE policy
+    id     = "keep-a-number-of-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 1
+    }
+  }
 }
 
 data "google_iam_policy" "artifact_registry_cloud_run_source_deploy" {

--- a/terraform-staging/artifact-registry.tf
+++ b/terraform-staging/artifact-registry.tf
@@ -2,10 +2,27 @@
 # See also: ./workload-identity-fededocker build.tf
 
 resource "google_artifact_registry_repository" "docker" {
-  location      = lower(var.location)
-  repository_id = "docker"
-  description   = "Docker repository"
-  format        = "DOCKER"
+  location               = lower(var.location)
+  repository_id          = "docker"
+  description            = "Docker repository"
+  format                 = "DOCKER"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    # Is overridden by a KEEP policy
+    id     = "delete-old-versions"
+    action = "DELETE"
+    condition {
+      older_than = "2678400s" # 31 days
+    }
+  }
+  cleanup_policies {
+    # Overrides a DELETE policy
+    id     = "keep-a-number-of-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 1
+    }
+  }
 }
 
 resource "google_service_account" "artifact_registry_docker" {

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -126,10 +126,27 @@ resource "google_secret_manager_secret_iam_policy" "cookie-session-signature" {
 
 # Then create a place to put the app images
 resource "google_artifact_registry_repository" "cloud_run_source_deploy" {
-  description   = "Cloud Run Source Deployments"
-  format        = "DOCKER"
-  location      = var.region
-  repository_id = "cloud-run-source-deploy"
+  description            = "Cloud Run Source Deployments"
+  format                 = "DOCKER"
+  location               = var.region
+  repository_id          = "cloud-run-source-deploy"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    # Is overridden by a KEEP policy
+    id     = "delete-old-versions"
+    action = "DELETE"
+    condition {
+      older_than = "2678400s" # 31 days
+    }
+  }
+  cleanup_policies {
+    # Overrides a DELETE policy
+    id     = "keep-a-number-of-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 1
+    }
+  }
 }
 
 data "google_iam_policy" "artifact_registry_cloud_run_source_deploy" {

--- a/terraform/artifact-registry.tf
+++ b/terraform/artifact-registry.tf
@@ -2,10 +2,27 @@
 # See also: ./workload-identity-fededocker build.tf
 
 resource "google_artifact_registry_repository" "docker" {
-  location      = lower(var.location)
-  repository_id = "docker"
-  description   = "Docker repository"
-  format        = "DOCKER"
+  location               = lower(var.location)
+  repository_id          = "docker"
+  description            = "Docker repository"
+  format                 = "DOCKER"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    # Is overridden by a KEEP policy
+    id     = "delete-old-versions"
+    action = "DELETE"
+    condition {
+      older_than = "2678400s" # 31 days
+    }
+  }
+  cleanup_policies {
+    # Overrides a DELETE policy
+    id     = "keep-a-number-of-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 1
+    }
+  }
 }
 
 resource "google_service_account" "artifact_registry_docker" {

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -126,10 +126,27 @@ resource "google_secret_manager_secret_iam_policy" "cookie-session-signature" {
 
 # Then create a place to put the app images
 resource "google_artifact_registry_repository" "cloud_run_source_deploy" {
-  description   = "Cloud Run Source Deployments"
-  format        = "DOCKER"
-  location      = var.region
-  repository_id = "cloud-run-source-deploy"
+  description            = "Cloud Run Source Deployments"
+  format                 = "DOCKER"
+  location               = var.region
+  repository_id          = "cloud-run-source-deploy"
+  cleanup_policy_dry_run = false
+  cleanup_policies {
+    # Is overridden by a KEEP policy
+    id     = "delete-old-versions"
+    action = "DELETE"
+    condition {
+      older_than = "2678400s" # 31 days
+    }
+  }
+  cleanup_policies {
+    # Overrides a DELETE policy
+    id     = "keep-a-number-of-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 1
+    }
+  }
 }
 
 data "google_iam_policy" "artifact_registry_cloud_run_source_deploy" {


### PR DESCRIPTION
Anything older than 31 days will be deleted from the Artifact Registry,
unless it is the most-recent version.
