### PR TITLE
fix: support a new column in Publishing API table

### DIFF
--- a/terraform-dev/bigquery/publishing-api-editions-current.sql
+++ b/terraform-dev/bigquery/publishing-api-editions-current.sql
@@ -81,7 +81,8 @@ SELECT *
       publishing_api_first_published_at,
       publishing_api_last_edited_at,
       auth_bypass_ids,
-      is_online
+      is_online,
+      last_edited_by_editor_id
     )
     REPLACE (
       IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,

--- a/terraform-dev/schemas/private/publishing-api-editions-new-current.json
+++ b/terraform-dev/schemas/private/publishing-api-editions-new-current.json
@@ -156,6 +156,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "last_edited_by_editor_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "unpublishing_type",
     "type": "STRING"
   },

--- a/terraform-dev/schemas/publishing-api/editions.json
+++ b/terraform-dev/schemas/publishing-api/editions.json
@@ -143,5 +143,10 @@
     "mode": "NULLABLE",
     "name": "redirects",
     "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_by_editor_id",
+    "type": "STRING"
   }
 ]

--- a/terraform-staging/bigquery/publishing-api-editions-current.sql
+++ b/terraform-staging/bigquery/publishing-api-editions-current.sql
@@ -81,7 +81,8 @@ SELECT *
       publishing_api_first_published_at,
       publishing_api_last_edited_at,
       auth_bypass_ids,
-      is_online
+      is_online,
+      last_edited_by_editor_id
     )
     REPLACE (
       IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,

--- a/terraform-staging/schemas/private/publishing-api-editions-new-current.json
+++ b/terraform-staging/schemas/private/publishing-api-editions-new-current.json
@@ -156,6 +156,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "last_edited_by_editor_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "unpublishing_type",
     "type": "STRING"
   },

--- a/terraform-staging/schemas/publishing-api/editions.json
+++ b/terraform-staging/schemas/publishing-api/editions.json
@@ -143,5 +143,10 @@
     "mode": "NULLABLE",
     "name": "redirects",
     "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_by_editor_id",
+    "type": "STRING"
   }
 ]

--- a/terraform/bigquery/publishing-api-editions-current.sql
+++ b/terraform/bigquery/publishing-api-editions-current.sql
@@ -81,7 +81,8 @@ SELECT *
       publishing_api_first_published_at,
       publishing_api_last_edited_at,
       auth_bypass_ids,
-      is_online
+      is_online,
+      last_edited_by_editor_id
     )
     REPLACE (
       IF(unpublishing_type IN ('redirect', 'gone'), unpublishing_type, document_type) AS document_type,

--- a/terraform/schemas/private/publishing-api-editions-new-current.json
+++ b/terraform/schemas/private/publishing-api-editions-new-current.json
@@ -156,6 +156,11 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "last_edited_by_editor_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "unpublishing_type",
     "type": "STRING"
   },

--- a/terraform/schemas/publishing-api/editions.json
+++ b/terraform/schemas/publishing-api/editions.json
@@ -143,5 +143,10 @@
     "mode": "NULLABLE",
     "name": "redirects",
     "type": "JSON"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_edited_by_editor_id",
+    "type": "STRING"
   }
 ]


### PR DESCRIPTION
The editions table in the upstream Publishing API database has a new column, `last_edited_by_editor_id`, created in https://github.com/alphagov/publishing-api/pull/2919. This broke the data pipeline, because the BigQuery schema of that table rejected the new column.

The new column contains sensitive data, so it is only included in tables in the `publishing-api` and `private` datasets, which most users cannot access. It is explicitly omitted from the query that puts the data into more accessible datasets.
