### PR TITLE
fix: GovSearch link search didn't find all links

### DIFF
--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -102,8 +102,8 @@ taxons AS (
 all_links AS (
   SELECT
     links.type AS link_type,
-    editions.base_path,
-    "https://www.gov.uk" || editions.base_path as link_url
+    links.source_base_path AS base_path,
+    "https://www.gov.uk" || links.target_base_path as link_url
   FROM links
   INNER JOIN editions ON editions.id = links.source_edition_id
   WHERE editions.base_path IS NOT NULL

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -102,8 +102,8 @@ taxons AS (
 all_links AS (
   SELECT
     links.type AS link_type,
-    editions.base_path,
-    "https://www.gov.uk" || editions.base_path as link_url
+    links.source_base_path AS base_path,
+    "https://www.gov.uk" || links.target_base_path as link_url
   FROM links
   INNER JOIN editions ON editions.id = links.source_edition_id
   WHERE editions.base_path IS NOT NULL

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -102,8 +102,8 @@ taxons AS (
 all_links AS (
   SELECT
     links.type AS link_type,
-    editions.base_path,
-    "https://www.gov.uk" || editions.base_path as link_url
+    links.source_base_path AS base_path,
+    "https://www.gov.uk" || links.target_base_path as link_url
   FROM links
   INNER JOIN editions ON editions.id = links.source_edition_id
   WHERE editions.base_path IS NOT NULL


### PR DESCRIPTION
Links such as related links (ones in the side bar) weren't returned in
search results because the query put the source URL into the table,
instead of the target URL.
