### PR TITLE
refactor: truncate/load data within a transaction

### DIFF
--- a/src/publishing-api/README.md
+++ b/src/publishing-api/README.md
@@ -6,8 +6,8 @@ A virtual machine fetches the scripts in this directory from the copy of the HEA
 
 1. Fetch the Publishing API database backup file.  It knows where to find it from environment variables that are set when the [workflow][workflow-terraform] starts the virtual machine ([more details][docker]).
 2. Use `pg_restore` to extract each table's data as plain text.  There is no need to actually restore the data to a running PostgreSQL instance.
-3. `TRUNCATE` (empty) each table in BigQuery.
-4. Append the new data to each table in BigQuery.  By truncating/appending, BigQuery retains the schema of each table.
+2. Use `pg_restore` to extract each table's data as plain text.  There is no need to actually restore the data to a running PostgreSQL instance.
+4. Upload the data into BigQuery.
 
 In March 2024 this took about 65 minutes.  A Makefile is used to parallelise the tasks.  The `editions` table takes longer than all the others put together, so there is no point using a machine with more than two cores.
 

--- a/src/publishing-api/functions.sh
+++ b/src/publishing-api/functions.sh
@@ -12,6 +12,8 @@ export_to_bigquery () {
 
   # Export data to the SSD, which is mapped to /data
   tsv_name="/data/table_${table_name}"
+
+  schema_name="schema_${table_name}"
   dataset_name="publishing_api"
 
   # We have to use uncompressed CSV for the largest table, so we might as well
@@ -52,9 +54,18 @@ export_to_bigquery () {
     | sed -e '/^\\\./Q' \
     > $tsv_name
 
-  # Empty the table
-  bq query --use_legacy_sql=false "TRUNCATE TABLE ${dataset_name}.${table_name}"
+  # Download the existing schema
+  bq show \
+    --schema=true \
+    --format=json \
+    "${dataset_name}.${table_name}" \
+    > $schema_name
 
+  # Load data into the the table, using the "write disposition", which is
+  # equivalent to WRITE_TRUNCATE in SQL. It empties the table and wipes its
+  # schema, before inserting new rows. This is done within a transaction. We
+  # preserve the schema by downloading it first with `bq show`, and then using
+  # it as an argument to `bq load`.
   bq load \
     --source_format="CSV" \
     --field_delimiter="\t" \
@@ -62,6 +73,7 @@ export_to_bigquery () {
     --quote="" \
     --skip_leading_rows=1 \
     --noreplace \
+    --schema="${schema_name}" \
     "${dataset_name}.${table_name}" \
     "${tsv_name}"
 }

--- a/src/support-api/README.md
+++ b/src/support-api/README.md
@@ -6,8 +6,7 @@ A virtual machine fetches the scripts in this directory from the copy of the HEA
 
 1. Fetch the Support API database backup file.  It knows where to find it from environment variables that are set when the [workflow][workflow-terraform] starts the virtual machine ([more details][docker]).
 2. Use `pg_restore` to extract each table's data as plain text.  There is no need to actually restore the data to a running PostgreSQL instance.
-3. `TRUNCATE` (empty) each table in BigQuery.
-4. Append the new data to each table in BigQuery.  By truncating/appending, BigQuery retains the schema of each table.
+4. Upload the data into BigQuery.
 
 A Makefile is used to parallelise the tasks.
 


### PR DESCRIPTION
Closes #742. This could have been done this way in the first place, because there is no need to have a the schema in a JSON file in GitHub. The schema can be exported from BigQuery just before uploading the new data.