### PR TITLE
chore: upgrade MongoDB docker image for publisher

### DIFF
--- a/docker/publisher/Dockerfile
+++ b/docker/publisher/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.4.16
+FROM mongo:8.0.4
 
 # Install gcloud
 # https://cloud.google.com/sdk/docs/install#deb

--- a/src/publisher/query.js
+++ b/src/publisher/query.js
@@ -10,7 +10,7 @@ db.editions.aggregate([
   { $match: { "state": { $in: [ "published", "archived" ] } } },
   { $project: {
     _id: false,
-    "url": { "$concat": [ "https://www.gov.uk/", "$slug" ] },
+    "url": { "$concat": [ "https://www.gov.uk/", { "$ifNull": [ "$slug", "" ] } ] },
     // created_at: true, // when the edition was first drafted
     updated_at: true, // almost but not quite the same time as the updated_at of the corresponding edition in the Publishing API.
     version_number: true, // sequence, sometimes in a different order from updated_at e.g. /1619-bursary-fund

--- a/src/publisher/run.sh
+++ b/src/publisher/run.sh
@@ -6,7 +6,7 @@
 set -m
 
 # Start mongo and put it in the background
-mongod --nojournal &
+mongod --fork --syslog
 
 # Wait for mongo to start
 sleep 5
@@ -42,7 +42,7 @@ TABLE="${DATASET}.${FILE}"
 
 # Create a dataset in mongodb of relevant metadata about relevant editions of
 # documents.
-mongo ${DATABASE} ${QUERY}
+mongosh ${DATABASE} ${QUERY}
 
 # 1. Export that dataset
 # 2. Upload it to a cloud bucket


### PR DESCRIPTION
`apt-get update` now fails in the docker image of MongoDB version 4.4.16 due to an expired signing key. That version of MongoDB is no longer supported, so the signing key is unlikely to be replaced. Upgrading to a newer docker image solves this problem.

Version compatibility check:

* We only need the package `mongodb-database-tools`, which is versioned independently of MongoDB. The version of `mongodb-database-tools` that comes in the Docker image of the latest version of MongoDB is 100.11.0.

* According to https://www.mongodb.com/docs/database-tools/mongorestore/mongorestore-compatibility-and-installation/#mongodb-server-compatibility `mongodb-database-tools` version 100.10.0 is compatible with MongoDB versions 5.0 and 4.0, so we presume that version 100.11.0 maintains that compatibility.

* The publisher database backup file is created by AWS DocumentDB, which according to https://docs.aws.amazon.com/documentdb/latest/developerguide/compatibility.html is compatible with MongoDB version 5.0 and 4.0.
