### PR TITLE
chore: upgrade terraform google provider

### DIFF
--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -359,6 +359,7 @@ resource "google_compute_backend_service" "govgraphsearch" {
     group = google_compute_region_network_endpoint_group.govgraphsearch_eg.self_link
   }
   iap {
+    enabled = var.enable_auth
     oauth2_client_id     = data.google_secret_manager_secret_version.iap_oauth_client_id.secret_data
     oauth2_client_secret = data.google_secret_manager_secret_version.iap_oauth_client_secret.secret_data
   }

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -175,7 +175,7 @@ variable "bigquery_test_data_viewer_members" {
 terraform {
   required_providers {
     google = {
-      version = "5.15.0"
+      version = "6.20.0"
     }
   }
 }

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -359,6 +359,7 @@ resource "google_compute_backend_service" "govgraphsearch" {
     group = google_compute_region_network_endpoint_group.govgraphsearch_eg.self_link
   }
   iap {
+    enabled = var.enable_auth
     oauth2_client_id     = data.google_secret_manager_secret_version.iap_oauth_client_id.secret_data
     oauth2_client_secret = data.google_secret_manager_secret_version.iap_oauth_client_secret.secret_data
   }

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -175,7 +175,7 @@ variable "bigquery_test_data_viewer_members" {
 terraform {
   required_providers {
     google = {
-      version = "5.15.0"
+      version = "6.20.0"
     }
   }
 }

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -359,6 +359,7 @@ resource "google_compute_backend_service" "govgraphsearch" {
     group = google_compute_region_network_endpoint_group.govgraphsearch_eg.self_link
   }
   iap {
+    enabled = var.enable_auth
     oauth2_client_id     = data.google_secret_manager_secret_version.iap_oauth_client_id.secret_data
     oauth2_client_secret = data.google_secret_manager_secret_version.iap_oauth_client_secret.secret_data
   }

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -175,7 +175,7 @@ variable "bigquery_test_data_viewer_members" {
 terraform {
   required_providers {
     google = {
-      version = "5.15.0"
+      version = "6.20.0"
     }
   }
 }


### PR DESCRIPTION
A boolean flag is now required to control whether IAP is enabled. We
already have a variable for this, which isn't being used.
