### PR TITLE
Adding that ability to return the number of images or tables on a page

### DIFF
--- a/docker/parse-html/README.md
+++ b/docker/parse-html/README.md
@@ -7,6 +7,10 @@ extracted from the HTML, in the form that BigQuery expects (JSON).
   cleaned-up version of their URL, and the text that they display).
 * `abbreviations`: an array of objects that describe abbreviations (the
   abbreviation, and the thing that is abbreviated).
+* `tables`: an array of objects that describe tables. Currently it only
+  includes a string of HTML.
+* `images`: an array of objects that describe images. Currently it includes the
+  URL of the image, and its alt text.
 
 ## BigQuery Remote Functions
 

--- a/docker/parse-html/app.rb
+++ b/docker/parse-html/app.rb
@@ -30,6 +30,8 @@ end
 def parse_html(html, url)
   hyperlinks = []
   abbreviations = []
+  images = []
+  tables = []
 
   begin
     Timeout.timeout(TIMEOUT_SECONDS) do
@@ -37,6 +39,9 @@ def parse_html(html, url)
       # Extract things from the rendered HTML
       hyperlinks = extract_hyperlinks(html_doc, url)
       abbreviations = extract_abbreviations(html_doc)
+      images = extract_image(html_doc)
+      tables = extract_table(html_doc)
+
 
       # TODO: extract other things from the HTML
     rescue Timeout::Error
@@ -49,6 +54,8 @@ def parse_html(html, url)
   {
     "hyperlinks" => hyperlinks,
     "abbreviations" => abbreviations,
+    "images" => images,
+    "tables" => tables,
     "error" => error_message,
   }
 end
@@ -123,4 +130,30 @@ def extract_abbreviations(html_doc)
   end
 
   abbreviations
+end
+
+def extract_image(html_doc)
+  images = []
+
+  html_doc.css("img").each do |images|
+    images.push({
+      "title" => images.attribute("title"), # Expansion
+      "text" => images.text, # Images
+    })
+  end
+
+  images
+end
+
+def extract_table(html_doc)
+  tables = []
+
+  html_doc.css("table").each do |tables|
+    tables.push({
+      "title" => tables.attribute("title"), # Expansion
+      "text" => tables.text, # Tables
+    })
+  end
+
+  tables
 end

--- a/docker/parse-html/app.rb
+++ b/docker/parse-html/app.rb
@@ -163,10 +163,9 @@ def extract_tables(html_doc)
 
   html_doc.css("table").each do |table|
     tables.push({
-      "html" => table.to_s # html string of the table tag
+      "html" => table.to_s, # html string of the table tag
     })
   end
 
   tables
 end
-

--- a/docker/parse-html/app.rb
+++ b/docker/parse-html/app.rb
@@ -39,9 +39,8 @@ def parse_html(html, url)
       # Extract things from the rendered HTML
       hyperlinks = extract_hyperlinks(html_doc, url)
       abbreviations = extract_abbreviations(html_doc)
-      images = extract_image(html_doc)
-      tables = extract_table(html_doc)
-
+      tables = extract_tables(html_doc)
+      images = extract_images(html_doc)
 
       # TODO: extract other things from the HTML
     rescue Timeout::Error
@@ -54,8 +53,8 @@ def parse_html(html, url)
   {
     "hyperlinks" => hyperlinks,
     "abbreviations" => abbreviations,
-    "images" => images,
     "tables" => tables,
+    "images" => images,
     "error" => error_message,
   }
 end
@@ -132,28 +131,42 @@ def extract_abbreviations(html_doc)
   abbreviations
 end
 
-def extract_image(html_doc)
+# A function to extract <img> elements from a parsed HTML document.
+#
+# Returns an array of hashes, one per <img> element. Each hash contains a "src"
+# key, with a string value that is the URL of the image, and an
+# "alt" key, with a string value that is the alt-text of the image.
+#
+# @param html_doc A nokokiri HTML document
+# @param url [String] URL of the HTML document
+def extract_images(html_doc)
   images = []
 
-  html_doc.css("img").each do |images|
+  html_doc.css("img").each do |img|
     images.push({
-      "title" => images.attribute("title"), # Expansion
-      "text" => images.text, # Images
+      "src" => img.attribute("src").to_s,
+      "alt" => img.attribute("alt").to_s,
     })
   end
 
   images
 end
 
-def extract_table(html_doc)
+# A function to extract <table> elements from a parsed HTML document.
+#
+# Returns an array of hashes, one per <table> element. Each hash contains a
+# "table" key, with a string value that is the HTML of the table.
+#
+# @param html_doc A nokokiri HTML document
+def extract_tables(html_doc)
   tables = []
 
