### PR TITLE
fix: don't use local SSD for publishing-api

### DIFF
--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -158,35 +158,7 @@ module "publishing-api-container" {
         value = var.zone
       }
     ]
-    volumeMounts = [
-      {
-        mountPath = "/var/lib/postgresql/data"
-        name      = "local-ssd-postgresql-data"
-        readOnly  = false
-      },
-      {
-        mountPath = "/data"
-        name      = "local-ssd-data"
-        readOnly  = false
-      }
-    ]
   }
-
-  volumes = [
-    # https://github.com/terraform-google-modules/terraform-google-container-vm/issues/66
-    {
-      name = "local-ssd-postgresql-data"
-      hostPath = {
-        path = "/mnt/disks/local-ssd/postgresql-data"
-      }
-    },
-    {
-      name = "local-ssd-data"
-      hostPath = {
-        path = "/mnt/disks/local-ssd/data"
-      }
-    }
-  ]
 
   restart_policy = "Never"
 }
@@ -355,15 +327,7 @@ resource "google_compute_instance_template" "publishing_api" {
   disk {
     boot         = true
     source_image = module.publishing-api-container.source_image
-    disk_size_gb = 10
-  }
-
-  disk {
-    device_name  = "local-ssd"
-    interface    = "NVME"
-    disk_type    = "local-ssd"
-    disk_size_gb = "375" # Must be exactly 375GB for a local SSD disk
-    type         = "SCRATCH"
+    disk_size_gb = 1024
   }
 
   metadata = {

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -158,35 +158,7 @@ module "publishing-api-container" {
         value = var.zone
       }
     ]
-    volumeMounts = [
-      {
-        mountPath = "/var/lib/postgresql/data"
-        name      = "local-ssd-postgresql-data"
-        readOnly  = false
-      },
-      {
-        mountPath = "/data"
-        name      = "local-ssd-data"
-        readOnly  = false
-      }
-    ]
   }
-
-  volumes = [
-    # https://github.com/terraform-google-modules/terraform-google-container-vm/issues/66
-    {
-      name = "local-ssd-postgresql-data"
-      hostPath = {
-        path = "/mnt/disks/local-ssd/postgresql-data"
-      }
-    },
-    {
-      name = "local-ssd-data"
-      hostPath = {
-        path = "/mnt/disks/local-ssd/data"
-      }
-    }
-  ]
 
   restart_policy = "Never"
 }
@@ -355,15 +327,7 @@ resource "google_compute_instance_template" "publishing_api" {
   disk {
     boot         = true
     source_image = module.publishing-api-container.source_image
-    disk_size_gb = 10
-  }
-
-  disk {
-    device_name  = "local-ssd"
-    interface    = "NVME"
-    disk_type    = "local-ssd"
-    disk_size_gb = "375" # Must be exactly 375GB for a local SSD disk
-    type         = "SCRATCH"
+    disk_size_gb = 1024
   }
 
   metadata = {

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -158,35 +158,7 @@ module "publishing-api-container" {
         value = var.zone
       }
     ]
-    volumeMounts = [
-      {
-        mountPath = "/var/lib/postgresql/data"
-        name      = "local-ssd-postgresql-data"
-        readOnly  = false
-      },
-      {
-        mountPath = "/data"
-        name      = "local-ssd-data"
-        readOnly  = false
-      }
-    ]
   }
-
-  volumes = [
-    # https://github.com/terraform-google-modules/terraform-google-container-vm/issues/66
-    {
-      name = "local-ssd-postgresql-data"
-      hostPath = {
-        path = "/mnt/disks/local-ssd/postgresql-data"
-      }
-    },
-    {
-      name = "local-ssd-data"
-      hostPath = {
-        path = "/mnt/disks/local-ssd/data"
-      }
-    }
-  ]
 
   restart_policy = "Never"
 }
@@ -355,15 +327,7 @@ resource "google_compute_instance_template" "publishing_api" {
   disk {
     boot         = true
     source_image = module.publishing-api-container.source_image
-    disk_size_gb = 10
-  }
-
-  disk {
-    device_name  = "local-ssd"
-    interface    = "NVME"
-    disk_type    = "local-ssd"
-    disk_size_gb = "375" # Must be exactly 375GB for a local SSD disk
-    type         = "SCRATCH"
+    disk_size_gb = 1024
   }
 
   metadata = {


### PR DESCRIPTION
The local SSD ran out of space when processing the Publishing API data.
SSDs are only available in a single, fixed size of 375GiB.

This fix assumes that the greater speed (via a direct connection to the
physical host of the virtual machine) is no longer necessary since #658.

If network storage is still a bottleneck, then alternatives can be
tried:

1. Delete the extracted data once the `bq load` command has succeeded.
   This might work in the short term, if the size of the
   database backup file and the `table_editions.tsv` file don't
   overwhelm the SSD on their own, or before any of the other files have
   been deleted.
1. Connect more SSDs, and distribute the data files among them. This
   would work for a longer term, until the `table_editions.tsv` file
   size overwhelms the capacity of a single SSD. It is currently about
   200GiB.
1. Use the local SSD only for the database backup file. Instead of
   extracting the data to the same SSD, stream it to a bucket, and load
   the data into BigQuery from the bucket. It was done that way before
   #658. There are various ways to load data from a bucket into
   BigQuery.
1. Mirror the AWS RDS Publishing API database directly in BigQuery,
   using the Datastream service. This option is being considered by
   another team, but won't be implemented immediately.
