### PR TITLE
fix: redeploy functions on change to source code

### DIFF
--- a/terraform-dev/parse-html.tf
+++ b/terraform-dev/parse-html.tf
@@ -35,6 +35,13 @@ resource "google_cloudfunctions2_function" "parse_html" {
     max_instance_count = 100
     # max_instance_request_concurrency = 1
   }
+
+  # https://github.com/hashicorp/terraform-provider-google/issues/1938#issuecomment-1229042663
+  lifecycle {
+    replace_triggered_by = [
+      google_storage_bucket_object.parse_html
+    ]
+  }
 }
 
 data "google_iam_policy" "cloud_function_parse_html" {

--- a/terraform-staging/parse-html.tf
+++ b/terraform-staging/parse-html.tf
@@ -35,6 +35,13 @@ resource "google_cloudfunctions2_function" "parse_html" {
     max_instance_count = 100
     # max_instance_request_concurrency = 1
   }
+
+  # https://github.com/hashicorp/terraform-provider-google/issues/1938#issuecomment-1229042663
+  lifecycle {
+    replace_triggered_by = [
+      google_storage_bucket_object.parse_html
+    ]
+  }
 }
 
 data "google_iam_policy" "cloud_function_parse_html" {

--- a/terraform/parse-html.tf
+++ b/terraform/parse-html.tf
@@ -35,6 +35,13 @@ resource "google_cloudfunctions2_function" "parse_html" {
     max_instance_count = 100
     # max_instance_request_concurrency = 1
   }
+
+  # https://github.com/hashicorp/terraform-provider-google/issues/1938#issuecomment-1229042663
+  lifecycle {
+    replace_triggered_by = [
+      google_storage_bucket_object.parse_html
+    ]
+  }
 }
 
 data "google_iam_policy" "cloud_function_parse_html" {


### PR DESCRIPTION
When changing a function's source code (usually due to dependabot),
`terraform apply` doesn't redploy the function. This is a problem that
Google isn't in a hurry to fix, so this is an attempt to work around it
with terraform's lifecycle rules.

https://github.com/hashicorp/terraform-provider-google/issues/1938#issuecomment-1229042663
