### PR TITLE
Add additional tables for whitehall data pipeline

### DIFF
--- a/src/whitehall/Makefile
+++ b/src/whitehall/Makefile
@@ -6,7 +6,7 @@ MAKEFLAGS += -j$(NPROCS)
 
 # Names of tables in the MySQL database to export to Cloud Storage
 # and BigQuery
-EXPORT = editions
+EXPORT = editions assets attachments attachment_data
 
 # A step to create all the targets described in the CSV.GZ and BIGQUERY
 # variables, which means that all the .sh and .sql scripts in the SH and
@@ -15,4 +15,13 @@ EXPORT = editions
 all: $(EXPORT)
 
 editions:
-	source functions.sh; export_to_bigquery table_name=$@
+	source functions.sh; export_editions_to_bigquery
+
+assets:
+	source functions.sh; export_assets_to_bigquery
+
+attachments:
+	source functions.sh; export_attachments_to_bigquery
+
+attachment_data:
+	source functions.sh; export_attachment_data_to_bigquery

--- a/src/whitehall/functions.sh
+++ b/src/whitehall/functions.sh
@@ -1,43 +1,90 @@
 #! /bin/bash
 set -e
 
+dataset_name="whitehall"
+
 # Export a table from an SQL dump file, upload to storage and import into BigQuery
