### PR TITLE
feat: add mainstream browse topics to govsearch

### DIFF
--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -185,6 +185,17 @@ resource "google_bigquery_routine" "organisations" {
   )
 }
 
+resource "google_bigquery_routine" "mainstream_browse" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "mainstream_browse"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/public-mainstream-browse.sql",
+    { project_id = var.project_id }
+  )
+}
+
 resource "google_bigquery_routine" "contact_phone_numbers" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "contact_phone_numbers"

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -129,6 +129,14 @@ resource "google_bigquery_table" "public_start_button_links" {
   schema        = file("schemas/public/start-button-links.json")
 }
 
+resource "google_bigquery_table" "public_mainstream_browse" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "mainstream_browse"
+  friendly_name = "Mainstream browse"
+  description   = "One row per page, per parent that it has in the mainstream browse taxonomy (because pages can be linked to from more than one mainstream browse page). Each has an array of its ancestors. If the page is itself a mainstream browse page, then it is included among its own ancestors."
+  schema        = file("schemas/public/mainstream-browse.json")
+}
+
 resource "google_bigquery_table" "public_taxonomy" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "taxonomy"

--- a/terraform-dev/bigquery/public-mainstream-browse.sql
+++ b/terraform-dev/bigquery/public-mainstream-browse.sql
@@ -1,0 +1,110 @@
+TRUNCATE TABLE public.mainstream_browse;
+INSERT INTO public.mainstream_browse
+WITH
+browse_pages AS (
+  SELECT *
+  FROM `public.publishing_api_editions_current`
+  WHERE schema_name = 'mainstream_browse_page'
+),
+links AS (
+  SELECT *
+  FROM `public.publishing_api_links_current`
+  WHERE type IN ('top_level_browse_pages', 'second_level_browse_pages', 'mainstream_browse_pages')
+),
+editions AS (
+  SELECT
+    id,
+    content_id
+  FROM public.publishing_api_editions_current
+  WHERE schema_name NOT IN ('gone', 'redirect')
+),
+root AS (
+  SELECT
+    id AS edition_id,
+    '/browse' AS base_path,
+    id AS parent_edition_id,
+    '/browse' AS parent_base_path,
+    1 AS level,
+    [STRUCT(id AS edition_id, '/browse' AS base_path, 1 AS level)] AS ancestors
+  FROM browse_pages
+  WHERE base_path = '/browse'
+),
+top_level_browse_pages AS (
+  SELECT
+    links.target_edition_id AS edition_id,
+    links.target_base_path AS base_path,
+    root.edition_id AS parent_edition_id,
+    root.base_path AS parent_base_path,
+    2 AS level,
+    ARRAY_CONCAT(
+      root.ancestors,
+      [STRUCT(
+        links.target_edition_id AS edition_id,
+        links.target_base_path AS target_base_path,
+        2 AS level
+      )]
+    ) AS ancestors
+  FROM links
+  INNER JOIN root ON root.edition_id = links.source_edition_id
+  INNER JOIN editions ON editions.id = links.target_edition_id
+  WHERE links.type = 'top_level_browse_pages'
+),
+second_level_browse_pages AS (
+  SELECT
+    links.target_edition_id AS edition_id,
+    links.target_base_path AS base_path,
+    top_level_browse_pages.edition_id AS parent_edition_id,
+    top_level_browse_pages.base_path AS parent_base_path,
+    3 AS level,
+    ARRAY_CONCAT(
+      top_level_browse_pages.ancestors,
+      [STRUCT(
+        links.target_edition_id AS edition_id,
+        links.target_base_path AS target_base_path,
+        3 AS level
+      )]
+    ) AS ancestors
+  FROM links
+  INNER JOIN top_level_browse_pages ON top_level_browse_pages.edition_id = links.source_edition_id
+  INNER JOIN editions ON editions.id = links.target_edition_id
+  WHERE links.type = 'second_level_browse_pages'
+),
+leaves AS (
+  SELECT
+    links.source_edition_id AS edition_id,
+    links.source_base_path AS base_path,
+    second_level_browse_pages.edition_id AS parent_edition_id,
+    second_level_browse_pages.base_path AS parent_base_path,
+    4 AS level,
+    second_level_browse_pages.ancestors
+  FROM links
+  INNER JOIN editions ON editions.id = links.source_edition_id
+  INNER JOIN second_level_browse_pages ON second_level_browse_pages.edition_id = links.target_edition_id
+  WHERE links.type = 'mainstream_browse_pages'
+),
+group_links AS (
+  SELECT
+    browse_pages.id AS source_edition_id,
+    editions.id AS target_edition_id,
+    group_index,
+    JSON_VALUE(link_groups, "$.name") AS group_name,
+    page_index
+  FROM browse_pages
+  INNER JOIN second_level_browse_pages ON second_level_browse_pages.edition_id = browse_pages.id
+  CROSS JOIN UNNEST(JSON_QUERY_ARRAY(details, "$.groups")) AS link_groups WITH OFFSET AS group_index
+  CROSS JOIN UNNEST(JSON_VALUE_ARRAY(link_groups, "$.content_ids")) AS group_content_ids WITH OFFSET AS page_index
+  LEFT JOIN editions ON editions.content_id = group_content_ids
+),
+all_pages AS (
+  SELECT * FROM root
+  UNION ALL SELECT * FROM top_level_browse_pages
+  UNION ALL SELECT * FROM second_level_browse_pages
+  UNION ALL SELECT * FROM leaves
+)
+SELECT
+  all_pages.*,
+  group_links.group_index,
+  group_links.group_name,
+  group_links.page_index
+FROM all_pages
+LEFT JOIN group_links ON group_links.source_edition_id = all_pages.parent_edition_id AND group_links.target_edition_id = all_pages.edition_id

