### PR TITLE
fix: truncate, don't append

### DIFF
--- a/src/publishing-api/functions.sh
+++ b/src/publishing-api/functions.sh
@@ -72,7 +72,7 @@ export_to_bigquery () {
     --null_marker="\\N" \
     --quote="" \
     --skip_leading_rows=1 \
-    --noreplace \
+    --replace=true \
     --schema="${schema_name}" \
     "${dataset_name}.${table_name}" \
     "${tsv_name}"

--- a/src/support-api/functions.sh
+++ b/src/support-api/functions.sh
@@ -72,7 +72,7 @@ export_to_bigquery () {
     --null_marker="\\N" \
     --quote="" \
     --skip_leading_rows=1 \
-    --noreplace \
+    --replace=true \
     --schema="${schema_name}" \
     "${dataset_name}.${table_name}" \
     "${tsv_name}"


### PR DESCRIPTION
Fixes #758, which left the `noreplace` argument in by mistake.
