### PR TITLE
refactor: use base_path not url from publisher

### DIFF
--- a/src/publisher/query.js
+++ b/src/publisher/query.js
@@ -10,7 +10,7 @@ db.editions.aggregate([
   { $match: { "state": { $in: [ "published", "archived" ] } } },
   { $project: {
     _id: false,
-    "url": { "$concat": [ "https://www.gov.uk/", "$slug" ] },
+    "base_path": { "$concat": [ "/", "$slug" ] }, // consistent with other data
     // created_at: true, // when the edition was first drafted
     updated_at: true, // almost but not quite the same time as the updated_at of the corresponding edition in the Publishing API.
     version_number: true, // sequence, sometimes in a different order from updated_at e.g. /1619-bursary-fund

--- a/src/publisher/run.sh
+++ b/src/publisher/run.sh
@@ -51,7 +51,7 @@ mongoexport \
   --db=govuk_content_production \
   --type=csv \
   --collection="${OUTPUT_COLLECTION}" \
-  --fields=url,updated_at,version_number,state,major_change \
+  --fields=base_path,updated_at,version_number,state,major_change \
   | gcloud storage cp - "${OBJECT}" --quiet --gzip-in-flight-all
 
 # Upload the dataset from the cloud bucket to a BigQuery table

--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -50,7 +50,7 @@ WITH
   -- editors don't tend to use 'public_updated_at', and 'updated_at' is polluted
   -- by creation of new editions for techy reasons rather than editing reasons.
   SELECT
-    url,
+    base_path,
     MAX(updated_at) AS publisher_updated_at,
   FROM publisher.editions
   WHERE state='published'
@@ -194,7 +194,8 @@ LEFT JOIN organisations ON organisations.edition_id = pages.edition_id
 LEFT JOIN phone_numbers ON phone_numbers.edition_id = pages.edition_id
 LEFT JOIN taxons ON taxons.edition_id = pages.edition_id
 -- one publisher_updated_at per multipart document
-LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url, publisher_updated_at.url)
+LEFT JOIN publisher_updated_at
+  ON publisher_updated_at.base_path = pages.base_path
 LEFT JOIN public.content -- one row per document or part
   ON content.base_path = pages.base_path -- includes the slug of parts
 LEFT JOIN links

--- a/terraform-dev/schemas/publisher/editions.json
+++ b/terraform-dev/schemas/publisher/editions.json
@@ -1,9 +1,9 @@
 [
   {
-    "name": "url",
+    "name": "base_path",
     "type": "STRING",
     "mode": "REQUIRED",
-    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+    "description": "URL of a document, omitting the protocol and domain https://www.gov.uk. Not broken down into chapters of guide or travel_advice documents. Equivalent to the Publishing API's base_path."
   },
   {
     "name": "updated_at",

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -50,7 +50,7 @@ WITH
   -- editors don't tend to use 'public_updated_at', and 'updated_at' is polluted
   -- by creation of new editions for techy reasons rather than editing reasons.
   SELECT
-    url,
+    base_path,
     MAX(updated_at) AS publisher_updated_at,
   FROM publisher.editions
   WHERE state='published'
@@ -194,7 +194,8 @@ LEFT JOIN organisations ON organisations.edition_id = pages.edition_id
 LEFT JOIN phone_numbers ON phone_numbers.edition_id = pages.edition_id
 LEFT JOIN taxons ON taxons.edition_id = pages.edition_id
 -- one publisher_updated_at per multipart document
-LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url, publisher_updated_at.url)
+LEFT JOIN publisher_updated_at
+  ON publisher_updated_at.base_path = pages.base_path
 LEFT JOIN public.content -- one row per document or part
   ON content.base_path = pages.base_path -- includes the slug of parts
 LEFT JOIN links

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -65,7 +65,7 @@ bigquery_functions_data_viewer_members = [
 bigquery_graph_data_viewer_members = [
 ]
 
-# BigQuery dataset: publishing
+# BigQuery dataset: publishing-api
 bigquery_publishing_api_data_viewer_members = [
 ]
 

--- a/terraform-staging/schemas/publisher/editions.json
+++ b/terraform-staging/schemas/publisher/editions.json
@@ -1,9 +1,9 @@
 [
   {
-    "name": "url",
+    "name": "base_path",
     "type": "STRING",
     "mode": "REQUIRED",
-    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+    "description": "URL of a document, omitting the protocol and domain https://www.gov.uk. Not broken down into chapters of guide or travel_advice documents. Equivalent to the Publishing API's base_path."
   },
   {
     "name": "updated_at",

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -50,7 +50,7 @@ WITH
   -- editors don't tend to use 'public_updated_at', and 'updated_at' is polluted
   -- by creation of new editions for techy reasons rather than editing reasons.
   SELECT
-    url,
+    base_path,
     MAX(updated_at) AS publisher_updated_at,
   FROM publisher.editions
   WHERE state='published'
@@ -194,7 +194,8 @@ LEFT JOIN organisations ON organisations.edition_id = pages.edition_id
 LEFT JOIN phone_numbers ON phone_numbers.edition_id = pages.edition_id
 LEFT JOIN taxons ON taxons.edition_id = pages.edition_id
 -- one publisher_updated_at per multipart document
-LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url, publisher_updated_at.url)
+LEFT JOIN publisher_updated_at
+  ON publisher_updated_at.base_path = pages.base_path
 LEFT JOIN public.content -- one row per document or part
   ON content.base_path = pages.base_path -- includes the slug of parts
 LEFT JOIN links

--- a/terraform/schemas/publisher/editions.json
+++ b/terraform/schemas/publisher/editions.json
@@ -1,9 +1,9 @@
 [
   {
-    "name": "url",
+    "name": "base_path",
     "type": "STRING",
     "mode": "REQUIRED",
-    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+    "description": "URL of a document, omitting the protocol and domain https://www.gov.uk. Not broken down into chapters of guide or travel_advice documents. Equivalent to the Publishing API's base_path."
   },
   {
     "name": "updated_at",


### PR DESCRIPTION
For consistency with other databases
