### PR TITLE
feat: Update service account access

### DIFF
--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -48,6 +48,7 @@ bigquery_private_data_viewer_members = [
 # BigQuery dataset: public
 bigquery_public_data_viewer_members = [
   "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk"
+  "serviceAccount:service-942729121218@gcp-sa-dataform.iam.gserviceaccount.com",
 ]
 
 bigquery_content_data_viewer_members = [
@@ -81,7 +82,7 @@ bigquery_graph_data_viewer_members = [
 # BigQuery dataset: publishing-api
 bigquery_publishing_api_data_viewer_members = [
   "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk",
-  "serviceAccount:service-419945323196@gcp-sa-dataform.iam.gserviceaccount.com",
+  "serviceAccount:service-942729121218@gcp-sa-dataform.iam.gserviceaccount.com",
 ]
 
 # BigQuery dataset: support-api
@@ -91,7 +92,7 @@ bigquery_support_api_data_viewer_members = [
 # BigQuery dataset: search
 bigquery_search_data_viewer_members = [
   "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk",
-  "serviceAccount:service-419945323196@gcp-sa-dataform.iam.gserviceaccount.com",
+  "serviceAccount:service-942729121218@gcp-sa-dataform.iam.gserviceaccount.com",
   "serviceAccount:wif-govgraph-bigquery-access@govuk-llm-question-answering.iam.gserviceaccount.com",
   "serviceAccount:wif-vectorstore@govuk-llm-question-answering.iam.gserviceaccount.com",
 ]


### PR DESCRIPTION
A new service account replaces an old one. It calculates metrics for the
publishing pipeline.