--- a/terraform-dev/bigquery/publishing-api-batch.sql
+++ b/terraform-dev/bigquery/publishing-api-batch.sql
@@ -35,3 +35,6 @@ CALL functions.taxonomy();
 
 -- Update the public table of organisations
 CALL functions.organisations();
+
+-- Update the public table of the mainstream browse taxonomy.
+CALL functions.mainstream_browse();

--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -12,7 +12,7 @@ WITH
       AS unpublishings
       ON (unpublishings.edition_id = editions.id)
     WHERE (unpublishings.edition_id IS NULL OR unpublishings.type = 'withdrawal')
-    AND editions.document_type NOT IN ('gone', 'redirect')
+    AND editions.schema_name NOT IN ('gone', 'redirect')
   ),
   links AS (
     SELECT *

--- a/terraform-dev/schemas/public/mainstream-browse.json
+++ b/terraform-dev/schemas/public/mainstream-browse.json
@@ -1,0 +1,60 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "description": "ID of an edition that is a mainstream browse page, or ls linked to from  a mainstream browse page."
+  },
+  {
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "name": "parent_edition_id",
+    "type": "INTEGER",
+    "description": "ID of an edition that links to this edition"
+  },
+  {
+    "name": "parent_base_path",
+    "type": "STRING"
+  },
+  {
+    "name": "level",
+    "type": "INTEGER",
+    "description": "Level 1 is the root of the mainstream browse taxonomy, which is /browse"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ancestors",
+    "type": "RECORD",
+    "description": "Parents of parents back to the root /browse. If this edition is itself a mainstream browse page, then it is included among its ancestors.",
+    "fields": [
+      {
+        "name": "edition_id",
+        "type": "INTEGER"
+      },
+      {
+        "name": "base_path",
+        "type": "STRING"
+      },
+      {
+        "name": "level",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "name": "group_index",
+    "type": "INTEGER",
+    "description": "If the links in the parent page are grouped, then first group is at index 1."
+  },
+  {
+    "name": "group_name",
+    "type": "STRING",
+    "description": "If the links in the parent page are grouped, the heading of the group that includes this page."
+  },
+  {
+    "name": "page_index",
+    "type": "INTEGER",
+    "description": "If the links in the parent page are grouped, the position of this page in its group, starting from 1."
+  }
+]

--- a/terraform-dev/schemas/search/page.json
+++ b/terraform-dev/schemas/search/page.json
@@ -90,6 +90,12 @@
     "description": "Array of titles of taxons that the page is tagged to, and their ancestors"
   },
   {
+    "mode": "REPEATED",
+    "name": "mainstream_browse_topics",
+    "type": "STRING",
+    "description": "Array of titles of mainstream browse topics that the page is tagged to, and their ancestors"
+  },
+  {
     "mode": "NULLABLE",
     "name": "primary_organisation",
     "type": "STRING",

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -185,6 +185,17 @@ resource "google_bigquery_routine" "organisations" {
   )
 }
 
