### PR TITLE
feat: lookup table of real-world base paths

### DIFF
--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -138,6 +138,20 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
   )
 }
 
+# Must only be executed after
+# google_bigquery_routine.extract_content_from_editions, which refreshes a table
+# that this depends on.
+resource "google_bigquery_routine" "base_path_lookup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "base_path_lookup"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/base-path-lookup.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 resource "google_bigquery_routine" "taxonomy" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "taxonomy"

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -41,6 +41,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "base_path_lookup" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "base_path_lookup"
+  friendly_name = "Base path lookup"
+  description   = "Maps base paths that the GOV.UK website serves, to base paths in the Publishing API. For example, /towing-with-car/weight-and-width-limits is a base path that the website serves with content from an edition in the Publishing API that has the (shorter) base path /towing-with-car."
+  schema        = file("schemas/public/base-path-lookup.json")
+}
+
 resource "google_bigquery_table" "public_content_new" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "content_new"

--- a/terraform-dev/bigquery/base-path-lookup.sql
+++ b/terraform-dev/bigquery/base-path-lookup.sql
@@ -1,0 +1,32 @@
+-- Refresh a table that maps base paths used in the real world to base paths
+-- that belong to editions in the Publishing API database.  The difference is
+-- due to documents of schema 'guide' and 'travel_advice' having a real-world
+-- base_path for each part of the document.
+--
+-- This query depends on the table public.content, which extracts the extra
+-- slugs of 'guide' and 'travel_advice' documents.  The public.content table
+-- can't itself be used as a lookup table, because it omits documents that don't
+-- have content, or whose content we don't yet extract.
+TRUNCATE TABLE public.base_path_lookup;
+INSERT INTO public.base_path_lookup
+WITH real_base_paths AS (
+  SELECT
+    id AS edition_id,
+    base_path
+  FROM public.publishing_api_editions_current
+  WHERE base_path IS NOT NULL
+  UNION DISTINCT
+  SELECT
+    edition_id,
+    base_path
+  FROM public.content
+  WHERE base_path IS NOT NULL
+)
+SELECT
+  real_base_paths.base_path AS base_path_for_joining,
+  editions.base_path AS publishing_api_base_path,
+  editions.id AS edition_id,
+  editions.content_id
+FROM real_base_paths
+INNER JOIN public.publishing_api_editions_current AS editions
+  ON editions.id = real_base_paths.edition_id

--- a/terraform-dev/bigquery/content-batch.sql
+++ b/terraform-dev/bigquery/content-batch.sql
@@ -2,6 +2,7 @@
 -- dataset.
 
 CALL content.content();
+CALL content.base_path_lookup(); -- Depends on results of content.content();
 CALL content.description();
 CALL content.expanded_links();
 CALL content.lines();

--- a/terraform-dev/schemas/public/base-path-lookup.json
+++ b/terraform-dev/schemas/public/base-path-lookup.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "base_path_for_joining",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "publishing_api_base_path",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "content_id",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -138,6 +138,20 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
   )
 }
 
+# Must only be executed after
+# google_bigquery_routine.extract_content_from_editions, which refreshes a table
+# that this depends on.
+resource "google_bigquery_routine" "base_path_lookup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "base_path_lookup"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/base-path-lookup.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 resource "google_bigquery_routine" "taxonomy" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "taxonomy"

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -41,6 +41,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "base_path_lookup" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "base_path_lookup"
+  friendly_name = "Base path lookup"
+  description   = "Maps base paths that the GOV.UK website serves, to base paths in the Publishing API. For example, /towing-with-car/weight-and-width-limits is a base path that the website serves with content from an edition in the Publishing API that has the (shorter) base path /towing-with-car."
+  schema        = file("schemas/public/base-path-lookup.json")
+}
+
 resource "google_bigquery_table" "public_content_new" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "content_new"

--- a/terraform-staging/bigquery/base-path-lookup.sql
+++ b/terraform-staging/bigquery/base-path-lookup.sql
@@ -1,0 +1,32 @@
+-- Refresh a table that maps base paths used in the real world to base paths
+-- that belong to editions in the Publishing API database.  The difference is
+-- due to documents of schema 'guide' and 'travel_advice' having a real-world
+-- base_path for each part of the document.
+--
+-- This query depends on the table public.content, which extracts the extra
+-- slugs of 'guide' and 'travel_advice' documents.  The public.content table
+-- can't itself be used as a lookup table, because it omits documents that don't
+-- have content, or whose content we don't yet extract.
+TRUNCATE TABLE public.base_path_lookup;
+INSERT INTO public.base_path_lookup
+WITH real_base_paths AS (
+  SELECT
+    id AS edition_id,
+    base_path
+  FROM public.publishing_api_editions_current
+  WHERE base_path IS NOT NULL
+  UNION DISTINCT
+  SELECT
+    edition_id,
+    base_path
+  FROM public.content
+  WHERE base_path IS NOT NULL
+)
+SELECT
+  real_base_paths.base_path AS base_path_for_joining,
+  editions.base_path AS publishing_api_base_path,
+  editions.id AS edition_id,
+  editions.content_id
+FROM real_base_paths
+INNER JOIN public.publishing_api_editions_current AS editions
+  ON editions.id = real_base_paths.edition_id

