### PR TITLE
feat: Make 'public' dataset publicly visible

### DIFF
--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -47,7 +47,7 @@ bigquery_private_data_viewer_members = [
 
 # BigQuery dataset: public
 bigquery_public_data_viewer_members = [
-  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
+  "allUsers"
 ]
 
 bigquery_content_data_viewer_members = [


### PR DESCRIPTION
The data in the 'public' dataset is the same as what is already
published publicly by the GOV.UK website and its Content API.  According
to the principle of being open by default, this dataset ought to be
publicly accessible.

This wouldn't cost us any money, because users would only have
permission to read the data, not to charge any costs to our account.  To
access the data, they would have to have their own Google Cloud Platform
project, and have arranged to pay its bills.

Openness would make collaboration with colleagues in other organisations
much easier.
