### PR TITLE
fix: duplicates in search.page

### DIFF
--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -236,7 +236,7 @@ LEFT JOIN phone_numbers ON phone_numbers.edition_id = pages.edition_id
 LEFT JOIN taxons ON taxons.edition_id = pages.edition_id
 LEFT JOIN people ON people.edition_id = pages.edition_id -- includes the slug of parts
 -- one publisher_updated_at per multipart document
-LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url, publisher_updated_at.url)
+LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url || "/", publisher_updated_at.url || "/")
 LEFT JOIN public.content -- one row per document or part
   ON content.base_path = pages.base_path -- includes the slug of parts
 LEFT JOIN interpage_links

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -236,7 +236,7 @@ LEFT JOIN phone_numbers ON phone_numbers.edition_id = pages.edition_id
 LEFT JOIN taxons ON taxons.edition_id = pages.edition_id
 LEFT JOIN people ON people.edition_id = pages.edition_id -- includes the slug of parts
 -- one publisher_updated_at per multipart document
-LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url, publisher_updated_at.url)
+LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url || "/", publisher_updated_at.url || "/")
 LEFT JOIN public.content -- one row per document or part
   ON content.base_path = pages.base_path -- includes the slug of parts
 LEFT JOIN interpage_links

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -236,7 +236,7 @@ LEFT JOIN phone_numbers ON phone_numbers.edition_id = pages.edition_id
 LEFT JOIN taxons ON taxons.edition_id = pages.edition_id
 LEFT JOIN people ON people.edition_id = pages.edition_id -- includes the slug of parts
 -- one publisher_updated_at per multipart document
-LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url, publisher_updated_at.url)
+LEFT JOIN publisher_updated_at ON STARTS_WITH(pages.url || "/", publisher_updated_at.url || "/")
 LEFT JOIN public.content -- one row per document or part
   ON content.base_path = pages.base_path -- includes the slug of parts
 LEFT JOIN interpage_links


### PR DESCRIPTION
The join between Publishing API editions and Publisher editions created duplicates, because it the approximate match `STARTS_WITH()` joined different URLs, such as:

```text
https://www.gov.uk/absenoldeb-a-thal-ar-y-cyd-i-rieni-canllaw-i-gyflogwyr`
https://www.gov.uk/absenoldeb-a-thal-ar-y-cyd-i-rieni`
```

This fix terminates each URL in the join with "/" so that only complete slugs will match, such as:

```text
https://www.gov.uk/absenoldeb-a-thal-ar-y-cyd-i-rieni-canllaw-i-gyflogwyr/cymhwystra/
https://www.gov.uk/absenoldeb-a-thal-ar-y-cyd-i-rieni-canllaw-i-gyflogwyr/
```

The purpose of matching with `STARTS_WITH()` is to handle sections of `guide` and `travel_advice` documents, which each have their own URL in the `search.page` table, but are only represented by their top-level URL in the `publisher.editions` table.