+resource "google_bigquery_routine" "mainstream_browse" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "mainstream_browse"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/public-mainstream-browse.sql",
+    { project_id = var.project_id }
+  )
+}
+
 resource "google_bigquery_routine" "contact_phone_numbers" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "contact_phone_numbers"

--- a/terraform-staging/bigquery/public-mainstream-browse.sql
+++ b/terraform-staging/bigquery/public-mainstream-browse.sql
@@ -1,0 +1,110 @@
+TRUNCATE TABLE public.mainstream_browse;
+INSERT INTO public.mainstream_browse
+WITH
+browse_pages AS (
+  SELECT *
+  FROM `public.publishing_api_editions_current`
+  WHERE schema_name = 'mainstream_browse_page'
+),
+links AS (
+  SELECT *
+  FROM `public.publishing_api_links_current`
+  WHERE type IN ('top_level_browse_pages', 'second_level_browse_pages', 'mainstream_browse_pages')
+),
+editions AS (
+  SELECT
+    id,
+    content_id
+  FROM public.publishing_api_editions_current
+  WHERE schema_name NOT IN ('gone', 'redirect')
+),
+root AS (
+  SELECT
+    id AS edition_id,
+    '/browse' AS base_path,
+    id AS parent_edition_id,
+    '/browse' AS parent_base_path,
+    1 AS level,
+    [STRUCT(id AS edition_id, '/browse' AS base_path, 1 AS level)] AS ancestors
+  FROM browse_pages
+  WHERE base_path = '/browse'
+),
+top_level_browse_pages AS (
+  SELECT
+    links.target_edition_id AS edition_id,
+    links.target_base_path AS base_path,
+    root.edition_id AS parent_edition_id,
+    root.base_path AS parent_base_path,
+    2 AS level,
+    ARRAY_CONCAT(
+      root.ancestors,
+      [STRUCT(
+        links.target_edition_id AS edition_id,
+        links.target_base_path AS target_base_path,
+        2 AS level
+      )]
+    ) AS ancestors
+  FROM links
+  INNER JOIN root ON root.edition_id = links.source_edition_id
+  INNER JOIN editions ON editions.id = links.target_edition_id
+  WHERE links.type = 'top_level_browse_pages'
+),
+second_level_browse_pages AS (
+  SELECT
+    links.target_edition_id AS edition_id,
+    links.target_base_path AS base_path,
+    top_level_browse_pages.edition_id AS parent_edition_id,
+    top_level_browse_pages.base_path AS parent_base_path,
+    3 AS level,
+    ARRAY_CONCAT(
+      top_level_browse_pages.ancestors,
+      [STRUCT(
+        links.target_edition_id AS edition_id,
+        links.target_base_path AS target_base_path,
+        3 AS level
+      )]
+    ) AS ancestors
+  FROM links
+  INNER JOIN top_level_browse_pages ON top_level_browse_pages.edition_id = links.source_edition_id
+  INNER JOIN editions ON editions.id = links.target_edition_id
+  WHERE links.type = 'second_level_browse_pages'
+),
+leaves AS (
+  SELECT
+    links.source_edition_id AS edition_id,
+    links.source_base_path AS base_path,
+    second_level_browse_pages.edition_id AS parent_edition_id,
+    second_level_browse_pages.base_path AS parent_base_path,
+    4 AS level,
+    second_level_browse_pages.ancestors
+  FROM links
+  INNER JOIN editions ON editions.id = links.source_edition_id
+  INNER JOIN second_level_browse_pages ON second_level_browse_pages.edition_id = links.target_edition_id
+  WHERE links.type = 'mainstream_browse_pages'
+),
+group_links AS (
+  SELECT
+    browse_pages.id AS source_edition_id,
+    editions.id AS target_edition_id,
+    group_index,
+    JSON_VALUE(link_groups, "$.name") AS group_name,
+    page_index
+  FROM browse_pages
+  INNER JOIN second_level_browse_pages ON second_level_browse_pages.edition_id = browse_pages.id
+  CROSS JOIN UNNEST(JSON_QUERY_ARRAY(details, "$.groups")) AS link_groups WITH OFFSET AS group_index
+  CROSS JOIN UNNEST(JSON_VALUE_ARRAY(link_groups, "$.content_ids")) AS group_content_ids WITH OFFSET AS page_index
+  LEFT JOIN editions ON editions.content_id = group_content_ids
+),
+all_pages AS (
+  SELECT * FROM root
+  UNION ALL SELECT * FROM top_level_browse_pages
+  UNION ALL SELECT * FROM second_level_browse_pages
+  UNION ALL SELECT * FROM leaves
+)
+SELECT
+  all_pages.*,
+  group_links.group_index,
+  group_links.group_name,
+  group_links.page_index
+FROM all_pages
+LEFT JOIN group_links ON group_links.source_edition_id = all_pages.parent_edition_id AND group_links.target_edition_id = all_pages.edition_id