-  html_doc.css("table").each do |tables|
+  html_doc.css("table").each do |table|
     tables.push({
-      "title" => tables.attribute("title"), # Expansion
-      "text" => tables.text, # Tables
+      "html" => table.to_s # html string of the table tag
     })
   end
 
   tables
 end
+

--- a/docker/parse-html/spec/app_spec.rb
+++ b/docker/parse-html/spec/app_spec.rb
@@ -146,4 +146,29 @@ describe "parse_html() function" do
       })
     end
   end
+
+  it "extracts tables" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<table>",
+        "",
+      ]])
+      expect(response.body[0]["tables"][0]).to eq({
+        "html" => "<table></table>",
+      })
+    end
+  end
+
+  it "extracts images" do
+    load_temporary "app.rb" do
+      response = request([[
+        "<img src=\"example.png\" alt=\"Example\"/>",
+        "https://www.gov.uk",
+      ]])
+      expect(response.body[0]["images"][0]).to eq({
+        "src" => "example.png",
+        "alt" => "Example",
+      })
+    end
+  end
 end

--- a/terraform-dev/bigquery/extract-content-from-editions.sql
+++ b/terraform-dev/bigquery/extract-content-from-editions.sql
@@ -304,7 +304,26 @@ SELECT
         )
       FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.abbreviations")) AS abbreviation
     )
-  ) AS abbreviations
+  ) AS abbreviations,
+  `${project_id}.functions.dedup`(
+    ARRAY(
+      SELECT
+        STRUCT(
+          JSON_EXTRACT_SCALAR(single_table, "$.html") AS html
+        )
+      FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.tables")) AS single_table
+    )
+  ) AS tables,
+  `${project_id}.functions.dedup`(
+    ARRAY(
+      SELECT
+        STRUCT(
+          JSON_EXTRACT_SCALAR(image, "$.src") AS src,
+          JSON_EXTRACT_SCALAR(image, "$.alt") AS alt
+        )
+      FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.images")) AS image
+    )
+  ) AS images
 FROM extracts
 ;
 

--- a/terraform-dev/schemas/public/content-new.json
+++ b/terraform-dev/schemas/public/content-new.json
@@ -117,5 +117,36 @@
         "description": "The abbreviated form"
       }
     ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "tables",
+    "type": "RECORD",
+    "description": "Array of tables from the body of the page, i.e. <table> tags",
+    "fields": [
+      {
+        "name": "html",
+        "type": "STRING",
+        "description": "HTML of the table"
+      }
+    ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "images",
+    "type": "RECORD",
+    "description": "Array of images from the body of the page, i.e. <img> tags",
+    "fields": [
+      {
+        "name": "src",
+        "type": "STRING",
+        "description": "The URL of the image"
+      },
+      {
+        "name": "alt",
+        "type": "STRING",
+        "description": "Alt text of the image (the <img alt=\"example\"> attribute)"
+      }
+    ]
   }
 ]

--- a/terraform-dev/schemas/public/content.json
+++ b/terraform-dev/schemas/public/content.json
@@ -119,5 +119,36 @@
         "description": "The abbreviated form"
       }
     ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "tables",
+    "type": "RECORD",
+    "description": "Array of tables from the body of the page, i.e. <table> tags",
+    "fields": [
+      {
+        "name": "html",
+        "type": "STRING",
+        "description": "HTML of the table"
+      }
+    ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "images",
+    "type": "RECORD",
+    "description": "Array of images from the body of the page, i.e. <img> tags",
+    "fields": [
+      {
+        "name": "src",
+        "type": "STRING",
+        "description": "The URL of the image"
+      },
+      {
+        "name": "alt",
+        "type": "STRING",
+        "description": "Alt text of the image (the <img alt=\"example\"> attribute)"
+      }
+    ]
   }
 ]

--- a/terraform-staging/bigquery/extract-content-from-editions.sql
+++ b/terraform-staging/bigquery/extract-content-from-editions.sql
@@ -304,7 +304,26 @@ SELECT
         )
       FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.abbreviations")) AS abbreviation
     )
-  ) AS abbreviations
+  ) AS abbreviations,
+  `${project_id}.functions.dedup`(
+    ARRAY(
+      SELECT
+        STRUCT(
+          JSON_EXTRACT_SCALAR(single_table, "$.html") AS html
+        )
+      FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.tables")) AS single_table
+    )
+  ) AS tables,
+  `${project_id}.functions.dedup`(
+    ARRAY(
+      SELECT
+        STRUCT(
+          JSON_EXTRACT_SCALAR(image, "$.src") AS src,
+          JSON_EXTRACT_SCALAR(image, "$.alt") AS alt
+        )
+      FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.images")) AS image
+    )
+  ) AS images
 FROM extracts
 ;
 

