### PR TITLE
feat: add 'people' column to search.page

### DIFF
--- a/terraform-dev/bigquery-search.tf
+++ b/terraform-dev/bigquery-search.tf
@@ -87,6 +87,14 @@ resource "google_bigquery_table" "search_page" {
   schema        = file("schemas/search/page.json")
 }
 
+resource "google_bigquery_table" "search_person" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "person"
+  friendly_name = "Distinct persons"
+  description   = "Distinct persons for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/person.json")
+}
+
 resource "google_bigquery_table" "search_taxon" {
   dataset_id    = google_bigquery_dataset.search.dataset_id
   table_id      = "taxon"
@@ -133,6 +141,14 @@ resource "google_bigquery_routine" "search_page" {
   routine_type    = "PROCEDURE"
   language        = "SQL"
   definition_body = file("bigquery/search-page.sql")
+}
+
+resource "google_bigquery_routine" "search_person" {
+  dataset_id      = google_bigquery_dataset.search.dataset_id
+  routine_id      = "person"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/search-person.sql")
 }
 
 resource "google_bigquery_routine" "search_taxon" {

--- a/terraform-dev/bigquery/search-batch.sql
+++ b/terraform-dev/bigquery/search-batch.sql
@@ -5,5 +5,6 @@ CALL search.document_type();
 CALL search.government();
 CALL search.locale();
 CALL search.organisation();
+CALL search.person();
 CALL search.taxon();
 CALL search.page();

--- a/terraform-dev/bigquery/search-person.sql
+++ b/terraform-dev/bigquery/search-person.sql
@@ -1,0 +1,9 @@
+-- A table of unique person titles, for a drop-down menu.
+TRUNCATE TABLE search.person;
+INSERT INTO search.person
+SELECT title
+FROM public.publishing_api_editions_current
+WHERE
+  TRUE
+  AND schema_name = 'person'
+  AND locale = 'en'

--- a/terraform-dev/schemas/search/page.json
+++ b/terraform-dev/schemas/search/page.json
@@ -103,6 +103,12 @@
   },
   {
     "mode": "REPEATED",
+    "name": "people",
+    "type": "STRING",
+    "description": "Array of names of people who are associated with the page"
+  },
+  {
+    "mode": "REPEATED",
     "name": "hyperlinks",
     "type": "RECORD",
     "description": "Array of hyperlinks from the body of the page",

--- a/terraform-dev/schemas/search/person.json
+++ b/terraform-dev/schemas/search/person.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "title",
+        "type": "STRING",
+        "description": "Title of a person's document, which is their name"
+    }
+]

--- a/terraform-staging/bigquery-search.tf
+++ b/terraform-staging/bigquery-search.tf
@@ -87,6 +87,14 @@ resource "google_bigquery_table" "search_page" {
   schema        = file("schemas/search/page.json")
 }
 
+resource "google_bigquery_table" "search_person" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "person"
+  friendly_name = "Distinct persons"
+  description   = "Distinct persons for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/person.json")
+}
+
 resource "google_bigquery_table" "search_taxon" {
   dataset_id    = google_bigquery_dataset.search.dataset_id
   table_id      = "taxon"
@@ -133,6 +141,14 @@ resource "google_bigquery_routine" "search_page" {
   routine_type    = "PROCEDURE"
   language        = "SQL"
   definition_body = file("bigquery/search-page.sql")
+}
+
+resource "google_bigquery_routine" "search_person" {
+  dataset_id      = google_bigquery_dataset.search.dataset_id
+  routine_id      = "person"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/search-person.sql")
 }
 
 resource "google_bigquery_routine" "search_taxon" {

--- a/terraform-staging/bigquery/search-batch.sql
+++ b/terraform-staging/bigquery/search-batch.sql
@@ -5,5 +5,6 @@ CALL search.document_type();
 CALL search.government();
 CALL search.locale();
 CALL search.organisation();
+CALL search.person();
 CALL search.taxon();
 CALL search.page();

--- a/terraform-staging/bigquery/search-person.sql
+++ b/terraform-staging/bigquery/search-person.sql
@@ -1,0 +1,9 @@
+-- A table of unique person titles, for a drop-down menu.
+TRUNCATE TABLE search.person;
+INSERT INTO search.person
+SELECT title
+FROM public.publishing_api_editions_current
+WHERE
+  TRUE
+  AND schema_name = 'person'
+  AND locale = 'en'

--- a/terraform-staging/schemas/search/page.json
+++ b/terraform-staging/schemas/search/page.json
@@ -103,6 +103,12 @@
   },
   {
     "mode": "REPEATED",
+    "name": "people",
+    "type": "STRING",
+    "description": "Array of names of people who are associated with the page"
+  },
+  {
+    "mode": "REPEATED",
     "name": "hyperlinks",
     "type": "RECORD",
     "description": "Array of hyperlinks from the body of the page",

--- a/terraform-staging/schemas/search/person.json
+++ b/terraform-staging/schemas/search/person.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "title",
+        "type": "STRING",
+        "description": "Title of a person's document, which is their name"
+    }
+]