--- a/terraform-staging/bigquery/content-batch.sql
+++ b/terraform-staging/bigquery/content-batch.sql
@@ -2,6 +2,7 @@
 -- dataset.
 
 CALL content.content();
+CALL content.base_path_lookup(); -- Depends on results of content.content();
 CALL content.description();
 CALL content.expanded_links();
 CALL content.lines();

--- a/terraform-staging/schemas/public/base-path-lookup.json
+++ b/terraform-staging/schemas/public/base-path-lookup.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "base_path_for_joining",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "publishing_api_base_path",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "content_id",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -138,6 +138,20 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
   )
 }
 
+# Must only be executed after
+# google_bigquery_routine.extract_content_from_editions, which refreshes a table
+# that this depends on.
+resource "google_bigquery_routine" "base_path_lookup" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "base_path_lookup"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/base-path-lookup.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 resource "google_bigquery_routine" "taxonomy" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "taxonomy"

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -41,6 +41,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "base_path_lookup" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "base_path_lookup"
+  friendly_name = "Base path lookup"
+  description   = "Maps base paths that the GOV.UK website serves, to base paths in the Publishing API. For example, /towing-with-car/weight-and-width-limits is a base path that the website serves with content from an edition in the Publishing API that has the (shorter) base path /towing-with-car."
+  schema        = file("schemas/public/base-path-lookup.json")
+}
+
 resource "google_bigquery_table" "public_content_new" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "content_new"

--- a/terraform/bigquery/base-path-lookup.sql
+++ b/terraform/bigquery/base-path-lookup.sql
@@ -1,0 +1,32 @@
+-- Refresh a table that maps base paths used in the real world to base paths
+-- that belong to editions in the Publishing API database.  The difference is
+-- due to documents of schema 'guide' and 'travel_advice' having a real-world
+-- base_path for each part of the document.
+--
+-- This query depends on the table public.content, which extracts the extra
+-- slugs of 'guide' and 'travel_advice' documents.  The public.content table
+-- can't itself be used as a lookup table, because it omits documents that don't
+-- have content, or whose content we don't yet extract.
+TRUNCATE TABLE public.base_path_lookup;
+INSERT INTO public.base_path_lookup
+WITH real_base_paths AS (
+  SELECT
+    id AS edition_id,
+    base_path
+  FROM public.publishing_api_editions_current
+  WHERE base_path IS NOT NULL
+  UNION DISTINCT
+  SELECT
+    edition_id,
+    base_path
+  FROM public.content
+  WHERE base_path IS NOT NULL
+)
+SELECT
+  real_base_paths.base_path AS base_path_for_joining,
+  editions.base_path AS publishing_api_base_path,
+  editions.id AS edition_id,
+  editions.content_id
+FROM real_base_paths
+INNER JOIN public.publishing_api_editions_current AS editions
+  ON editions.id = real_base_paths.edition_id

--- a/terraform/bigquery/content-batch.sql
+++ b/terraform/bigquery/content-batch.sql
@@ -2,6 +2,7 @@
 -- dataset.
 
 CALL content.content();
+CALL content.base_path_lookup(); -- Depends on results of content.content();
 CALL content.description();
 CALL content.expanded_links();
 CALL content.lines();

--- a/terraform/schemas/public/base-path-lookup.json
+++ b/terraform/schemas/public/base-path-lookup.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "base_path_for_joining",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "publishing_api_base_path",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "content_id",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]


### PR DESCRIPTION
Create a table that maps base paths used in the real world to base paths that belong to editions in the Publishing API database.  The difference is due to documents of schema `guide` and `travel_advice` having a real-world `base_path` for each part of the document.

This depends on the table public.content, which extracts the extra slugs of `guide` and `travel_advice` documents.  The public.content table can't itself be used as a lookup table, because it omits documents that don't have content, or whose content we don't yet extract.