--- a/terraform-staging/bigquery/publishing-api-batch.sql
+++ b/terraform-staging/bigquery/publishing-api-batch.sql
@@ -35,3 +35,6 @@ CALL functions.taxonomy();
 
 -- Update the public table of organisations
 CALL functions.organisations();
+
+-- Update the public table of the mainstream browse taxonomy.
+CALL functions.mainstream_browse();

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -12,7 +12,7 @@ WITH
       AS unpublishings
       ON (unpublishings.edition_id = editions.id)
     WHERE (unpublishings.edition_id IS NULL OR unpublishings.type = 'withdrawal')
-    AND editions.document_type NOT IN ('gone', 'redirect')
+    AND editions.schema_name NOT IN ('gone', 'redirect')
   ),
   links AS (
     SELECT *

--- a/terraform-staging/schemas/public/mainstream-browse.json
+++ b/terraform-staging/schemas/public/mainstream-browse.json
@@ -1,0 +1,60 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "description": "ID of an edition that is a mainstream browse page, or ls linked to from  a mainstream browse page."
+  },
+  {
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "name": "parent_edition_id",
+    "type": "INTEGER",
+    "description": "ID of an edition that links to this edition"
+  },
+  {
+    "name": "parent_base_path",
+    "type": "STRING"
+  },
+  {
+    "name": "level",
+    "type": "INTEGER",
+    "description": "Level 1 is the root of the mainstream browse taxonomy, which is /browse"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ancestors",
+    "type": "RECORD",
+    "description": "Parents of parents back to the root /browse. If this edition is itself a mainstream browse page, then it is included among its ancestors.",
+    "fields": [
+      {
+        "name": "edition_id",
+        "type": "INTEGER"
+      },
+      {
+        "name": "base_path",
+        "type": "STRING"
+      },
+      {
+        "name": "level",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "name": "group_index",
+    "type": "INTEGER",
+    "description": "If the links in the parent page are grouped, then first group is at index 1."
+  },
+  {
+    "name": "group_name",
+    "type": "STRING",
+    "description": "If the links in the parent page are grouped, the heading of the group that includes this page."
+  },
+  {
+    "name": "page_index",
+    "type": "INTEGER",
+    "description": "If the links in the parent page are grouped, the position of this page in its group, starting from 1."
+  }
+]

--- a/terraform-staging/schemas/search/page.json
+++ b/terraform-staging/schemas/search/page.json
@@ -90,6 +90,12 @@
     "description": "Array of titles of taxons that the page is tagged to, and their ancestors"
   },
   {
+    "mode": "REPEATED",
+    "name": "mainstream_browse_topics",
+    "type": "STRING",
+    "description": "Array of titles of mainstream browse topics that the page is tagged to, and their ancestors"
+  },
+  {
     "mode": "NULLABLE",
     "name": "primary_organisation",
     "type": "STRING",

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -185,6 +185,17 @@ resource "google_bigquery_routine" "organisations" {
   )
 }
 
