### PR TITLE
feat: derive a table of org codes

### DIFF
--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -152,6 +152,17 @@ resource "google_bigquery_routine" "base_path_lookup" {
   )
 }
 
+resource "google_bigquery_routine" "department_analytics_profile" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "department_analytics_profile"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/department-analytics-profile.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 resource "google_bigquery_routine" "taxonomy" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "taxonomy"

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -73,6 +73,14 @@ resource "google_bigquery_table" "public_contact_phone_numbers" {
   schema        = file("schemas/public/contact-phone-numbers.json")
 }
 
+resource "google_bigquery_table" "department_analytics_profile" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "department_analytics_profile"
+  friendly_name = "Department analytics profile (org ID)"
+  description   = "The ID of an organisation, which is also its Google Analytics ID"
+  schema        = file("schemas/public/department-analytics-profile.json")
+}
+
 resource "google_bigquery_table" "public_phone_numbers" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "phone_numbers"

--- a/terraform-dev/bigquery/content-batch.sql
+++ b/terraform-dev/bigquery/content-batch.sql
@@ -2,7 +2,6 @@
 -- dataset.
 
 CALL content.content();
-CALL content.base_path_lookup(); -- Depends on results of content.content();
 CALL content.description();
 CALL content.expanded_links();
 CALL content.lines();

--- a/terraform-dev/bigquery/department-analytics-profile.sql
+++ b/terraform-dev/bigquery/department-analytics-profile.sql
@@ -1,0 +1,11 @@
+-- Maintains a table `public.department_analytics_profle` of IDs of
+-- organisations, which happen to also be their Google Analytics ID.
+TRUNCATE TABLE public.department_analytics_profile;
+INSERT INTO public.department_analytics_profile
+SELECT
+  editions.id,
+  JSON_value(details, "$.department_analytics_profile") AS organisation_analytics_profile
+FROM public.publishing_api_editions_current AS editions
+WHERE JSON_value(details, "$.department_analytics_profile") IS NOT NULL
+  AND JSON_value(details, "$.department_analytics_profile") <> ""
+;

--- a/terraform-dev/bigquery/publishing-api-batch.sql
+++ b/terraform-dev/bigquery/publishing-api-batch.sql
@@ -14,6 +14,9 @@ CALL functions.publishing_api_unpublishings_current();
 -- extract plain text and various tags.
 CALL functions.extract_content_from_editions();
 
+-- Depends on results of functions.extract_content_from_editions();
+CALL content.base_path_lookup();
+
 -- Update the public table of phone numbers extracted from 'contact' documents.
 CALL functions.contact_phone_numbers();
 

--- a/terraform-dev/bigquery/publishing-api-batch.sql
+++ b/terraform-dev/bigquery/publishing-api-batch.sql
@@ -14,6 +14,10 @@ CALL functions.publishing_api_unpublishings_current();
 -- extract plain text and various tags.
 CALL functions.extract_content_from_editions();
 
+-- Update the public table of organisation IDs, which are the same as their
+-- Google Analytics ID.
+CALL functions.department_analytics_profile();
+
 -- Depends on results of functions.extract_content_from_editions();
 CALL content.base_path_lookup();
 

--- a/terraform-dev/schemas/public/department-analytics-profile.json
+++ b/terraform-dev/schemas/public/department-analytics-profile.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "department_analytics_profile",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -152,6 +152,17 @@ resource "google_bigquery_routine" "base_path_lookup" {
   )
 }
 
+resource "google_bigquery_routine" "department_analytics_profile" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "department_analytics_profile"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/department-analytics-profile.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 resource "google_bigquery_routine" "taxonomy" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "taxonomy"

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -73,6 +73,14 @@ resource "google_bigquery_table" "public_contact_phone_numbers" {
   schema        = file("schemas/public/contact-phone-numbers.json")
 }
 
+resource "google_bigquery_table" "department_analytics_profile" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "department_analytics_profile"
+  friendly_name = "Department analytics profile (org ID)"
+  description   = "The ID of an organisation, which is also its Google Analytics ID"
+  schema        = file("schemas/public/department-analytics-profile.json")
+}
+
 resource "google_bigquery_table" "public_phone_numbers" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "phone_numbers"

--- a/terraform-staging/bigquery/content-batch.sql
+++ b/terraform-staging/bigquery/content-batch.sql
@@ -2,7 +2,6 @@
 -- dataset.
 
 CALL content.content();
-CALL content.base_path_lookup(); -- Depends on results of content.content();
 CALL content.description();
 CALL content.expanded_links();
 CALL content.lines();

--- a/terraform-staging/bigquery/department-analytics-profile.sql
+++ b/terraform-staging/bigquery/department-analytics-profile.sql
@@ -1,0 +1,11 @@
+-- Maintains a table `public.department_analytics_profle` of IDs of
+-- organisations, which happen to also be their Google Analytics ID.
+TRUNCATE TABLE public.department_analytics_profile;
+INSERT INTO public.department_analytics_profile
+SELECT
+  editions.id,
+  JSON_value(details, "$.department_analytics_profile") AS organisation_analytics_profile
+FROM public.publishing_api_editions_current AS editions
+WHERE JSON_value(details, "$.department_analytics_profile") IS NOT NULL
+  AND JSON_value(details, "$.department_analytics_profile") <> ""
+;