--- a/terraform/bigquery-search.tf
+++ b/terraform/bigquery-search.tf
@@ -87,6 +87,14 @@ resource "google_bigquery_table" "search_page" {
   schema        = file("schemas/search/page.json")
 }
 
+resource "google_bigquery_table" "search_person" {
+  dataset_id    = google_bigquery_dataset.search.dataset_id
+  table_id      = "person"
+  friendly_name = "Distinct persons"
+  description   = "Distinct persons for dropdown menus in the govsearch app"
+  schema        = file("schemas/search/person.json")
+}
+
 resource "google_bigquery_table" "search_taxon" {
   dataset_id    = google_bigquery_dataset.search.dataset_id
   table_id      = "taxon"
@@ -133,6 +141,14 @@ resource "google_bigquery_routine" "search_page" {
   routine_type    = "PROCEDURE"
   language        = "SQL"
   definition_body = file("bigquery/search-page.sql")
+}
+
+resource "google_bigquery_routine" "search_person" {
+  dataset_id      = google_bigquery_dataset.search.dataset_id
+  routine_id      = "person"
+  routine_type    = "PROCEDURE"
+  language        = "SQL"
+  definition_body = file("bigquery/search-person.sql")
 }
 
 resource "google_bigquery_routine" "search_taxon" {

--- a/terraform/bigquery/search-batch.sql
+++ b/terraform/bigquery/search-batch.sql
@@ -5,5 +5,6 @@ CALL search.document_type();
 CALL search.government();
 CALL search.locale();
 CALL search.organisation();
+CALL search.person();
 CALL search.taxon();
 CALL search.page();

--- a/terraform/bigquery/search-person.sql
+++ b/terraform/bigquery/search-person.sql
@@ -1,0 +1,9 @@
+-- A table of unique person titles, for a drop-down menu.
+TRUNCATE TABLE search.person;
+INSERT INTO search.person
+SELECT title
+FROM public.publishing_api_editions_current
+WHERE
+  TRUE
+  AND schema_name = 'person'
+  AND locale = 'en'

--- a/terraform/schemas/search/page.json
+++ b/terraform/schemas/search/page.json
@@ -103,6 +103,12 @@
   },
   {
     "mode": "REPEATED",
+    "name": "people",
+    "type": "STRING",
+    "description": "Array of names of people who are associated with the page"
+  },
+  {
+    "mode": "REPEATED",
     "name": "hyperlinks",
     "type": "RECORD",
     "description": "Array of hyperlinks from the body of the page",

--- a/terraform/schemas/search/person.json
+++ b/terraform/schemas/search/person.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "title",
+        "type": "STRING",
+        "description": "Title of a person's document, which is their name"
+    }
+]


### PR DESCRIPTION
A GovSearch user asked to filter for pages that are associated with a
given person.  This will require changes in the GovSearch repository too
https://github.com/alphagov/govuk-knowledge-graph-search

This doesn't disambiguate between people who have the same name.  There are 81 different names that are each used by multiple people.  Some of them seem to be duplicates of the same person, such as:

* https://www.gov.uk/government/people/jonathan-evans
* https://www.gov.uk/government/people/jonathan-evans--2

The could perhaps be disambiguated in GovSearch by their photograph (if it exists), or base path, or description, or body text. That would require a drastic change to the selector.  Another option would be to number them, e.g. "Lord Jonathan Evans KCB DL (1)", "Lord Jonathan Evans KCB DL (2)", but we couldn't guarantee to number them consistently, because one of the instances of those people could be removed in a subsequent update to GOV.UK.

```sql
SELECT
  title,
  ARRAY_AGG(id) AS ids,
  ARRAY_AGG(base_path) AS base_paths
FROM
  public.publishing_api_editions_current
WHERE
  TRUE
  AND schema_name = 'person'
  AND locale = 'en'
GROUP BY
  title
HAVING
  COUNT(*) > 1
```