### PR TITLE
Whitehall data pipeline

### DIFF
--- a/.github/workflows/docker-whitehall-dev.yml
+++ b/.github/workflows/docker-whitehall-dev.yml
@@ -1,0 +1,74 @@
+name: Docker-whitehall-dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/whitehall/**'
+      - '.github/workflows/docker-whitehall-dev.yml'
+
+defaults:
+  run:
+    working-directory: docker/whitehall
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'whitehall'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      # actions/checkout MUST come before auth
+      - uses: 'actions/checkout@v4'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+          service_account: 'artifact-registry-docker@govuk-knowledge-graph-dev.iam.gserviceaccount.com'
+
+      # Further steps are automatically authenticated
+
+      # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+      # Build the Docker image
+      - name: Docker build
+        id: build
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF" .
+
+      # Push the Docker image to Google Container Registry
+      - name: Docker push
+        id: push
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+          docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-whitehall-staging.yml
+++ b/.github/workflows/docker-whitehall-staging.yml
@@ -1,0 +1,74 @@
+name: Docker-whitehall-staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - staging
+    paths:
+      - 'docker/whitehall/**'
+      - '.github/workflows/docker-whitehall-staging.yml'
+
+defaults:
+  run:
+    working-directory: docker/whitehall
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'whitehall'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      # actions/checkout MUST come before auth
+      - uses: 'actions/checkout@v4'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+          service_account: 'artifact-registry-docker@govuk-knowledge-graph-staging.iam.gserviceaccount.com'
+
+      # Further steps are automatically authenticated
+
+      # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+      # Build the Docker image
+      - name: Docker build
+        id: build
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF" .
+
+      # Push the Docker image to Google Container Registry
+      - name: Docker push
+        id: push
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+          docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-whitehall.yml
+++ b/.github/workflows/docker-whitehall.yml
@@ -1,0 +1,74 @@
+name: Docker-whitehall
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/whitehall/**'
+      - '.github/workflows/docker-whitehall.yml'
+
+defaults:
+  run:
+    working-directory: docker/whitehall
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'whitehall'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      # actions/checkout MUST come before auth
+      - uses: 'actions/checkout@v4'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+          service_account: 'artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+      # Further steps are automatically authenticated
+
+      # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+      # Build the Docker image
+      - name: Docker build
+        id: build
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF" .
+
+      # Push the Docker image to Google Container Registry
+      - name: Docker push
+        id: push
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+          docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/docker/whitehall/Dockerfile
+++ b/docker/whitehall/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:12.10
+
+# Install the gcloud CLI, a specific version from a long-term archive
+# Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
+# Also install make, and GNU sed (for Q command) and coreutils (for faster wc)
+ENV CLOUD_SDK_VERSION=452.0.1
+ENV PATH /google-cloud-sdk/bin:$PATH
+RUN groupadd -g 1000 cloudsdk && \
+    useradd -u 1000 cloudsdk -g cloudsdk
+RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
+RUN ARCH=`cat /tmp/arch` && apt update && apt install -y \
+        coreutils \
+        curl \
+        python3 \
+        python3-crcmod \
+        python3-openssl \
+        libc6-dev \
+        openssh-client \
+        gnupg \
+        make \
+        mariadb-server \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
+
+RUN mkdir -p /var/lib/mysql && \
+    chown -R mysql:mysql /var/lib/mysql && \
+    mkdir -p /data/mysql && \
+    chown -R mysql:mysql /data/mysql && \
+    mkdir /run/mysqld/ && \
+    chown mysql:mysql /run/mysqld/ && \
+    mariadb-install-db --datadir=/var/lib/mysql
+
+
+# Reset the postgres entrypoint to the docker default, so that we can run our
+# own CMD
+ENTRYPOINT []
+COPY entrypoint.sh .
+CMD bash entrypoint.sh

--- a/docker/whitehall/Dockerfile
+++ b/docker/whitehall/Dockerfile
@@ -35,6 +35,7 @@ RUN mkdir -p /var/lib/mysql && \
     chown mysql:mysql /run/mysqld/ && \
     mariadb-install-db --datadir=/var/lib/mysql
 
+COPY my.cnf /etc/mysql/conf.d/mysql.cnf
 
 # Reset the postgres entrypoint to the docker default, so that we can run our
 # own CMD

--- a/docker/whitehall/README.md
+++ b/docker/whitehall/README.md
@@ -20,6 +20,10 @@ Open a recent, successful [workflow-run][workflow-runs]. Its state will be `retu
 
 If the most recent successful workflow run was a few days ago, then the Whitehall database backup file that it responded to might have been deleted. In this case, make a new copy of one of the Whitehall database backup files that do exist in the [bucket][bucket]. Doing so will create a new message in Pub/Sub, which will soon trigger the workflow to start the VM.
 
+## Local build
+
+To build the image locally, decrease the `innodb_buffer_pool_size`, by overriding the values in [my.cnf][./my.cnf].
+
 [govuk-s3-mirror]: https://github.com/alphagov/govuk-s3-mirror
 [bucket]: https://console.cloud.google.com/storage/browser/govuk-s3-mirror_govuk-database-backups/whitehall-mysql
 [workflow-terraform]: ../../terraform/workflows/govuk-database-backups.yaml
@@ -28,3 +32,4 @@ If the most recent successful workflow run was a few days ago, then the Whitehal
 [github-action]: ../../.github/workflows/docker-whitehall.yml
 [entrypoint.sh]: ./entrypoint.sh
 [Dockerfile]: ./Dockerfile
+[my.cnf]: ./my.cnf

--- a/docker/whitehall/README.md
+++ b/docker/whitehall/README.md
@@ -1,0 +1,30 @@
+# Virtual machine to import Whitehall data into BigQuery
+
+The Whitehall database is backed up daily to files in AWS S3, which are copied into a GCP bucket by the [govuk-s3-mirror][govuk-s3-mirror].
+
+This VM imports a backup from the govuk S3 mirror bucket, restores it to a temporary MariaDB instance and exports it to a CSV file before uploading to BigQuery.
+
+## Build the image
+
+This folder only contains the [`Dockerfile`][Dockerfile] and [`entrypoint.sh`][entrypoint.sh]. A GitHub action rebuilds the image when these files are changed, and pushes it to the Artifact Registry.
+
+The rest of the code is in [`src/whitehall`][src]. When the VM starts, the [`entrypoint.sh`][entrypoint.sh] script fetches that code and runs it. This separation avoids having to rebuild the docker image when only changing the code that it runs.
+
+## Trigger the VM to start
+
+When the [govuk-s3-mirror][govuk-s3-mirror] finishes copying any file into its GCP bucket, it publishes a message to Pub/Sub channel. This project subscribes to that channel. A [workflow][workflow-terraform] reads the messages, and if they describe a file whose name fits the pattern for Whitehall database backups, then it starts an instance of this virtual machine.
+
+### Manually start the VM
+
+Open a recent, successful [workflow-run][workflow-runs]. Its state will be `return_started_whitehall: Succeeded`. Click "Execute again" and then "Execute". This will run the workflow with the last input, which was a message that carried the information that the VM needs to find the Whitehall database backup file.
+
+If the most recent successful workflow run was a few days ago, then the Whitehall database backup file that it responded to might have been deleted. In this case, make a new copy of one of the Whitehall database backup files that do exist in the [bucket][bucket]. Doing so will create a new message in Pub/Sub, which will soon trigger the workflow to start the VM.
+
+[govuk-s3-mirror]: https://github.com/alphagov/govuk-s3-mirror
+[bucket]: https://console.cloud.google.com/storage/browser/govuk-s3-mirror_govuk-database-backups/whitehall-mysql
+[workflow-terraform]: ../../terraform/workflows/govuk-database-backups.yaml
+[workflow-runs]: https://console.cloud.google.com/workflows/workflow/europe-west2/govuk-database-backups/executions?project=govuk-knowledge-graph&pli=1
+[src]: ../../src/whitehall
+[github-action]: ../../.github/workflows/docker-whitehall.yml
+[entrypoint.sh]: ./entrypoint.sh
+[Dockerfile]: ./Dockerfile

--- a/docker/whitehall/entrypoint.sh
+++ b/docker/whitehall/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Run a script from a copy of the HEAD of the repository
+# This sometimes fails with
+#
+# > ERROR: (gcloud.storage.cat) You do not currently have an active account selected.
+#
+# So retry for a few minutes.  Newly-built containers don't seem to work
+# immediately.
+
+MAX_RETRIES=10
+RETRY_INTERVAL_SECONDS=60
+COUNTER=0
+CMD="gcloud storage cat gs://${PROJECT_ID}-repository/src/whitehall/run.sh"
+
+while [ $COUNTER -lt $MAX_RETRIES ]; do
+  $CMD
+  if [ $? -eq 0 ]; then
+    break
+  else
+    echo "Command failed, retrying in ${RETRY_INTERVAL_SECONDS} seconds..."
+    sleep $RETRY_INTERVAL_SECONDS
+    let COUNTER=COUNTER+1
+  fi
+done
+
+if [ $COUNTER -eq $MAX_RETRIES ]; then
+  echo "Command failed after $MAX_RETRIES attempts, exiting..."
+  exit 1
+fi
+
+$CMD | bash

--- a/docker/whitehall/my.cnf
+++ b/docker/whitehall/my.cnf
@@ -1,0 +1,14 @@
+[mariadb]
+max_connections = 10
+connect_timeout	= 5
+wait_timeout = 600
+max_allowed_packet = 1G
+default_storage_engine = InnoDB
+innodb_log_file_size = 2G
+innodb_buffer_pool_size = 8G
+innodb_log_buffer_size = 8M
+innodb_file_per_table	= 1
+innodb_open_files = 400
+innodb_io_capacity = 200
+innodb_flush_method = O_DIRECT
+innodb_flush_log_at_trx_commit = 0

--- a/src/whitehall/Makefile
+++ b/src/whitehall/Makefile
@@ -1,0 +1,18 @@
+SHELL := /bin/bash
+
+# Parallelise with all cores, if possible
+NPROCS = $(shell grep -c 'processor' /proc/cpuinfo)
+MAKEFLAGS += -j$(NPROCS)
+
+# Names of tables in the MySQL database to export to Cloud Storage
+# and BigQuery
+EXPORT = editions
+
+# A step to create all the targets described in the CSV.GZ and BIGQUERY
+# variables, which means that all the .sh and .sql scripts in the SH and
+# BIGQUERY variables will be executed.
+.PHONY: all
+all: $(EXPORT)
+
+editions:
+	source functions.sh; export_to_bigquery table_name=$@

--- a/src/whitehall/README.md
+++ b/src/whitehall/README.md
@@ -1,0 +1,58 @@
+# Import Whitehall data into BigQuery
+
+The Whitehall database is backed up daily to files in AWS S3, which are copied into a GCP bucket by the [govuk-s3-mirror][govuk-s3-mirror].
+
+A virtual machine fetches the scripts in this directory from the copy of the HEAD of this repository that is synced to a [bucket][bucket], and runs [`run.sh`][run.sh], which initiates the following steps.
+
+1. Fetch the Whitehall database backup file. It knows where to find it from environment variables that are set when the [workflow][workflow-terraform] starts the virtual machine ([more details][docker]).
+2. Start a MariaDB server and wait for it to come online.
+3. Create a Whitehall database to restore the data to.
+4. Import the data into MariaDB.
+5. Export the selected tables into CSV files.
+6. Upload the data into BigQuery.
+
+A Makefile is used to parallelise the tasks.
+
+## Dockerfile
+
+The [Docker configuration][docker] is separate, so that changes to the code here don't cause the image to be rebuilt unnecessarily.  When the virtual machine starts, it fetches [`run.sh`][run.sh] from the copy of the HEAD of this repository that is synced to a [bucket][bucket].
+
+## Test locally
+
+Local testing is difficult, because the Whitehall database is huge. It can be easier to do the following:
+
+1. Add a line to [`run.sh`][run.sh] `tail -f /dev/null` before the command that deletes the virtual machine.
+2. Upload your modified copy of [`run.sh`][run.sh].
+3. [Manually start the VM][docker-readme].
+4. SSH into the VM.
+
+### SSH into a VM
+
+Once a VM instance is running, you can SSH into it from your local device, in the terminal.
+
+```sh
+# SSH into the instance
+gcloud compute ssh \
+  --zone "europe-west2-b" \
+  "whitehall" \
+  --project "govuk-knowledge-graph" \
+  --tunnel-through-iap
+
+# Wait a while for the docker image to start (about 30 seconds to a minute)
+
+# Get the ID of the docker image.  For example, `klt--ulug`.
+docker ps
+
+# Tail the logs of the docker image
+docker logs -tf klt--ulug
+
+# Otherwise, SSH directly from your device into the docker image
+gcloud compute ssh --zone "europe-west2-b" "whitehall" --project "govuk-knowledge-graph" -- container "klt--ulug" --tunnel-through-iap
+```
+
+[bucket]: https://console.cloud.google.com/storage/browser/govuk-knowledge-graph-repository
+[docker]: ../../docker/whitehall
+[docker-readme]: ../../docker/whitehall/README.md
+[run.sh]: ./run.sh
+[workflow-terraform]: ../../terraform/workflows/govuk-database-backups.yaml
+[govuk-s3-mirror]: https://github.com/alphagov/govuk-s3-mirror

--- a/src/whitehall/functions.sh
+++ b/src/whitehall/functions.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+set -e
+
+# Export a table from an SQL dump file, upload to storage and import into BigQuery
+export_to_bigquery () {
+  # reset variables in case they are defined globally
+  local table_name
+  local "${@}"
+
+  csv_name="/data/mysql/table_${table_name}"
+
+  schema_name="schema_${table_name}"
+  dataset_name="whitehall"
+
+  mysql -u root ${dataset_name} -e "SELECT id,created_at,updated_at,document_id,state,type,major_change_published_at,first_published_at,force_published,public_timestamp,scheduled_publication,access_limited,opening_at,closing_at,political,primary_locale,auth_bypass_id,government_id
+                              INTO OUTFILE '${csv_name}'
+                              FIELDS TERMINATED BY ','
+                              ENCLOSED BY '\"'
+                              LINES TERMINATED BY '\n'
+                              FROM editions;"
+
+  # Download the existing schema
+  bq show \
+    --schema=true \
+    --format=json \
+    "${dataset_name}.${table_name}" \
+    > $schema_name
+
+  # Load data into the the table, using the "write disposition", which is
+  # equivalent to WRITE_TRUNCATE in SQL. It empties the table and wipes its
+  # schema, before inserting new rows. This is done within a transaction. We
+  # preserve the schema by downloading it first with `bq show`, and then using
+  # it as an argument to `bq load`.
+  bq load \
+    --source_format="CSV" \
+    --field_delimiter="," \
+    --null_marker="\\N" \
+    --quote="\"" \
+    --replace=true \
+    --schema="${schema_name}" \
+    "${dataset_name}.${table_name}" \
+    "${csv_name}"
+}

--- a/src/whitehall/run.sh
+++ b/src/whitehall/run.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Obtain the latest state of the repository
+gcloud storage cp -r "gs://${PROJECT_ID}-repository/*" .
+
+# turn on bash's job control
+set -m
+
+# Fetch the Whitehall database backup file from GCP Storage
+BUCKET=$(
+  gcloud compute instances describe whitehall \
+    --project $PROJECT_ID \
+    --zone $ZONE \
+    --format="value(metadata.items.object_bucket)"
+)
+OBJECT=$(
+gcloud compute instances describe whitehall \
+  --project $PROJECT_ID \
+  --zone $ZONE \
+  --format="value(metadata.items.object_name)"
+)
+OBJECT_URL="gs://$BUCKET/$OBJECT"
+export FILE_PATH="/root/$OBJECT"
+
+gcloud storage cp "$OBJECT_URL" "$FILE_PATH"
+
+# Check that the file size is larger than an arbitrary size of 2GiB.
+# If it is not, then the file is likely corrupt and we should not proceed.
+minimumsize=2147483648
+actualsize=$(wc -c <"$FILE_PATH")
+if [ $actualsize -le $minimumsize ]; then
+  # Turn this instance off and exit.  The data that is currrently in BigQuery
+  # will remain there.
+  gcloud compute instances delete whitehall --quiet --zone=$ZONE
+  exit 1
+fi
+
+cd src/whitehall
+
+# Start the mysql service
+mariadbd --user=mysql &
+
+# Wait for mariadb to start
+sleep 30
+
+# Restore the dump to mariadb and export it to csv and then bigquery (via Makefile)
+mysql -u root -e 'create database whitehall;'
+gunzip < "$FILE_PATH" | mysql -u root whitehall
+make
+
+# Delete this instance
+gcloud compute instances delete whitehall --quiet --zone=$ZONE

--- a/src/whitehall/run.sh
+++ b/src/whitehall/run.sh
@@ -44,8 +44,11 @@ mariadbd --user=mysql &
 sleep 30
 
 # Restore the dump to mariadb and export it to csv and then bigquery (via Makefile)
-mysql -u root -e 'create database whitehall;'
+echo "Creating whitehall database..."
+mysql -u root -e 'create database whitehall; use whitehall; SET unique_checks=0; SET foreign_key_checks=0; SET autocommit=0;'
+echo "Restoring whitehall database..."
 gunzip < "$FILE_PATH" | mysql -u root whitehall
+echo "Uploading to BigQuery..."
 make
 
 # Delete this instance

--- a/terraform-dev/artifact-registry.tf
+++ b/terraform-dev/artifact-registry.tf
@@ -60,6 +60,7 @@ data "google_iam_policy" "artifact_registry_docker" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
+      google_service_account.gce_whitehall.member,
     ]
   }
 

--- a/terraform-dev/bigquery-whitehall.tf
+++ b/terraform-dev/bigquery-whitehall.tf
@@ -1,0 +1,56 @@
+# A dataset of tables from the Whitehall mysql database
+
+resource "google_bigquery_dataset" "whitehall" {
+  dataset_id            = "whitehall"
+  friendly_name         = "Whitehall"
+  description           = "Data from the GOV.UK Whitehall database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_whitehall" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_whitehall.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_whitehall_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "whitehall" {
+  dataset_id  = google_bigquery_dataset.whitehall.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_whitehall.policy_data
+}
+
+resource "google_bigquery_table" "whitehall_editions" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/editions.json")
+  clustering    = ["state", "type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+

--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -78,3 +78,7 @@ bigquery_search_data_viewer_members = [
 # BigQuery dataset: test
 bigquery_test_data_viewer_members = [
 ]
+
+# BigQuery dataset: whitehall
+bigquery_whitehall_data_viewer_members = [
+]

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -172,6 +172,10 @@ variable "bigquery_test_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_whitehall_data_viewer_members" {
+  type = list(string)
+}
+
 terraform {
   required_providers {
     google = {
@@ -295,6 +299,7 @@ data "google_iam_policy" "project" {
         google_service_account.gce_publishing_api.member,
         google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
+        google_service_account.gce_whitehall.member,
         google_service_account.govgraphsearch.member,
       ],
       var.bigquery_job_user_members
@@ -364,6 +369,7 @@ data "google_iam_policy" "project" {
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
+      google_service_account.gce_whitehall.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]
@@ -415,7 +421,8 @@ data "google_iam_policy" "project" {
     role = "roles/logging.logWriter"
     members = [
       google_service_account.workflow_govuk_database_backups.member,
-      google_service_account.workflow_redis_cli.member
+      google_service_account.workflow_redis_cli.member,
+      google_service_account.gce_whitehall.member
     ]
   }
 

--- a/terraform-dev/schemas/whitehall/editions.json
+++ b/terraform-dev/schemas/whitehall/editions.json
@@ -1,0 +1,110 @@
+[
+  {
+    "description": "The ID of the edition",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the edition",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the edition",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the document that the edition belongs to",
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The publication status of the edition",
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "description": "The document type of the edition",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the last edition with a major change on the parent document was published",
+    "mode": "NULLABLE",
+    "name": "major_change_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the parent document was first published",
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition has been published without 21",
+    "mode": "NULLABLE",
+    "name": "force_published",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The publicly visible time at which the edition appears to have been published (this may be different to the actual publication time)",
+    "mode": "NULLABLE",
+    "name": "public_timestamp",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the edition has been scheduled for publication",
+    "mode": "NULLABLE",
+    "name": "scheduled_publication",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition is restricted from the view of other organisations than the lead organisations (draft editions only)",
+    "mode": "NULLABLE",
+    "name": "access_limited",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The time at which some edition types are open for public feedback",
+    "mode": "NULLABLE",
+    "name": "opening_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which some edition types are closed for public feedback",
+    "mode": "NULLABLE",
+    "name": "closing_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition is associated with a government",
+    "mode": "NULLABLE",
+    "name": "political",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The language code of the primary locale",
+    "mode": "NULLABLE",
+    "name": "primary_locale",
+    "type": "STRING"
+  },
+  {
+    "description": "A token used to compose a shareable preview url",
+    "mode": "NULLABLE",
+    "name": "auth_bypass_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the government that the edition is associated with",
+    "mode": "NULLABLE",
+    "name": "government_id",
+    "type": "INTEGER"
+  }
+]

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -50,6 +50,7 @@ data "google_iam_policy" "bucket_repository" {
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
+      google_service_account.gce_whitehall.member,
     ]
   }
 

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -24,6 +24,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)
       support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
+      whitehall_metadata_value      = jsonencode(module.whitehall-container.metadata_value)
     }
   )
 }

--- a/terraform-dev/workflows/govuk-database-backups.yaml
+++ b/terraform-dev/workflows/govuk-database-backups.yaml
@@ -120,6 +120,35 @@ main:
                           value: ${publisher_metadata_value}
           - return_started_publisher:
               return: $${"Started publisher instance"}
+        - condition: $${text.match_regex(object_name, "^whitehall-mysql/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-whitehall_production\\.gz$")}
+          steps:
+            - log_starting_whitehall_instance:
+                call: sys.log
+                args:
+                  text: "Starting whitehall instance"
+                  severity: INFO
+            - start_whitehall:
+                call: googleapis.compute.v1.instances.insert
+                args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/whitehall
+                  body:
+                    name: whitehall
+                    metadata:
+                      items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${whitehall_metadata_value}
+            - return_started_whitehall:
+                return: $${"Started whitehall instance"}
   - log_not_starting_instance:
       call: sys.log
       args:

--- a/terraform-staging/artifact-registry.tf
+++ b/terraform-staging/artifact-registry.tf
@@ -60,6 +60,7 @@ data "google_iam_policy" "artifact_registry_docker" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
+      google_service_account.gce_whitehall.member,
     ]
   }
 

--- a/terraform-staging/bigquery-whitehall.tf
+++ b/terraform-staging/bigquery-whitehall.tf
@@ -1,0 +1,56 @@
+# A dataset of tables from the Whitehall mysql database
+
+resource "google_bigquery_dataset" "whitehall" {
+  dataset_id            = "whitehall"
+  friendly_name         = "Whitehall"
+  description           = "Data from the GOV.UK Whitehall database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_whitehall" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_whitehall.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_whitehall_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "whitehall" {
+  dataset_id  = google_bigquery_dataset.whitehall.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_whitehall.policy_data
+}
+
+resource "google_bigquery_table" "whitehall_editions" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/editions.json")
+  clustering    = ["state", "type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -80,3 +80,7 @@ bigquery_search_data_viewer_members = [
 # BigQuery dataset: test
 bigquery_test_data_viewer_members = [
 ]
+
+# BigQuery dataset: whitehall
+bigquery_whitehall_data_viewer_members = [
+]

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -415,7 +415,8 @@ data "google_iam_policy" "project" {
     role = "roles/logging.logWriter"
     members = [
       google_service_account.workflow_govuk_database_backups.member,
-      google_service_account.workflow_redis_cli.member
+      google_service_account.workflow_redis_cli.member,
+      google_service_account.gce_whitehall.member
     ]
   }
 

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -172,6 +172,10 @@ variable "bigquery_test_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_whitehall_data_viewer_members" {
+  type = list(string)
+}
+
 terraform {
   required_providers {
     google = {
@@ -295,6 +299,7 @@ data "google_iam_policy" "project" {
         google_service_account.gce_publishing_api.member,
         google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
+        google_service_account.gce_whitehall.member,
         google_service_account.govgraphsearch.member,
       ],
       var.bigquery_job_user_members
@@ -364,6 +369,7 @@ data "google_iam_policy" "project" {
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
+      google_service_account.gce_whitehall.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]

--- a/terraform-staging/schemas/whitehall/editions.json
+++ b/terraform-staging/schemas/whitehall/editions.json
@@ -1,0 +1,110 @@
+[
+  {
+    "description": "The ID of the edition",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the edition",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the edition",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the document that the edition belongs to",
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The publication status of the edition",
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "description": "The document type of the edition",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the last edition with a major change on the parent document was published",
+    "mode": "NULLABLE",
+    "name": "major_change_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the parent document was first published",
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition has been published without 21",
+    "mode": "NULLABLE",
+    "name": "force_published",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The publicly visible time at which the edition appears to have been published (this may be different to the actual publication time)",
+    "mode": "NULLABLE",
+    "name": "public_timestamp",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the edition has been scheduled for publication",
+    "mode": "NULLABLE",
+    "name": "scheduled_publication",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition is restricted from the view of other organisations than the lead organisations (draft editions only)",
+    "mode": "NULLABLE",
+    "name": "access_limited",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The time at which some edition types are open for public feedback",
+    "mode": "NULLABLE",
+    "name": "opening_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which some edition types are closed for public feedback",
+    "mode": "NULLABLE",
+    "name": "closing_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition is associated with a government",
+    "mode": "NULLABLE",
+    "name": "political",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The language code of the primary locale",
+    "mode": "NULLABLE",
+    "name": "primary_locale",
+    "type": "STRING"
+  },
+  {
+    "description": "A token used to compose a shareable preview url",
+    "mode": "NULLABLE",
+    "name": "auth_bypass_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the government that the edition is associated with",
+    "mode": "NULLABLE",
+    "name": "government_id",
+    "type": "INTEGER"
+  }
+]

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -50,6 +50,7 @@ data "google_iam_policy" "bucket_repository" {
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
+      google_service_account.gce_whitehall.member,
     ]
   }
 

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -24,6 +24,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)
       support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
+      whitehall_metadata_value      = jsonencode(module.whitehall-container.metadata_value)
     }
   )
 }

--- a/terraform-staging/workflows/govuk-database-backups.yaml
+++ b/terraform-staging/workflows/govuk-database-backups.yaml
@@ -120,6 +120,35 @@ main:
                           value: ${publisher_metadata_value}
           - return_started_publisher:
               return: $${"Started publisher instance"}
+        - condition: $${text.match_regex(object_name, "^whitehall-mysql/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-whitehall_production\\.gz$")}
+          steps:
+            - log_starting_whitehall_instance:
+                call: sys.log
+                args:
+                  text: "Starting whitehall instance"
+                  severity: INFO
+            - start_whitehall:
+                call: googleapis.compute.v1.instances.insert
+                args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/whitehall
+                  body:
+                    name: whitehall
+                    metadata:
+                      items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${whitehall_metadata_value}
+            - return_started_whitehall:
+                return: $${"Started whitehall instance"}
   - log_not_starting_instance:
       call: sys.log
       args:

--- a/terraform/artifact-registry.tf
+++ b/terraform/artifact-registry.tf
@@ -60,6 +60,7 @@ data "google_iam_policy" "artifact_registry_docker" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
+      google_service_account.gce_whitehall.member,
     ]
   }
 

--- a/terraform/bigquery-whitehall.tf
+++ b/terraform/bigquery-whitehall.tf
@@ -1,0 +1,56 @@
+# A dataset of tables from the Whitehall mysql database
+
+resource "google_bigquery_dataset" "whitehall" {
+  dataset_id            = "whitehall"
+  friendly_name         = "Whitehall"
+  description           = "Data from the GOV.UK Whitehall database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_whitehall" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_whitehall.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_whitehall_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "whitehall" {
+  dataset_id  = google_bigquery_dataset.whitehall.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_whitehall.policy_data
+}
+
+resource "google_bigquery_table" "whitehall_editions" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "editions"
+  friendly_name = "Editions"
+  description   = "Editions table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/editions.json")
+  clustering    = ["state", "type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -106,3 +106,7 @@ bigquery_search_data_viewer_members = [
 # BigQuery dataset: test
 bigquery_test_data_viewer_members = [
 ]
+
+# BigQuery dataset: whitehall
+bigquery_whitehall_data_viewer_members = [
+]

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -415,7 +415,8 @@ data "google_iam_policy" "project" {
     role = "roles/logging.logWriter"
     members = [
       google_service_account.workflow_govuk_database_backups.member,
-      google_service_account.workflow_redis_cli.member
+      google_service_account.workflow_redis_cli.member,
+      google_service_account.gce_whitehall.member
     ]
   }
 

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -172,6 +172,10 @@ variable "bigquery_test_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_whitehall_data_viewer_members" {
+  type = list(string)
+}
+
 terraform {
   required_providers {
     google = {
@@ -295,6 +299,7 @@ data "google_iam_policy" "project" {
         google_service_account.gce_publishing_api.member,
         google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
+        google_service_account.gce_whitehall.member,
         google_service_account.govgraphsearch.member,
       ],
       var.bigquery_job_user_members
@@ -364,6 +369,7 @@ data "google_iam_policy" "project" {
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
+      google_service_account.gce_whitehall.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]

--- a/terraform/schemas/whitehall/editions.json
+++ b/terraform/schemas/whitehall/editions.json
@@ -1,0 +1,110 @@
+[
+  {
+    "description": "The ID of the edition",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the edition",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the edition",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the document that the edition belongs to",
+    "mode": "NULLABLE",
+    "name": "document_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The publication status of the edition",
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "description": "The document type of the edition",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the last edition with a major change on the parent document was published",
+    "mode": "NULLABLE",
+    "name": "major_change_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the parent document was first published",
+    "mode": "NULLABLE",
+    "name": "first_published_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition has been published without 21",
+    "mode": "NULLABLE",
+    "name": "force_published",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The publicly visible time at which the edition appears to have been published (this may be different to the actual publication time)",
+    "mode": "NULLABLE",
+    "name": "public_timestamp",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the edition has been scheduled for publication",
+    "mode": "NULLABLE",
+    "name": "scheduled_publication",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition is restricted from the view of other organisations than the lead organisations (draft editions only)",
+    "mode": "NULLABLE",
+    "name": "access_limited",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The time at which some edition types are open for public feedback",
+    "mode": "NULLABLE",
+    "name": "opening_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which some edition types are closed for public feedback",
+    "mode": "NULLABLE",
+    "name": "closing_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "A flag to indicate whether the edition is associated with a government",
+    "mode": "NULLABLE",
+    "name": "political",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The language code of the primary locale",
+    "mode": "NULLABLE",
+    "name": "primary_locale",
+    "type": "STRING"
+  },
+  {
+    "description": "A token used to compose a shareable preview url",
+    "mode": "NULLABLE",
+    "name": "auth_bypass_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the government that the edition is associated with",
+    "mode": "NULLABLE",
+    "name": "government_id",
+    "type": "INTEGER"
+  }
+]

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -50,6 +50,7 @@ data "google_iam_policy" "bucket_repository" {
       google_service_account.gce_publishing_api.member,
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
+      google_service_account.gce_whitehall.member,
     ]
   }
 

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -24,6 +24,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       publishing_api_metadata_value = jsonencode(module.publishing-api-container.metadata_value)
       support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
+      whitehall_metadata_value      = jsonencode(module.whitehall-container.metadata_value)
     }
   )
 }

--- a/terraform/workflows/govuk-database-backups.yaml
+++ b/terraform/workflows/govuk-database-backups.yaml
@@ -120,6 +120,35 @@ main:
                           value: ${publisher_metadata_value}
           - return_started_publisher:
               return: $${"Started publisher instance"}
+        - condition: $${text.match_regex(object_name, "^whitehall-mysql/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-whitehall_production\\.gz$")}
+          steps:
+            - log_starting_whitehall_instance:
+                call: sys.log
+                args:
+                  text: "Starting whitehall instance"
+                  severity: INFO
+            - start_whitehall:
+                call: googleapis.compute.v1.instances.insert
+                args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/whitehall
+                  body:
+                    name: whitehall
+                    metadata:
+                      items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${whitehall_metadata_value}
+            - return_started_whitehall:
+                return: $${"Started whitehall instance"}
   - log_not_starting_instance:
       call: sys.log
       args:


### PR DESCRIPTION
This adds a pipeline to push Whitehall editions data into Google BigQuery. We will be adding more schemas in future PRs.

## Notable Features

We chose not to take the proposed approach of using Google DataStream to move data into BigQuery, as we did not want to be blocked while we wait for the Platform Engineering team to agree on a suitable network model.

We are installing MariaDB on a Debian image to import the database from a production dump and then export the relevant table data to CSV for upload to Google BigQuery.

Relevant S3 Mirror PRs:

- https://github.com/alphagov/govuk-s3-mirror/pull/74
- https://github.com/alphagov/govuk-s3-mirror/pull/75

## Testing

We have tested this successfully in the dev environment. It took just under 6 hours to import the Whitehall database into MariaDB and then to export the editions table to BigQuery.

## Follow ups

There are a few features we'd like to add to the pipeline that we intend to introduce in later PRs:

1. Find a way to pass logs from the Docker container to Google's Cloud logs ([this looks promising](https://docs.docker.com/engine/logging/drivers/gcplogs/))
2. Find a way to provide some kind of progress update for the MySQL import, if possible
3. Find a way to improve performance of the MySQL import (some of [these](https://betterstack.com/community/questions/how-can-i-speedup-mysql-restore-from-dump-file/) look worth a try)


[Trello](https://trello.com/c/EmdtD0tK/3523-replicate-the-whitehall-database-in-google-cloudsql)