--- a/terraform-staging/bigquery/publishing-api-batch.sql
+++ b/terraform-staging/bigquery/publishing-api-batch.sql
@@ -14,6 +14,9 @@ CALL functions.publishing_api_unpublishings_current();
 -- extract plain text and various tags.
 CALL functions.extract_content_from_editions();
 
+-- Depends on results of functions.extract_content_from_editions();
+CALL content.base_path_lookup();
+
 -- Update the public table of phone numbers extracted from 'contact' documents.
 CALL functions.contact_phone_numbers();
 

--- a/terraform-staging/bigquery/publishing-api-batch.sql
+++ b/terraform-staging/bigquery/publishing-api-batch.sql
@@ -14,6 +14,10 @@ CALL functions.publishing_api_unpublishings_current();
 -- extract plain text and various tags.
 CALL functions.extract_content_from_editions();
 
+-- Update the public table of organisation IDs, which are the same as their
+-- Google Analytics ID.
+CALL functions.department_analytics_profile();
+
 -- Depends on results of functions.extract_content_from_editions();
 CALL content.base_path_lookup();
 

--- a/terraform-staging/schemas/public/department-analytics-profile.json
+++ b/terraform-staging/schemas/public/department-analytics-profile.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "department_analytics_profile",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -152,6 +152,17 @@ resource "google_bigquery_routine" "base_path_lookup" {
   )
 }
 
+resource "google_bigquery_routine" "department_analytics_profile" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "department_analytics_profile"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/department-analytics-profile.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 resource "google_bigquery_routine" "taxonomy" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "taxonomy"

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -73,6 +73,14 @@ resource "google_bigquery_table" "public_contact_phone_numbers" {
   schema        = file("schemas/public/contact-phone-numbers.json")
 }
 
+resource "google_bigquery_table" "department_analytics_profile" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "department_analytics_profile"
+  friendly_name = "Department analytics profile (org ID)"
+  description   = "The ID of an organisation, which is also its Google Analytics ID"
+  schema        = file("schemas/public/department-analytics-profile.json")
+}
+
 resource "google_bigquery_table" "public_phone_numbers" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "phone_numbers"

--- a/terraform/bigquery/content-batch.sql
+++ b/terraform/bigquery/content-batch.sql
@@ -2,7 +2,6 @@
 -- dataset.
 
 CALL content.content();
-CALL content.base_path_lookup(); -- Depends on results of content.content();
 CALL content.description();
 CALL content.expanded_links();
 CALL content.lines();

--- a/terraform/bigquery/department-analytics-profile.sql
+++ b/terraform/bigquery/department-analytics-profile.sql
@@ -1,0 +1,11 @@
+-- Maintains a table `public.department_analytics_profle` of IDs of
+-- organisations, which happen to also be their Google Analytics ID.
+TRUNCATE TABLE public.department_analytics_profile;
+INSERT INTO public.department_analytics_profile
+SELECT
+  editions.id,
+  JSON_value(details, "$.department_analytics_profile") AS organisation_analytics_profile
+FROM public.publishing_api_editions_current AS editions
+WHERE JSON_value(details, "$.department_analytics_profile") IS NOT NULL
+  AND JSON_value(details, "$.department_analytics_profile") <> ""
+;

--- a/terraform/bigquery/publishing-api-batch.sql
+++ b/terraform/bigquery/publishing-api-batch.sql
@@ -14,6 +14,9 @@ CALL functions.publishing_api_unpublishings_current();
 -- extract plain text and various tags.
 CALL functions.extract_content_from_editions();
 
+-- Depends on results of functions.extract_content_from_editions();
+CALL content.base_path_lookup();
+
 -- Update the public table of phone numbers extracted from 'contact' documents.
 CALL functions.contact_phone_numbers();
 

--- a/terraform/bigquery/publishing-api-batch.sql
+++ b/terraform/bigquery/publishing-api-batch.sql
@@ -14,6 +14,10 @@ CALL functions.publishing_api_unpublishings_current();
 -- extract plain text and various tags.
 CALL functions.extract_content_from_editions();
 
+-- Update the public table of organisation IDs, which are the same as their
+-- Google Analytics ID.
+CALL functions.department_analytics_profile();
+
 -- Depends on results of functions.extract_content_from_editions();
 CALL content.base_path_lookup();
 

--- a/terraform/schemas/public/department-analytics-profile.json
+++ b/terraform/schemas/public/department-analytics-profile.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "department_analytics_profile",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  }
+]


### PR DESCRIPTION
Maintains a table `public.department_analytics_profle` of IDs of organisations, which happen to also be their Google Analytics ID.

- **fix: batch query was in the wrong batch**
- **feat: derive a table of Org codes**