-export_to_bigquery () {
-  # reset variables in case they are defined globally
-  local table_name
-  local "${@}"
-
-  csv_name="/data/mysql/table_${table_name}"
-
-  schema_name="schema_${table_name}"
-  dataset_name="whitehall"
+export_editions_to_bigquery () {
+  local table_name="editions"
+  local csv_name="/data/mysql/table_${table_name}"
 
   mysql -u root ${dataset_name} -e "SELECT id,created_at,updated_at,document_id,state,type,major_change_published_at,first_published_at,force_published,public_timestamp,scheduled_publication,access_limited,opening_at,closing_at,political,primary_locale,auth_bypass_id,government_id
-                              INTO OUTFILE '${csv_name}'
-                              FIELDS TERMINATED BY ','
-                              ENCLOSED BY '\"'
-                              LINES TERMINATED BY '\n'
-                              FROM editions;"
+                                    INTO OUTFILE '${csv_name}'
+                                    FIELDS TERMINATED BY ','
+                                    ENCLOSED BY '\"'
+                                    LINES TERMINATED BY '\n'
+                                    FROM editions;"
+
+  upload_to_bq $table_name $csv_name
+}
+
+export_assets_to_bigquery () {
+  local table_name="assets"
+  local csv_name="/data/mysql/table_${table_name}"
+
+   mysql -u root ${dataset_name} -e "SELECT id,asset_manager_id,variant,created_at,updated_at,assetable_type,assetable_id,filename
+                                     INTO OUTFILE '${csv_name}'
+                                     FIELDS TERMINATED BY ','
+                                     ENCLOSED BY '\"'
+                                     LINES TERMINATED BY '\n'
+                                     FROM assets;"
+
+  upload_to_bq $table_name $csv_name
+}
+
+export_attachment_data_to_bigquery () {
+  local table_name="attachment_data"
+  local csv_name="/data/mysql/table_${table_name}"
+
+   mysql -u root ${dataset_name} -e "SELECT id,carrierwave_file,content_type,file_size,number_of_pages,created_at,updated_at,replaced_by_id
+                                     INTO OUTFILE '${csv_name}'
+                                     FIELDS TERMINATED BY ','
+                                     ENCLOSED BY '\"'
+                                     LINES TERMINATED BY '\n'
+                                     FROM attachment_data;"
+
+  upload_to_bq $table_name $csv_name
+}
+
+export_attachments_to_bigquery() {
+  local table_name="attachments"
+  local csv_name="/data/mysql/table_${table_name}"
+
+   mysql -u root ${dataset_name} -e "SELECT id,created_at,updated_at,title,attachment_data_id,attachable_id,attachable_type,type,slug,locale,content_id,deleted
+                                     INTO OUTFILE '${csv_name}'
+                                     FIELDS TERMINATED BY ','
+                                     ENCLOSED BY '\"'
+                                     LINES TERMINATED BY '\n'
+                                     FROM attachments;"
+
+  upload_to_bq $table_name $csv_name
+}
+
+
+upload_to_bq () {
+  local table_name=$1
+  local csv_name=$2
+  local schema_name="schema_${table_name}"
 
   # Download the existing schema
-  bq show \
-    --schema=true \
-    --format=json \
-    "${dataset_name}.${table_name}" \
-    > $schema_name
+    bq show \
+      --schema=true \
+      --format=json \
+      "${dataset_name}.${table_name}" \
+      > $schema_name
 
   # Load data into the the table, using the "write disposition", which is
   # equivalent to WRITE_TRUNCATE in SQL. It empties the table and wipes its
   # schema, before inserting new rows. This is done within a transaction. We
   # preserve the schema by downloading it first with `bq show`, and then using
   # it as an argument to `bq load`.
-  bq load \
-    --source_format="CSV" \
-    --field_delimiter="," \
-    --null_marker="\\N" \
-    --quote="\"" \
-    --replace=true \
-    --schema="${schema_name}" \
-    "${dataset_name}.${table_name}" \
-    "${csv_name}"
+    bq load \
+      --source_format="CSV" \
+      --field_delimiter="," \
+      --null_marker="\\N" \
+      --quote="\"" \
+      --replace=true \
+      --schema="${schema_name}" \
+      "${dataset_name}.${table_name}" \
+      "${csv_name}"
 }

--- a/terraform-dev/bigquery-whitehall.tf
+++ b/terraform-dev/bigquery-whitehall.tf
@@ -40,6 +40,44 @@ resource "google_bigquery_dataset_iam_policy" "whitehall" {
   policy_data = data.google_iam_policy.bigquery_dataset_whitehall.policy_data
 }
 
+resource "google_bigquery_table" "whitehall_assets" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets"
+  description   = "Assets table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/assets.json")
+  clustering    = ["assetable_type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+resource "google_bigquery_table" "whitehall_attachment_data" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "attachment_data"
+  friendly_name = "Attachment Data"
+  description   = "Attachment Data table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/attachment_data.json")
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+resource "google_bigquery_table" "whitehall_attachments" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "attachments"
+  friendly_name = "Attachments"
+  description   = "Attachments table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/attachments.json")
+  clustering    = ["type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
 resource "google_bigquery_table" "whitehall_editions" {
   dataset_id    = google_bigquery_dataset.whitehall.dataset_id
   table_id      = "editions"
@@ -52,5 +90,3 @@ resource "google_bigquery_table" "whitehall_editions" {
     field = "updated_at"
   }
 }
-
-

--- a/terraform-dev/schemas/whitehall/assets.json
+++ b/terraform-dev/schemas/whitehall/assets.json
@@ -1,0 +1,50 @@
+[
+  {
+    "description": "The ID of the asset",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The Asset Manager unique identifier for the asset",
+    "mode": "NULLABLE",
+    "name": "asset_manager_id",
+    "type": "STRING"
+  },
+  {
+    "description": "Some assets have different versions of the same file (such as image sizes). Default is 'original'.",
+    "mode": "NULLABLE",
+    "name": "variant",
+    "type": "STRING"
+  },
+  {
+    "description": "The created timestamp of the asset",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the asset",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The type of the model the asset is associated with (for example 'AttachmentData')",
+    "mode": "NULLABLE",
+    "name": "assetable_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the model the asset is associated with (for example the 'AttachmentData' ID)",
+    "mode": "NULLABLE",
+    "name": "assetable_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The name of the attached file",
+    "mode": "NULLABLE",
+    "name": "filename",
+    "type": "STRING"
+  }
+]

--- a/terraform-dev/schemas/whitehall/attachment_data.json
+++ b/terraform-dev/schemas/whitehall/attachment_data.json
@@ -1,0 +1,50 @@
+[
+  {
+    "description": "The ID of the attachment data",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The name of the attached file",
+    "mode": "NULLABLE",
+    "name": "carrierwave_file",
+    "type": "STRING"
+  },
+  {
+    "description": "The MIME type of the attached file",
+    "mode": "NULLABLE",
+    "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The size of the attached file",
+    "mode": "NULLABLE",
+    "name": "file_size",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The number of pages in the attached file",
+    "mode": "NULLABLE",
+    "name": "number_of_pages",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the attachment data",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the attachment data",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the replacement AttachmentData",
+    "mode": "NULLABLE",
+    "name": "replaced_by_id",
+    "type": "INTEGER"
+  }
+]

--- a/terraform-dev/schemas/whitehall/attachments.json
+++ b/terraform-dev/schemas/whitehall/attachments.json
@@ -1,0 +1,74 @@
+[
+  {
+    "description": "The ID of the attachment",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the attachment",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the attachment",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The title of the attachment",
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the attachment data the attachment is associated with",
+    "mode": "NULLABLE",
+    "name": "attachment_data_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The ID of the attachable the attachment is associated with. The attachable can be an edition, or a non-editionable model.`",
+    "mode": "NULLABLE",
+    "name": "attachable_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The type of the attachable the attachment is associated with. The attachable can be an edition, or a non-editionable model.`",
+    "mode": "NULLABLE",
+    "name": "attachable_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The type of the attachment",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "The slug of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "description": "The locale of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "description": "The content ID of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "description": "A flag to indicate whether the attachment is deleted",
+    "mode": "NULLABLE",
+    "name": "deleted",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform-staging/bigquery-whitehall.tf
+++ b/terraform-staging/bigquery-whitehall.tf
@@ -40,6 +40,44 @@ resource "google_bigquery_dataset_iam_policy" "whitehall" {
   policy_data = data.google_iam_policy.bigquery_dataset_whitehall.policy_data
 }
 
+resource "google_bigquery_table" "whitehall_assets" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets"
+  description   = "Assets table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/assets.json")
+  clustering    = ["assetable_type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+resource "google_bigquery_table" "whitehall_attachment_data" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "attachment_data"
+  friendly_name = "Attachment Data"
+  description   = "Attachment Data table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/attachment_data.json")
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+resource "google_bigquery_table" "whitehall_attachments" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "attachments"
+  friendly_name = "Attachments"
+  description   = "Attachments table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/attachments.json")
+  clustering    = ["type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
 resource "google_bigquery_table" "whitehall_editions" {
   dataset_id    = google_bigquery_dataset.whitehall.dataset_id
   table_id      = "editions"
@@ -52,5 +90,3 @@ resource "google_bigquery_table" "whitehall_editions" {
     field = "updated_at"
   }
 }
-
-

--- a/terraform-staging/schemas/whitehall/assets.json
+++ b/terraform-staging/schemas/whitehall/assets.json
@@ -1,0 +1,50 @@
+[
+  {
+    "description": "The ID of the asset",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The Asset Manager unique identifier for the asset",
+    "mode": "NULLABLE",
+    "name": "asset_manager_id",
+    "type": "STRING"
+  },
+  {
+    "description": "Some assets have different versions of the same file (such as image sizes). Default is 'original'.",
+    "mode": "NULLABLE",
+    "name": "variant",
+    "type": "STRING"
+  },
+  {
+    "description": "The created timestamp of the asset",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the asset",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The type of the model the asset is associated with (for example 'AttachmentData')",
+    "mode": "NULLABLE",
+    "name": "assetable_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the model the asset is associated with (for example the 'AttachmentData' ID)",
+    "mode": "NULLABLE",
+    "name": "assetable_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The name of the attached file",
+    "mode": "NULLABLE",
+    "name": "filename",
+    "type": "STRING"
+  }
+]

--- a/terraform-staging/schemas/whitehall/attachment_data.json
+++ b/terraform-staging/schemas/whitehall/attachment_data.json
@@ -1,0 +1,50 @@
+[
+  {
+    "description": "The ID of the attachment data",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The name of the attached file",
+    "mode": "NULLABLE",
+    "name": "carrierwave_file",
+    "type": "STRING"
+  },
+  {
+    "description": "The MIME type of the attached file",
+    "mode": "NULLABLE",
+    "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The size of the attached file",
+    "mode": "NULLABLE",
+    "name": "file_size",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The number of pages in the attached file",
+    "mode": "NULLABLE",
+    "name": "number_of_pages",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the attachment data",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the attachment data",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the replacement AttachmentData",
+    "mode": "NULLABLE",
+    "name": "replaced_by_id",
+    "type": "INTEGER"
+  }
+]

--- a/terraform-staging/schemas/whitehall/attachments.json
+++ b/terraform-staging/schemas/whitehall/attachments.json
@@ -1,0 +1,74 @@
+[
+  {
+    "description": "The ID of the attachment",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the attachment",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the attachment",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The title of the attachment",
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the attachment data the attachment is associated with",
+    "mode": "NULLABLE",
+    "name": "attachment_data_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The ID of the attachable the attachment is associated with. The attachable can be an edition, or a non-editionable model.`",
+    "mode": "NULLABLE",
+    "name": "attachable_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The type of the attachable the attachment is associated with. The attachable can be an edition, or a non-editionable model.`",
+    "mode": "NULLABLE",
+    "name": "attachable_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The type of the attachment",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "The slug of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "description": "The locale of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "description": "The content ID of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "description": "A flag to indicate whether the attachment is deleted",
+    "mode": "NULLABLE",
+    "name": "deleted",
+    "type": "BOOLEAN"
+  }
+]

--- a/terraform/bigquery-whitehall.tf
+++ b/terraform/bigquery-whitehall.tf
@@ -40,6 +40,44 @@ resource "google_bigquery_dataset_iam_policy" "whitehall" {
   policy_data = data.google_iam_policy.bigquery_dataset_whitehall.policy_data
 }
 
+resource "google_bigquery_table" "whitehall_assets" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets"
+  description   = "Assets table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/assets.json")
+  clustering    = ["assetable_type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+resource "google_bigquery_table" "whitehall_attachment_data" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "attachment_data"
+  friendly_name = "Attachment Data"
+  description   = "Attachment Data table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/attachment_data.json")
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
+resource "google_bigquery_table" "whitehall_attachments" {
+  dataset_id    = google_bigquery_dataset.whitehall.dataset_id
+  table_id      = "attachments"
+  friendly_name = "Attachments"
+  description   = "Attachments table from the GOV.UK Whitehall MySQL database"
+  schema        = file("schemas/whitehall/attachments.json")
+  clustering    = ["type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}
+
 resource "google_bigquery_table" "whitehall_editions" {
   dataset_id    = google_bigquery_dataset.whitehall.dataset_id
   table_id      = "editions"
@@ -52,5 +90,3 @@ resource "google_bigquery_table" "whitehall_editions" {
     field = "updated_at"
   }
 }
-
-

--- a/terraform/schemas/whitehall/assets.json
+++ b/terraform/schemas/whitehall/assets.json
@@ -1,0 +1,50 @@
+[
+  {
+    "description": "The ID of the asset",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The Asset Manager unique identifier for the asset",
+    "mode": "NULLABLE",
+    "name": "asset_manager_id",
+    "type": "STRING"
+  },
+  {
+    "description": "Some assets have different versions of the same file (such as image sizes). Default is 'original'.",
+    "mode": "NULLABLE",
+    "name": "variant",
+    "type": "STRING"
+  },
+  {
+    "description": "The created timestamp of the asset",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the asset",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The type of the model the asset is associated with (for example 'AttachmentData')",
+    "mode": "NULLABLE",
+    "name": "assetable_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the model the asset is associated with (for example the 'AttachmentData' ID)",
+    "mode": "NULLABLE",
+    "name": "assetable_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The name of the attached file",
+    "mode": "NULLABLE",
+    "name": "filename",
+    "type": "STRING"
+  }
+]

--- a/terraform/schemas/whitehall/attachment_data.json
+++ b/terraform/schemas/whitehall/attachment_data.json
@@ -1,0 +1,50 @@
+[
+  {
+    "description": "The ID of the attachment data",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The name of the attached file",
+    "mode": "NULLABLE",
+    "name": "carrierwave_file",
+    "type": "STRING"
+  },
+  {
+    "description": "The MIME type of the attached file",
+    "mode": "NULLABLE",
+    "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The size of the attached file",
+    "mode": "NULLABLE",
+    "name": "file_size",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The number of pages in the attached file",
+    "mode": "NULLABLE",
+    "name": "number_of_pages",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the attachment data",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the attachment data",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the replacement AttachmentData",
+    "mode": "NULLABLE",
+    "name": "replaced_by_id",
+    "type": "INTEGER"
+  }
+]

--- a/terraform/schemas/whitehall/attachments.json
+++ b/terraform/schemas/whitehall/attachments.json
@@ -1,0 +1,74 @@
+[
+  {
+    "description": "The ID of the attachment",
+    "mode": "NULLABLE",
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The created timestamp of the attachment",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The updated timestamp of the attachment",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The title of the attachment",
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "description": "The ID of the attachment data the attachment is associated with",
+    "mode": "NULLABLE",
+    "name": "attachment_data_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The ID of the attachable the attachment is associated with. The attachable can be an edition, or a non-editionable model.`",
+    "mode": "NULLABLE",
+    "name": "attachable_id",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The type of the attachable the attachment is associated with. The attachable can be an edition, or a non-editionable model.`",
+    "mode": "NULLABLE",
+    "name": "attachable_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The type of the attachment",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "The slug of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "slug",
+    "type": "STRING"
+  },
+  {
+    "description": "The locale of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "locale",
+    "type": "STRING"
+  },
+  {
+    "description": "The content ID of the attachment (only for HTML Attachments)",
+    "mode": "NULLABLE",
+    "name": "content_id",
+    "type": "STRING"
+  },
+  {
+    "description": "A flag to indicate whether the attachment is deleted",
+    "mode": "NULLABLE",
+    "name": "deleted",
+    "type": "BOOLEAN"
+  }
+]


### PR DESCRIPTION
Added:
- attachments
- assets
- attachment_data

These tables, alongside the upcoming data from Asset Manager (pipeline TBD), should give us a good picture of the state of assets.

[Trello](https://trello.com/c/EmdtD0tK/3523-replicate-part-of-the-whitehall-database-in-google-bigquery)