### PR TITLE
feat: Import the Support API database

### DIFF
--- a/.github/workflows/docker-support-api-dev.yml
+++ b/.github/workflows/docker-support-api-dev.yml
@@ -1,0 +1,72 @@
+name: Docker-support-api-dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/support-api/**'
+      - '.github/workflows/docker-support-api-dev.yml'
+
+defaults:
+  run:
+    working-directory: docker/support-api
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'support-api'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-dev.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-support-api-staging.yml
+++ b/.github/workflows/docker-support-api-staging.yml
@@ -1,0 +1,72 @@
+name: Docker-support-api-staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/support-api/**'
+      - '.github/workflows/docker-support-api-staging.yml'
+
+defaults:
+  run:
+    working-directory: docker/support-api
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'support-api'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph-staging.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-support-api.yml
+++ b/.github/workflows/docker-support-api.yml
@@ -1,0 +1,72 @@
+name: Docker-support-api
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/support-api/**'
+      - '.github/workflows/docker-support-api.yml'
+
+defaults:
+  run:
+    working-directory: docker/support-api
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'support-api'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v3'
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+        service_account: 'artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+    # Further steps are automatically authenticated
+
+    # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
+    # Configure docker to use the gcloud command-line tool as a credential helper
+    - run: |
+        # Set up docker to authenticate
+        # via gcloud command-line tool.
+        gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+    # Build the Docker image
+    - name: Docker build
+      id: build
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+
+    # Push the Docker image to Google Container Registry
+    - name: Docker push
+      id: push
+      run: |
+        export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+        echo $TAG
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+        docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+        docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,6 +17,11 @@ backup of the Publisher app database, and imports it into BigQuery.
 For a virtual machine in GCE (Google Compute Engine).  It extracts data from a
 backup of the Publshing API database, and imports it into BigQuery.
 
+# [`support-api`][support-api]
+
+For a virtual machine in GCE (Google Compute Engine).  It extracts data from a
+backup of the support API database, and imports it into BigQuery.
+
 # [`redis-cli`][redis-cli]
 
 For a virtual machine in GCE (Google Compute Engine) that is used occasionally
@@ -27,4 +32,5 @@ state.
 [html-to-text]: ./html-to-text
 [publisher]: ./publisher
 [publishing-api]: ./publisher-api
+[support-api]: ./support-api
 [redis-cli]: ./redis-cli

--- a/docker/support-api/Dockerfile
+++ b/docker/support-api/Dockerfile
@@ -1,0 +1,35 @@
+FROM postgres:16.0-alpine3.18
+
+# Install the gcloud CLI, a specific version from a long-term archive
+# Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
+# Also install make, and GNU sed (for Q command) and coreutils (for faster wc)
+ENV CLOUD_SDK_VERSION=452.0.1
+ENV PATH /google-cloud-sdk/bin:$PATH
+RUN addgroup -g 1000 -S cloudsdk && \
+    adduser -u 1000 -S cloudsdk -G cloudsdk
+RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
+RUN ARCH=`cat /tmp/arch` && apk --no-cache add \
+        sed \
+        coreutils \
+        curl \
+        python3 \
+        py3-crcmod \
+        py3-openssl \
+        bash \
+        libc6-compat \
+        openssh-client \
+        gnupg \
+        make \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
+
+# Reset the postgres entrypoint to the docker default, so that we can run our
+# own CMD
+ENTRYPOINT []
+COPY entrypoint.sh .
+CMD bash entrypoint.sh

--- a/docker/support-api/README.md
+++ b/docker/support-api/README.md
@@ -1,0 +1,28 @@
+# Virtual machine to import Support API data into BigQuery
+
+The Support API database is backed up daily to files in AWS S3, which are copied into a GCP bucket by the [`govuk-s3-mirror`][govuk-s3-mirror].
+
+This VM runs scripts that fetch the backup file, extract each table as plain text, and upload them into BigQuery tables.  It runs on a PostgreSQL image that is isued only for the `pg_restore` command.  There is no need to restore the backup to an actual running database.
+
+## Build the image
+
+This folder only contains the `Dockerfile` and `entrypoint.sh`. A GitHub action rebuilds the image when these files are changed, and pushes it to the Artifact Registry.
+
+The rest of the code is in [`src/support-api`][src].  When the VM starts, the `entrypoint.sh` script fetches that code and runs it.  This separation avoids having to rebuild the docker image when only changing the code that it runs.
+
+## Trigger the VM to start
+
+When the [govuk-s3-mirror][govuk-s3-mirror] finishes copying any file into its GCP bucket, it publishes a message to Pub/Sub channel.  This project subscribes to that channel. A [workflow][workflow] reads the messages, and if they describe a file whose name fits the pattern for Support API database backups, then it starts an instance of this virtual machine.
+
+### Manually start the VM
+
+Open a recent, successful [workflow-run][workflow-runs].  Its state will be `return_started_support_api: Succeeded`.  Click "Execute again" and then "Execute".  This will run the workflow with the last input, which was a message that carried the information that the VM needs to find the Support API database backup file.
+
+If the most recent successful workflow run was a few days ago, then the Support API database backup file that it responded to might have been deleted.  In this case, make a new copy of any of the Support API database backup files that do exist in the [bucket][bucket].  Doing so will create a new message in Pub/Sub, which will soon trigger the workflow to start the VM.
+
+[govuk-s3-mirror]: https://github.com/alphagov/govuk-s3-mirror
+[bucket]: https://console.cloud.google.com/storage/browser/govuk-s3-mirror_govuk-database-backups/support-api-postgres
+[workflow-terraform]: ../../terraform/workflows/govuk-database-backups.yaml
+[workflow-runs]: https://console.cloud.google.com/workflows/workflow/europe-west2/govuk-database-backups/executions?project=govuk-knowledge-graph&pli=1
+[src]: ../../src/support-api
+[github-action]: ../../.github/workflows/docker-support-api.yml

--- a/docker/support-api/entrypoint.sh
+++ b/docker/support-api/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Run a script from a copy of the HEAD of the repository
+# This sometimes fails with
+#
+# > ERROR: (gcloud.storage.cat) You do not currently have an active account selected.
+#
+# So retry for a few minutes.  Newly-built containers don't seem to work
+# immediately.
+
+MAX_RETRIES=10
+RETRY_INTERVAL_SECONDS=60
+COUNTER=0
+CMD="gcloud storage cat gs://${PROJECT_ID}-repository/src/support-api/run.sh"
+
+while [ $COUNTER -lt $MAX_RETRIES ]; do
+  $CMD
+  if [ $? -eq 0 ]; then
+    break
+  else
+    echo "Command failed, retrying in ${RETRY_INTERVAL_SECONDS} seconds..."
+    sleep $RETRY_INTERVAL_SECONDS
+    let COUNTER=COUNTER+1
+  fi
+done
+
+if [ $COUNTER -eq $MAX_RETRIES ]; then
+  echo "Command failed after $MAX_RETRIES attempts, exiting..."
+  exit 1
+fi
+
+$CMD | bash

--- a/src/support-api/Makefile
+++ b/src/support-api/Makefile
@@ -1,0 +1,21 @@
+SHELL := /bin/bash
+
+# Parallelise with all cores, if possible
+NPROCS = $(shell grep -c 'processor' /proc/cpuinfo)
+MAKEFLAGS += -j$(NPROCS)
+
+# Names of tables in the postgres database to export to Cloud Storage
+# and BigQuery
+EXPORT = anonymous_contacts archived_service_feedbacks
+
+# A step to create all the targets described in the CSV.GZ and BIGQUERY
+# variables, which means that all the .sh and .sql scripts in the SH and
+# BIGQUERY variables will be executed.
+.PHONY: all
+all: $(EXPORT)
+
+anonymous_contacts:
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@
+
+archived_service_feedbacks:
+	source functions.sh; export_to_bigquery backup_name=${FILE_PATH} table_name=$@

--- a/src/support-api/README.md
+++ b/src/support-api/README.md
@@ -1,0 +1,58 @@
+# Import Support API data into BigQuery
+
+The Support API database is backed up daily to files in AWS S3, which are copied into a GCP bucket by the [`govuk-s3-mirror`][govuk-s3-mirror].
+
+A virtual machine fetches the scripts in this directory from the copy of the HEAD of this repository that is synced to a [bucket][bucket], and runs [`run.sh`][run.sh], which initiates the following steps.
+
+1. Fetch the Support API database backup file.  It knows where to find it from environment variables that are set when the [workflow][workflow-terraform] starts the virtual machine ([more details][docker]).
+2. Use `pg_restore` to extract each table's data as plain text.  There is no need to actually restore the data to a running PostgreSQL instance.
+3. `TRUNCATE` (empty) each table in BigQuery.
+4. Append the new data to each table in BigQuery.  By truncating/appending, BigQuery retains the schema of each table.
+
+A Makefile is used to parallelise the tasks.
+
+## Dockerfile
+
+The [Docker configuration][docker] is separate, so that changes to the code here don't cause the image to be rebuilt unnecessarily.  When the virtual machine starts, it fetches [`run.sh`][run.sh] from the copy of the HEAD of this repository that is synced to a [bucket][bucket].
+
+## Test locally
+
+Local testing is difficult, because the Support API database is large.  It can be easier to do the following:
+
+1. Add a line to [`run.sh`][run.sh] `tail -f /dev/null` before the command that deletes the virtual machine.
+2. Upload your modified copy of [run.sh].
+3. [Manually start the VM][docker-readme].
+4. SSH into the VM.
+
+### SSH into a VM
+
+Once a VM instance is running, you can SSH into it from your local device, in the
+terminal.
+
+```sh
+# SSH into the instance
+gcloud compute ssh \
+  --zone "europe-west2-b" \
+  "support-api" \
+  --project "govuk-knowledge-graph"
+
+# Wait a while for the docker image to start (about 30 seconds to a minute)
+
+# Get the ID of the docker image.  For example, `klt--ulug`.
+docker ps
+
+# Tail the logs of the mongodb docker image
+docker logs -tf klt--ofyk
+
+# Tail the logs of the postgres docker image
+docker logs -tf klt--ofyk
+
+# Otherwise, SSH directly from your device into the docker image
+gcloud compute ssh --zone "europe-west2-b" "support-api" --project "govuk-knowledge-graph" -- container "klt--ulug"
+```
+
+[bucket]: https://console.cloud.google.com/storage/browser/govuk-knowledge-graph-repository
+[docker]: ../../docker/support-api
+[docker-readme]: ../../docker/support-api/README.md
+[run.sh]: ./run.sh
+[workflow-terraform]: ../../terraform/workflows/govuk-database-backups.yaml

--- a/src/support-api/functions.sh
+++ b/src/support-api/functions.sh
@@ -1,0 +1,67 @@
+#! /bin/bash
+
+# Export a table from a pg_dump file, upload to storage and import into BigQuery
+#
+# Usage:
+# query_bigquery backup_name=name_of_db_backup_file table_name=name_of_table_in_postgres
+export_to_bigquery () {
+  # reset variables in case they are defined globally
+  local backup_name
+  local table_name
+  local "${@}"
+
+  # Export data to the SSD, which is mapped to /data
+  tsv_name="/data/table_${table_name}"
+  dataset_name="support_api"
+
+  # We have to use uncompressed CSV for the largest table, so we might as well
+  # use it for the others too.
+  # BigQuery can't deal with compressed CSVs larger than 4GB.  The largest table
+  # is 19GB when compressed.
+  # Alternatively we could use Parquet (via DuckDB) but BigQuery can't cope with
+  # values larger than 10MiB in any particular column, and the largest page has
+  # 11302027 bytes (>10MiB) in the `details` column.
+  # /hmrc-internal-manuals/customs-authorisation-and-approval/caa08030
+  # https://webarchive.nationalarchives.gov.uk/ukgwa/20211120003440/https://www.gov.uk/hmrc-internal-manuals/customs-authorisation-and-approval/caa08030
+  # The DuckDB max_line_size parameter defaults to 2 MiB, which would eliminate
+  # those rows before they break BigQuery, but DuckDB stops with an error
+  # instead of ignoring those lines.
+  # The command gcloud bq load has options for ignoring bad lines, but they
+  # don't work for parquet.
+  # Finally, BigQuery does in fact seem to allow values larger than 10MiB, as
+  # long as they come from uncompressed CSV files.  So that's what we use.
+  # What a palaver.  "Big" Query, huh.
+
+  # Dump the table
+  #
+  # pg_restore emits SQL statements, which can be trimmed to resemble
+  # tab-separated values. Lines up to and including a COPY
+  # statement are discarded. Following lines are retained until a line that has
+  # only a backslash and a full stop.  That line and following lines are
+  # discarded. Lines that are retained are modified to unescape escaped
+  # backslashes, i.e. replace \\ with \.
+  pg_restore \
+    -U postgres \
+    --no-owner \
+    --data-only \
+    --file=- \
+    --table=$table_name \
+    $backup_name \
+    | sed -e '1,/^COPY/d' \
+    | sed -e 's/\\\\/\\/g' \
+    | sed -e '/^\\\./Q' \
+    > $tsv_name
+
+  # Empty the table
+  bq query --use_legacy_sql=false "TRUNCATE TABLE ${dataset_name}.${table_name}"
+
+  bq load \
+    --source_format="CSV" \
+    --field_delimiter="\t" \
+    --null_marker="\\N" \
+    --quote="" \
+    --skip_leading_rows=1 \
+    --noreplace \
+    "${dataset_name}.${table_name}" \
+    "${tsv_name}"
+}

--- a/src/support-api/run.sh
+++ b/src/support-api/run.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Obtain the latest state of the repository
+gcloud storage cp -r "gs://${PROJECT_ID}-repository/*" .
+
+# turn on bash's job control
+set -m
+
+# Fetch the Support API database backup file from GCP Storage
+BUCKET=$(
+  gcloud compute instances describe support-api \
+    --project $PROJECT_ID \
+    --zone $ZONE \
+    --format="value(metadata.items.object_bucket)"
+)
+OBJECT=$(
+gcloud compute instances describe support-api \
+  --project $PROJECT_ID \
+  --zone $ZONE \
+  --format="value(metadata.items.object_name)"
+)
+OBJECT_URL="gs://$BUCKET/$OBJECT"
+# Export a variable so that the Makefile can use it
+export FILE_PATH="/data/$OBJECT"
+
+# https://stackoverflow.com/questions/6575221
+gcloud storage cp "$OBJECT_URL" "$FILE_PATH"
+
+# Check that the file size is larger than an arbitrary size of 2GiB.
+# Typically they are about 27GiB.
+# On 2023-03-03 the database backup files had a problem and were only a few
+# megabytes.
+minimumsize=2147483648
+actualsize=$(wc -c <"$FILE_PATH")
+if [ $actualsize -le $minimumsize ]; then
+  # Turn this instance off and exit.  The data that is currrently in BigQuery
+  # will remain there.
+  gcloud compute instances delete support-api --quiet --zone=$ZONE
+  exit 1
+fi
+
+# pg_dump each table into a file, upload it to BigQuery, and delete the file.
+#
+# Use a Makefile to do this in parallel.
+#
+# Two cores are sufficient, because the editions table takes longer than all the
+# other tables together.
+cd src/support-api
+make
+
+# Stop this instance
+# https://stackoverflow.com/a/41232669
+gcloud compute instances delete support-api --quiet --zone=$ZONE

--- a/terraform-dev/artifact-registry.tf
+++ b/terraform-dev/artifact-registry.tf
@@ -57,6 +57,7 @@ data "google_iam_policy" "artifact_registry_docker" {
     role = "roles/artifactregistry.reader"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
     ]

--- a/terraform-dev/bigquery-scheduled-queries.tf
+++ b/terraform-dev/bigquery-scheduled-queries.tf
@@ -17,3 +17,14 @@ resource "google_bigquery_data_transfer_config" "publishing_api_batch" {
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
+
+resource "google_bigquery_data_transfer_config" "support_api_batch" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Support API batch"
+  location       = var.region
+  schedule       = "every day 00:00"
+  params = {
+    query = file("bigquery/support-api-batch.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform-dev/bigquery-support-api.tf
+++ b/terraform-dev/bigquery-support-api.tf
@@ -1,0 +1,57 @@
+# A dataset of tables from the Publishing API postgres database
+
+resource "google_bigquery_dataset" "support_api" {
+  dataset_id            = "support_api"
+  friendly_name         = "Support API"
+  description           = "Data from the GOV.UK Support API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_support_api" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_support_api.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_support_api_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "support_api" {
+  dataset_id  = google_bigquery_dataset.support_api.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_support_api.policy_data
+}
+
+resource "google_bigquery_table" "support_api_anonymous_contacts" {
+  dataset_id    = google_bigquery_dataset.support_api.dataset_id
+  table_id      = "anonymous_contacts"
+  friendly_name = "Anonymous contacts"
+  description   = "Contact tickets (anonymous, long-form), problem reports (collected at the bottom of a page), service feedback (rating out of 5, and what could be improved)"
+  schema        = file("schemas/support-api/anonymous-contacts.json")
+}
+
+resource "google_bigquery_table" "support_api_archived_service_feedbacks" {
+  dataset_id    = google_bigquery_dataset.support_api.dataset_id
+  table_id      = "archived_service_feedbacks"
+  friendly_name = "Archived service feedback"
+  description   = "Service feedback (rating out of 5, and what could be improved)"
+  schema        = file("schemas/support-api/archived-service-feedbacks.json")
+}

--- a/terraform-dev/bigquery/support-api-batch.sql
+++ b/terraform-dev/bigquery/support-api-batch.sql
@@ -1,0 +1,2 @@
+-- Call a sequence of routines that process updated documents from the
+-- Support API database.

--- a/terraform-dev/bigquery/tables-metadata.sql
+++ b/terraform-dev/bigquery/tables-metadata.sql
@@ -13,6 +13,8 @@ WITH tables AS (
   UNION ALL
   SELECT * FROM publishing_api.__TABLES__
   UNION ALL
+  SELECT * FROM support_api.__TABLES__
+  UNION ALL
   SELECT * FROM search.__TABLES__
 )
 SELECT

--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -67,6 +67,10 @@ bigquery_graph_data_viewer_members = [
 bigquery_publishing_api_data_viewer_members = [
 ]
 
+# BigQuery dataset: support-api
+bigquery_support_api_data_viewer_members = [
+]
+
 # BigQuery dataset: search
 bigquery_search_data_viewer_members = [
 ]

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -160,6 +160,10 @@ variable "bigquery_publishing_api_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_support_api_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_search_data_viewer_members" {
   type = list(string)
 }
@@ -289,6 +293,7 @@ data "google_iam_policy" "project" {
         google_service_account.bigquery_scheduled_queries.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_publishing_api.member,
+        google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
         google_service_account.govgraphsearch.member,
       ],
@@ -357,6 +362,7 @@ data "google_iam_policy" "project" {
     role = "roles/compute.instanceAdmin.v1"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member

--- a/terraform-dev/schemas/support-api/anonymous-contacts.json
+++ b/terraform-dev/schemas/support-api/anonymous-contacts.json
@@ -1,0 +1,112 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "what_doing",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "what_wrong",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page_owner",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_agent",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "referrer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "javascript_enabled",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "personal_information_status",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "service_satisfaction_rating",
+    "type": "INTEGER"
+  },
+    {
+    "mode": "NULLABLE",
+    "name": "user_specified_url",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_actionable",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reason_why_not_actionable",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_item_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "marked_as_spam",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reviewed",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform-dev/schemas/support-api/archived-service-feedbacks.json
+++ b/terraform-dev/schemas/support-api/archived-service-feedbacks.json
@@ -1,0 +1,32 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "service_satisfaction_rating",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  }
+]

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -48,6 +48,7 @@ data "google_iam_policy" "bucket_repository" {
     role = "roles/storage.objectViewer"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
     ]
   }

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -22,6 +22,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       zone                          = var.zone
       postgres_startup_script       = jsonencode(var.postgres-startup-script)
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)
+      support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
     }
   )

--- a/terraform-dev/workflows/govuk-database-backups.yaml
+++ b/terraform-dev/workflows/govuk-database-backups.yaml
@@ -62,6 +62,35 @@ main:
                           value: ${publishing_api_metadata_value}
           - return_started_publishing_api:
               return: $${"Started publishing-api instance"}
+        - condition: $${text.match_regex(object_name, "^support-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-support_contacts_production\\.gz$")}
+          steps:
+          - log_starting_support_api_instance:
+              call: sys.log
+              args:
+                  text: "Starting support-api instance"
+                  severity: INFO
+          - start_support_api:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/support-api
+                  body:
+                      name: support-api
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: user-data
+                          value: ${postgres_startup_script}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${support_api_metadata_value}
+          - return_started_support_api:
+              return: $${"Started support-api instance"}
         - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
           steps:
           - log_starting_publisher_instance:

--- a/terraform-staging/artifact-registry.tf
+++ b/terraform-staging/artifact-registry.tf
@@ -57,6 +57,7 @@ data "google_iam_policy" "artifact_registry_docker" {
     role = "roles/artifactregistry.reader"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
     ]

--- a/terraform-staging/backend.tf
+++ b/terraform-staging/backend.tf
@@ -3,6 +3,6 @@
 # https://github.com/hashicorp/terraform/issues/13022
 terraform {
   backend "gcs" {
-    bucket = "govuk-knowledge-graph-staging-tfstate" # Change this (keep the -tfstate suffix)
+    bucket = "govuk-knowledge-graph-dev-tfstate" # Change this (keep the -tfstate suffix)
   }
 }

--- a/terraform-staging/bigquery-scheduled-queries.tf
+++ b/terraform-staging/bigquery-scheduled-queries.tf
@@ -17,3 +17,14 @@ resource "google_bigquery_data_transfer_config" "publishing_api_batch" {
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
+
+resource "google_bigquery_data_transfer_config" "support_api_batch" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Support API batch"
+  location       = var.region
+  schedule       = "every day 00:00"
+  params = {
+    query = file("bigquery/support-api-batch.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform-staging/bigquery-support-api.tf
+++ b/terraform-staging/bigquery-support-api.tf
@@ -1,0 +1,57 @@
+# A dataset of tables from the Publishing API postgres database
+
+resource "google_bigquery_dataset" "support_api" {
+  dataset_id            = "support_api"
+  friendly_name         = "Support API"
+  description           = "Data from the GOV.UK Support API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_support_api" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_support_api.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_support_api_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "support_api" {
+  dataset_id  = google_bigquery_dataset.support_api.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_support_api.policy_data
+}
+
+resource "google_bigquery_table" "support_api_anonymous_contacts" {
+  dataset_id    = google_bigquery_dataset.support_api.dataset_id
+  table_id      = "anonymous_contacts"
+  friendly_name = "Anonymous contacts"
+  description   = "Contact tickets (anonymous, long-form), problem reports (collected at the bottom of a page), service feedback (rating out of 5, and what could be improved)"
+  schema        = file("schemas/support-api/anonymous-contacts.json")
+}
+
+resource "google_bigquery_table" "support_api_archived_service_feedbacks" {
+  dataset_id    = google_bigquery_dataset.support_api.dataset_id
+  table_id      = "archived_service_feedbacks"
+  friendly_name = "Archived service feedback"
+  description   = "Service feedback (rating out of 5, and what could be improved)"
+  schema        = file("schemas/support-api/archived-service-feedbacks.json")
+}

--- a/terraform-staging/bigquery/support-api-batch.sql
+++ b/terraform-staging/bigquery/support-api-batch.sql
@@ -1,0 +1,2 @@
+-- Call a sequence of routines that process updated documents from the
+-- Support API database.

--- a/terraform-staging/bigquery/tables-metadata.sql
+++ b/terraform-staging/bigquery/tables-metadata.sql
@@ -13,6 +13,8 @@ WITH tables AS (
   UNION ALL
   SELECT * FROM publishing_api.__TABLES__
   UNION ALL
+  SELECT * FROM support_api.__TABLES__
+  UNION ALL
   SELECT * FROM search.__TABLES__
 )
 SELECT

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -65,8 +65,12 @@ bigquery_functions_data_viewer_members = [
 bigquery_graph_data_viewer_members = [
 ]
 
-# BigQuery dataset: publishing
+# BigQuery dataset: publishing-api
 bigquery_publishing_api_data_viewer_members = [
+]
+
+# BigQuery dataset: support-api
+bigquery_support_api_data_viewer_members = [
 ]
 
 # BigQuery dataset: search

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -160,6 +160,10 @@ variable "bigquery_publishing_api_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_support_api_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_search_data_viewer_members" {
   type = list(string)
 }
@@ -289,6 +293,7 @@ data "google_iam_policy" "project" {
         google_service_account.bigquery_scheduled_queries.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_publishing_api.member,
+        google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
         google_service_account.govgraphsearch.member,
       ],
@@ -357,6 +362,7 @@ data "google_iam_policy" "project" {
     role = "roles/compute.instanceAdmin.v1"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member

--- a/terraform-staging/schemas/support-api/anonymous-contacts.json
+++ b/terraform-staging/schemas/support-api/anonymous-contacts.json
@@ -1,0 +1,112 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "what_doing",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "what_wrong",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page_owner",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_agent",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "referrer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "javascript_enabled",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "personal_information_status",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "service_satisfaction_rating",
+    "type": "INTEGER"
+  },
+    {
+    "mode": "NULLABLE",
+    "name": "user_specified_url",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_actionable",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reason_why_not_actionable",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_item_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "marked_as_spam",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reviewed",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform-staging/schemas/support-api/archived-service-feedbacks.json
+++ b/terraform-staging/schemas/support-api/archived-service-feedbacks.json
@@ -1,0 +1,32 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "service_satisfaction_rating",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  }
+]

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -48,6 +48,7 @@ data "google_iam_policy" "bucket_repository" {
     role = "roles/storage.objectViewer"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
     ]
   }

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -22,6 +22,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       zone                          = var.zone
       postgres_startup_script       = jsonencode(var.postgres-startup-script)
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)
+      support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
     }
   )

--- a/terraform-staging/workflows/govuk-database-backups.yaml
+++ b/terraform-staging/workflows/govuk-database-backups.yaml
@@ -62,6 +62,35 @@ main:
                           value: ${publishing_api_metadata_value}
           - return_started_publishing_api:
               return: $${"Started publishing-api instance"}
+        - condition: $${text.match_regex(object_name, "^support-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-support_contacts_production\\.gz$")}
+          steps:
+          - log_starting_support_api_instance:
+              call: sys.log
+              args:
+                  text: "Starting support-api instance"
+                  severity: INFO
+          - start_support_api:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/support-api
+                  body:
+                      name: support-api
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: user-data
+                          value: ${postgres_startup_script}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${support_api_metadata_value}
+          - return_started_support_api:
+              return: $${"Started support-api instance"}
         - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
           steps:
           - log_starting_publisher_instance:

--- a/terraform/artifact-registry.tf
+++ b/terraform/artifact-registry.tf
@@ -57,6 +57,7 @@ data "google_iam_policy" "artifact_registry_docker" {
     role = "roles/artifactregistry.reader"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
     ]

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -3,6 +3,6 @@
 # https://github.com/hashicorp/terraform/issues/13022
 terraform {
   backend "gcs" {
-    bucket = "govuk-knowledge-graph-tfstate" # Change this (keep the -tfstate suffix)
+    bucket = "govuk-knowledge-graph-dev-tfstate" # Change this (keep the -tfstate suffix)
   }
 }

--- a/terraform/bigquery-scheduled-queries.tf
+++ b/terraform/bigquery-scheduled-queries.tf
@@ -17,3 +17,14 @@ resource "google_bigquery_data_transfer_config" "publishing_api_batch" {
   }
   service_account_name = google_service_account.bigquery_scheduled_queries.email
 }
+
+resource "google_bigquery_data_transfer_config" "support_api_batch" {
+  data_source_id = "scheduled_query" # This is a magic word
+  display_name   = "Support API batch"
+  location       = var.region
+  schedule       = "every day 00:00"
+  params = {
+    query = file("bigquery/support-api-batch.sql")
+  }
+  service_account_name = google_service_account.bigquery_scheduled_queries.email
+}

--- a/terraform/bigquery-support-api.tf
+++ b/terraform/bigquery-support-api.tf
@@ -1,0 +1,57 @@
+# A dataset of tables from the Publishing API postgres database
+
+resource "google_bigquery_dataset" "support_api" {
+  dataset_id            = "support_api"
+  friendly_name         = "Support API"
+  description           = "Data from the GOV.UK Support API database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_support_api" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_support_api.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_support_api_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "support_api" {
+  dataset_id  = google_bigquery_dataset.support_api.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_support_api.policy_data
+}
+
+resource "google_bigquery_table" "support_api_anonymous_contacts" {
+  dataset_id    = google_bigquery_dataset.support_api.dataset_id
+  table_id      = "anonymous_contacts"
+  friendly_name = "Anonymous contacts"
+  description   = "Contact tickets (anonymous, long-form), problem reports (collected at the bottom of a page), service feedback (rating out of 5, and what could be improved)"
+  schema        = file("schemas/support-api/anonymous-contacts.json")
+}
+
+resource "google_bigquery_table" "support_api_archived_service_feedbacks" {
+  dataset_id    = google_bigquery_dataset.support_api.dataset_id
+  table_id      = "archived_service_feedbacks"
+  friendly_name = "Archived service feedback"
+  description   = "Service feedback (rating out of 5, and what could be improved)"
+  schema        = file("schemas/support-api/archived-service-feedbacks.json")
+}

--- a/terraform/bigquery/support-api-batch.sql
+++ b/terraform/bigquery/support-api-batch.sql
@@ -1,0 +1,2 @@
+-- Call a sequence of routines that process updated documents from the
+-- Support API database.

--- a/terraform/bigquery/tables-metadata.sql
+++ b/terraform/bigquery/tables-metadata.sql
@@ -13,6 +13,8 @@ WITH tables AS (
   UNION ALL
   SELECT * FROM publishing_api.__TABLES__
   UNION ALL
+  SELECT * FROM support_api.__TABLES__
+  UNION ALL
   SELECT * FROM search.__TABLES__
 )
 SELECT

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -78,10 +78,14 @@ bigquery_graph_data_viewer_members = [
   "serviceAccount:govuk-looker-poc@govuk-looker-poc.iam.gserviceaccount.com",
 ]
 
-# BigQuery dataset: publishing
+# BigQuery dataset: publishing-api
 bigquery_publishing_api_data_viewer_members = [
   "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk",
   "serviceAccount:service-419945323196@gcp-sa-dataform.iam.gserviceaccount.com",
+]
+
+# BigQuery dataset: support-api
+bigquery_support_api_data_viewer_members = [
 ]
 
 # BigQuery dataset: search

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -160,6 +160,10 @@ variable "bigquery_publishing_api_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_support_api_data_viewer_members" {
+  type = list(string)
+}
+
 variable "bigquery_search_data_viewer_members" {
   type = list(string)
 }
@@ -289,6 +293,7 @@ data "google_iam_policy" "project" {
         google_service_account.bigquery_scheduled_queries.member,
         google_service_account.bigquery_scheduled_queries_search.member,
         google_service_account.gce_publishing_api.member,
+        google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
         google_service_account.govgraphsearch.member,
       ],
@@ -357,6 +362,7 @@ data "google_iam_policy" "project" {
     role = "roles/compute.instanceAdmin.v1"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member

--- a/terraform/schemas/support-api/anonymous-contacts.json
+++ b/terraform/schemas/support-api/anonymous-contacts.json
@@ -1,0 +1,112 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "what_doing",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "what_wrong",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "details",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page_owner",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "user_agent",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "referrer",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "javascript_enabled",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "personal_information_status",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "service_satisfaction_rating",
+    "type": "INTEGER"
+  },
+    {
+    "mode": "NULLABLE",
+    "name": "user_specified_url",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_actionable",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reason_why_not_actionable",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "path",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "content_item_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "marked_as_spam",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reviewed",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform/schemas/support-api/archived-service-feedbacks.json
+++ b/terraform/schemas/support-api/archived-service-feedbacks.json
@@ -1,0 +1,32 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "service_satisfaction_rating",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  }
+]

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -48,6 +48,7 @@ data "google_iam_policy" "bucket_repository" {
     role = "roles/storage.objectViewer"
     members = [
       google_service_account.gce_publishing_api.member,
+      google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
     ]
   }

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -22,6 +22,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       zone                          = var.zone
       postgres_startup_script       = jsonencode(var.postgres-startup-script)
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)
+      support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
     }
   )

--- a/terraform/workflows/govuk-database-backups.yaml
+++ b/terraform/workflows/govuk-database-backups.yaml
@@ -62,6 +62,35 @@ main:
                           value: ${publishing_api_metadata_value}
           - return_started_publishing_api:
               return: $${"Started publishing-api instance"}
+        - condition: $${text.match_regex(object_name, "^support-api-postgres/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-support_contacts_production\\.gz$")}
+          steps:
+          - log_starting_support_api_instance:
+              call: sys.log
+              args:
+                  text: "Starting support-api instance"
+                  severity: INFO
+          - start_support_api:
+              call: googleapis.compute.v1.instances.insert
+              args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/support-api
+                  body:
+                      name: support-api
+                      metadata:
+                        items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: user-data
+                          value: ${postgres_startup_script}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${support_api_metadata_value}
+          - return_started_support_api:
+              return: $${"Started support-api instance"}
         - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_content_production\\.gz$")}
           steps:
           - log_starting_publisher_instance:


### PR DESCRIPTION
This is a database of some of the ways that users can give feedback.

* Contact tickets (anonymous, long-form)
* Problem reports (collected at the bottom of a page)
* Service feedback (rating out of 5, and what could be improved)

As soon as possible after merging and `terraform apply`, merge and apply https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/736 to allow the service accounts to access the database backup file in S3.