### PR TITLE
Fix escaped characters in whitehall data pipeline attachments table

### DIFF
--- a/src/whitehall/functions.sh
+++ b/src/whitehall/functions.sh
@@ -50,7 +50,7 @@ export_attachments_to_bigquery() {
   local table_name="attachments"
   local csv_name="/data/mysql/table_${table_name}"
 
-   mysql -u root ${dataset_name} -e "SELECT id,created_at,updated_at,title,attachment_data_id,attachable_id,attachable_type,type,slug,locale,content_id,deleted
+   mysql -u root ${dataset_name} -e "SELECT id,created_at,updated_at,REPLACE(REPLACE(title,'\n',' '),'\"','') as title,attachment_data_id,attachable_id,attachable_type,type,slug,locale,content_id,deleted
                                      INTO OUTFILE '${csv_name}'
                                      FIELDS TERMINATED BY ','
                                      ENCLOSED BY '\"'


### PR DESCRIPTION
Some of the values we receive in the title field look like `Peer review of  \"some other thing\"` or `string \n string` (for long titles), tripping up our bq load from the csv. This commit replaces any occurrences of `\"` with `` and any occurrences of `\n` with ` `. A slight mismatch in the title should be ok, since we mostly care about matching IDs for the monitoring tool we're using the data pipeline for.

[Trello](https://trello.com/c/EmdtD0tK/3523-replicate-part-of-the-whitehall-database-in-google-bigquery)