### PR TITLE
Use staging backups in staging and prod

### DIFF
--- a/diff-exclude
+++ b/diff-exclude
@@ -2,4 +2,3 @@ environment.auto.tfvars
 backend.tf
 .terraform
 .terraform.lock.hcl
-pubsub.tf

--- a/terraform-staging/pubsub.tf
+++ b/terraform-staging/pubsub.tf
@@ -1,5 +1,5 @@
 resource "google_pubsub_topic" "govuk_integration_database_backups" {
-  name                       = "govuk-integration-database-backups"
+  name                       = "govuk-database-backups"
   message_retention_duration = "604800s" # 604800 seconds is 7 days
   message_storage_policy {
     allowed_persistence_regions = [
@@ -25,7 +25,7 @@ resource "google_pubsub_topic_iam_policy" "govuk_integration_database_backups" {
 
 # Subscribe to the topic
 resource "google_pubsub_subscription" "govuk_integration_database_backups" {
-  name  = "govuk-integration-database-backups"
+  name  = "govuk-database-backups"
   topic = google_pubsub_topic.govuk_integration_database_backups.name
 
   message_retention_duration = "604800s" # 604800 seconds is 7 days

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -1,5 +1,5 @@
 resource "google_pubsub_topic" "govuk_integration_database_backups" {
-  name                       = "govuk-integration-database-backups"
+  name                       = "govuk-database-backups"
   message_retention_duration = "604800s" # 604800 seconds is 7 days
   message_storage_policy {
     allowed_persistence_regions = [
@@ -25,7 +25,7 @@ resource "google_pubsub_topic_iam_policy" "govuk_integration_database_backups" {
 
 # Subscribe to the topic
 resource "google_pubsub_subscription" "govuk_integration_database_backups" {
-  name  = "govuk-integration-database-backups"
+  name  = "govuk-database-backups"
   topic = google_pubsub_topic.govuk_integration_database_backups.name
 
   message_retention_duration = "604800s" # 604800 seconds is 7 days


### PR DESCRIPTION
This follows on from #717, and uses the GOV.UK staging backups in the knowledgegraph staging / production environments.

This PR initially targets the `use-staging-backups` branch rather than `main`, so we can either merge this first and have it update #717, or we can merge #717 and this will retarget main automatically.