--- a/terraform-staging/schemas/public/content-new.json
+++ b/terraform-staging/schemas/public/content-new.json
@@ -117,5 +117,36 @@
         "description": "The abbreviated form"
       }
     ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "tables",
+    "type": "RECORD",
+    "description": "Array of tables from the body of the page, i.e. <table> tags",
+    "fields": [
+      {
+        "name": "html",
+        "type": "STRING",
+        "description": "HTML of the table"
+      }
+    ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "images",
+    "type": "RECORD",
+    "description": "Array of images from the body of the page, i.e. <img> tags",
+    "fields": [
+      {
+        "name": "src",
+        "type": "STRING",
+        "description": "The URL of the image"
+      },
+      {
+        "name": "alt",
+        "type": "STRING",
+        "description": "Alt text of the image (the <img alt=\"example\"> attribute)"
+      }
+    ]
   }
 ]

--- a/terraform-staging/schemas/public/content.json
+++ b/terraform-staging/schemas/public/content.json
@@ -119,5 +119,36 @@
         "description": "The abbreviated form"
       }
     ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "tables",
+    "type": "RECORD",
+    "description": "Array of tables from the body of the page, i.e. <table> tags",
+    "fields": [
+      {
+        "name": "html",
+        "type": "STRING",
+        "description": "HTML of the table"
+      }
+    ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "images",
+    "type": "RECORD",
+    "description": "Array of images from the body of the page, i.e. <img> tags",
+    "fields": [
+      {
+        "name": "src",
+        "type": "STRING",
+        "description": "The URL of the image"
+      },
+      {
+        "name": "alt",
+        "type": "STRING",
+        "description": "Alt text of the image (the <img alt=\"example\"> attribute)"
+      }
+    ]
   }
 ]

--- a/terraform/bigquery/extract-content-from-editions.sql
+++ b/terraform/bigquery/extract-content-from-editions.sql
@@ -304,7 +304,26 @@ SELECT
         )
       FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.abbreviations")) AS abbreviation
     )
-  ) AS abbreviations
+  ) AS abbreviations,
+  `${project_id}.functions.dedup`(
+    ARRAY(
+      SELECT
+        STRUCT(
+          JSON_EXTRACT_SCALAR(single_table, "$.html") AS html
+        )
+      FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.tables")) AS single_table
+    )
+  ) AS tables,
+  `${project_id}.functions.dedup`(
+    ARRAY(
+      SELECT
+        STRUCT(
+          JSON_EXTRACT_SCALAR(image, "$.src") AS src,
+          JSON_EXTRACT_SCALAR(image, "$.alt") AS alt
+        )
+      FROM UNNEST(JSON_EXTRACT_ARRAY(extracted_content, "$.images")) AS image
+    )
+  ) AS images
 FROM extracts
 ;
 

--- a/terraform/schemas/public/content-new.json
+++ b/terraform/schemas/public/content-new.json
@@ -117,5 +117,36 @@
         "description": "The abbreviated form"
       }
     ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "tables",
+    "type": "RECORD",
+    "description": "Array of tables from the body of the page, i.e. <table> tags",
+    "fields": [
+      {
+        "name": "html",
+        "type": "STRING",
+        "description": "HTML of the table"
+      }
+    ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "images",
+    "type": "RECORD",
+    "description": "Array of images from the body of the page, i.e. <img> tags",
+    "fields": [
+      {
+        "name": "src",
+        "type": "STRING",
+        "description": "The URL of the image"
+      },
+      {
+        "name": "alt",
+        "type": "STRING",
+        "description": "Alt text of the image (the <img alt=\"example\"> attribute)"
+      }
+    ]
   }
 ]

--- a/terraform/schemas/public/content.json
+++ b/terraform/schemas/public/content.json
@@ -119,5 +119,36 @@
         "description": "The abbreviated form"
       }
     ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "tables",
+    "type": "RECORD",
+    "description": "Array of tables from the body of the page, i.e. <table> tags",
+    "fields": [
+      {
+        "name": "html",
+        "type": "STRING",
+        "description": "HTML of the table"
+      }
+    ]
+  },
+  {
+    "mode": "REPEATED",
+    "name": "images",
+    "type": "RECORD",
+    "description": "Array of images from the body of the page, i.e. <img> tags",
+    "fields": [
+      {
+        "name": "src",
+        "type": "STRING",
+        "description": "The URL of the image"
+      },
+      {
+        "name": "alt",
+        "type": "STRING",
+        "description": "Alt text of the image (the <img alt=\"example\"> attribute)"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adding two new functions following the structure of the extract_abbreviation functions as they best seem to match with is needed

Please check that the attributes and text for the returned tables and images in the functions work and at they are real attributes for the elements