+resource "google_bigquery_routine" "mainstream_browse" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "mainstream_browse"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/public-mainstream-browse.sql",
+    { project_id = var.project_id }
+  )
+}
+
 resource "google_bigquery_routine" "contact_phone_numbers" {
   dataset_id   = google_bigquery_dataset.functions.dataset_id
   routine_id   = "contact_phone_numbers"

--- a/terraform/bigquery/public-mainstream-browse.sql
+++ b/terraform/bigquery/public-mainstream-browse.sql
@@ -1,0 +1,110 @@
+TRUNCATE TABLE public.mainstream_browse;
+INSERT INTO public.mainstream_browse
+WITH
+browse_pages AS (
+  SELECT *
+  FROM `public.publishing_api_editions_current`
+  WHERE schema_name = 'mainstream_browse_page'
+),
+links AS (
+  SELECT *
+  FROM `public.publishing_api_links_current`
+  WHERE type IN ('top_level_browse_pages', 'second_level_browse_pages', 'mainstream_browse_pages')
+),
+editions AS (
+  SELECT
+    id,
+    content_id
+  FROM public.publishing_api_editions_current
+  WHERE schema_name NOT IN ('gone', 'redirect')
+),
+root AS (
+  SELECT
+    id AS edition_id,
+    '/browse' AS base_path,
+    id AS parent_edition_id,
+    '/browse' AS parent_base_path,
+    1 AS level,
+    [STRUCT(id AS edition_id, '/browse' AS base_path, 1 AS level)] AS ancestors
+  FROM browse_pages
+  WHERE base_path = '/browse'
+),
+top_level_browse_pages AS (
+  SELECT
+    links.target_edition_id AS edition_id,
+    links.target_base_path AS base_path,
+    root.edition_id AS parent_edition_id,
+    root.base_path AS parent_base_path,
+    2 AS level,
+    ARRAY_CONCAT(
+      root.ancestors,
+      [STRUCT(
+        links.target_edition_id AS edition_id,
+        links.target_base_path AS target_base_path,
+        2 AS level
+      )]
+    ) AS ancestors
+  FROM links
+  INNER JOIN root ON root.edition_id = links.source_edition_id
+  INNER JOIN editions ON editions.id = links.target_edition_id
+  WHERE links.type = 'top_level_browse_pages'
+),
+second_level_browse_pages AS (
+  SELECT
+    links.target_edition_id AS edition_id,
+    links.target_base_path AS base_path,
+    top_level_browse_pages.edition_id AS parent_edition_id,
+    top_level_browse_pages.base_path AS parent_base_path,
+    3 AS level,
+    ARRAY_CONCAT(
+      top_level_browse_pages.ancestors,
+      [STRUCT(
+        links.target_edition_id AS edition_id,
+        links.target_base_path AS target_base_path,
+        3 AS level
+      )]
+    ) AS ancestors
+  FROM links
+  INNER JOIN top_level_browse_pages ON top_level_browse_pages.edition_id = links.source_edition_id
+  INNER JOIN editions ON editions.id = links.target_edition_id
+  WHERE links.type = 'second_level_browse_pages'
+),
+leaves AS (
+  SELECT
+    links.source_edition_id AS edition_id,
+    links.source_base_path AS base_path,
+    second_level_browse_pages.edition_id AS parent_edition_id,
+    second_level_browse_pages.base_path AS parent_base_path,
+    4 AS level,
+    second_level_browse_pages.ancestors
+  FROM links
+  INNER JOIN editions ON editions.id = links.source_edition_id
+  INNER JOIN second_level_browse_pages ON second_level_browse_pages.edition_id = links.target_edition_id
+  WHERE links.type = 'mainstream_browse_pages'
+),
+group_links AS (
+  SELECT
+    browse_pages.id AS source_edition_id,
+    editions.id AS target_edition_id,
+    group_index,
+    JSON_VALUE(link_groups, "$.name") AS group_name,
+    page_index
+  FROM browse_pages
+  INNER JOIN second_level_browse_pages ON second_level_browse_pages.edition_id = browse_pages.id
+  CROSS JOIN UNNEST(JSON_QUERY_ARRAY(details, "$.groups")) AS link_groups WITH OFFSET AS group_index
+  CROSS JOIN UNNEST(JSON_VALUE_ARRAY(link_groups, "$.content_ids")) AS group_content_ids WITH OFFSET AS page_index
+  LEFT JOIN editions ON editions.content_id = group_content_ids
+),
+all_pages AS (
+  SELECT * FROM root
+  UNION ALL SELECT * FROM top_level_browse_pages
+  UNION ALL SELECT * FROM second_level_browse_pages
+  UNION ALL SELECT * FROM leaves
+)
+SELECT
+  all_pages.*,
+  group_links.group_index,
+  group_links.group_name,
+  group_links.page_index
+FROM all_pages
+LEFT JOIN group_links ON group_links.source_edition_id = all_pages.parent_edition_id AND group_links.target_edition_id = all_pages.edition_id

--- a/terraform/bigquery/publishing-api-batch.sql
+++ b/terraform/bigquery/publishing-api-batch.sql
@@ -35,3 +35,6 @@ CALL functions.taxonomy();
 
 -- Update the public table of organisations
 CALL functions.organisations();
+
+-- Update the public table of the mainstream browse taxonomy.
+CALL functions.mainstream_browse();

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -12,7 +12,7 @@ WITH
       AS unpublishings
       ON (unpublishings.edition_id = editions.id)
     WHERE (unpublishings.edition_id IS NULL OR unpublishings.type = 'withdrawal')
-    AND editions.document_type NOT IN ('gone', 'redirect')
+    AND editions.schema_name NOT IN ('gone', 'redirect')
   ),
   links AS (
     SELECT *

--- a/terraform/schemas/public/mainstream-browse.json
+++ b/terraform/schemas/public/mainstream-browse.json
@@ -1,0 +1,60 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "description": "ID of an edition that is a mainstream browse page, or ls linked to from  a mainstream browse page."
+  },
+  {
+    "name": "base_path",
+    "type": "STRING"
+  },
+  {
+    "name": "parent_edition_id",
+    "type": "INTEGER",
+    "description": "ID of an edition that links to this edition"
+  },
+  {
+    "name": "parent_base_path",
+    "type": "STRING"
+  },
+  {
+    "name": "level",
+    "type": "INTEGER",
+    "description": "Level 1 is the root of the mainstream browse taxonomy, which is /browse"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ancestors",
+    "type": "RECORD",
+    "description": "Parents of parents back to the root /browse. If this edition is itself a mainstream browse page, then it is included among its ancestors.",
+    "fields": [
+      {
+        "name": "edition_id",
+        "type": "INTEGER"
+      },
+      {
+        "name": "base_path",
+        "type": "STRING"
+      },
+      {
+        "name": "level",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "name": "group_index",
+    "type": "INTEGER",
+    "description": "If the links in the parent page are grouped, then first group is at index 1."
+  },
+  {
+    "name": "group_name",
+    "type": "STRING",
+    "description": "If the links in the parent page are grouped, the heading of the group that includes this page."
+  },
+  {
+    "name": "page_index",
+    "type": "INTEGER",
+    "description": "If the links in the parent page are grouped, the position of this page in its group, starting from 1."
+  }
+]


### PR DESCRIPTION
- Derive the Mainstream Browse taxonomy into the table
  public.mainstream_browse
- Update the docs about how to write queries, with examples of using
  that table
- Derive a complete ancestry per page, and include it in the table
  search.page
