### PR TITLE
Add asset-manager data pipeline

### DIFF
--- a/.github/workflows/docker-asset-manager-dev.yml
+++ b/.github/workflows/docker-asset-manager-dev.yml
@@ -1,0 +1,74 @@
+name: Docker-asset-manager-dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'docker/asset-manager/**'
+      - '.github/workflows/docker-asset-manager-dev.yml'
+
+defaults:
+  run:
+    working-directory: docker/asset-manager
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'asset-manager'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      # actions/checkout MUST come before auth
+      - uses: 'actions/checkout@v4'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/628722085506/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+          service_account: 'artifact-registry-docker@govuk-knowledge-graph-dev.iam.gserviceaccount.com'
+
+      # Further steps are automatically authenticated
+
+      # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+      # Build the Docker image
+      - name: Docker build
+        id: build
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF" .
+
+      # Push the Docker image to Google Container Registry
+      - name: Docker push
+        id: push
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+          docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-asset-manager-staging.yml
+++ b/.github/workflows/docker-asset-manager-staging.yml
@@ -1,0 +1,74 @@
+name: Docker-asset-manager-staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - staging
+    paths:
+      - 'docker/asset-manager/**'
+      - '.github/workflows/docker-asset-manager-staging.yml'
+
+defaults:
+  run:
+    working-directory: docker/asset-manager
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'asset-manager'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      # actions/checkout MUST come before auth
+      - uses: 'actions/checkout@v4'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/957740527277/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+          service_account: 'artifact-registry-docker@govuk-knowledge-graph-staging.iam.gserviceaccount.com'
+
+      # Further steps are automatically authenticated
+
+      # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+      # Build the Docker image
+      - name: Docker build
+        id: build
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF" .
+
+      # Push the Docker image to Google Container Registry
+      - name: Docker push
+        id: push
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+          docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/.github/workflows/docker-asset-manager.yml
+++ b/.github/workflows/docker-asset-manager.yml
@@ -1,0 +1,74 @@
+name: Docker-asset-manager
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/asset-manager/**'
+      - '.github/workflows/docker-asset-manager.yml'
+
+defaults:
+  run:
+    working-directory: docker/asset-manager
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: 'asset-manager'
+  REGISTRY_HOSTNAME: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker'
+
+jobs:
+
+  terraform:
+    name: 'Docker Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      # actions/checkout MUST come before auth
+      - uses: 'actions/checkout@v4'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/19513753240/locations/global/workloadIdentityPools/github-pool/providers/github-pool-provider'
+          service_account: 'artifact-registry-docker@govuk-knowledge-graph.iam.gserviceaccount.com'
+
+      # Further steps are automatically authenticated
+
+      # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          # Set up docker to authenticate
+          # via gcloud command-line tool.
+          gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+      # Build the Docker image
+      - name: Docker build
+        id: build
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker build -t "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF" .
+
+      # Push the Docker image to Google Container Registry
+      - name: Docker push
+        id: push
+        run: |
+          TAG=$(echo "$GITHUB_REF" | awk -F/ '{print $NF}')
+          export TAG
+          echo "$TAG"
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG"
+          docker tag "$REGISTRY_HOSTNAME"/"$IMAGE":"$TAG" "$REGISTRY_HOSTNAME"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$IMAGE":latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,8 +29,14 @@ for debugging. It has the Redis CLI available and is configured to easily access
 the Redis instance that the GovSearch app uses to manage GOV.UK Signon user
 state.
 
+# [`asset-manager`][asset-manager]
+
+For a virtual machine in GCE (Google Compute Engine). It extracts data from a
+backup of the Asset Manager app database, and imports it into BigQuery.
+
 [html-to-text]: ./html-to-text
 [publisher]: ./publisher
 [publishing-api]: ./publisher-api
 [support-api]: ./support-api
 [redis-cli]: ./redis-cli
+[asset-manager]: ./asset-manager

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,6 +29,11 @@ for debugging. It has the Redis CLI available and is configured to easily access
 the Redis instance that the GovSearch app uses to manage GOV.UK Signon user
 state.
 
+# [`whitehall`][whitehall]
+
+For a virtual machine in GCE (Google Compute Engine). It extracts data from a
+backup of the Whitehall app database, and imports it into BigQuery.
+
 # [`asset-manager`][asset-manager]
 
 For a virtual machine in GCE (Google Compute Engine). It extracts data from a
@@ -39,4 +44,5 @@ backup of the Asset Manager app database, and imports it into BigQuery.
 [publishing-api]: ./publisher-api
 [support-api]: ./support-api
 [redis-cli]: ./redis-cli
+[whitehall]: ./whitehall
 [asset-manager]: ./asset-manager

--- a/docker/asset-manager/Dockerfile
+++ b/docker/asset-manager/Dockerfile
@@ -1,0 +1,30 @@
+FROM mongo:8.0.4
+
+# Install gcloud
+# https://cloud.google.com/sdk/docs/install#deb
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update -y
+RUN apt-get install -y \
+  apt-transport-https \
+  ca-certificates \
+  gnupg \
+  curl
+RUN \
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+  | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+  | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+  && apt-get update -y \
+  && apt-get install google-cloud-cli -y \
+  # Clean up
+  && rm -rf /var/lib/apt/lists/*
+
+ARG GITHUB_SHA=missing
+ENV GITHUB_SHA=${GITHUB_SHA}
+
+ARG GITHUB_REF=missing
+ENV GITHUB_REF=${GITHUB_REF}
+
+ENTRYPOINT []
+COPY entrypoint.sh .
+CMD bash entrypoint.sh

--- a/docker/asset-manager/README.md
+++ b/docker/asset-manager/README.md
@@ -1,0 +1,35 @@
+# Virtual machine to import Asset Manager app data into BigQuery
+
+The Asset Manager app is used to store files and metadata for the publishing apps. Its database is backed up daily to files in AWS S3, which are copied into a GCP bucket by the [govuk-s3-mirror][govuk-s3-mirror].
+
+A virtual machine fetches the scripts in this directory from the copy of the HEAD of this repository that is synced to a [bucket][bucket], and runs [`run.sh`][run.sh], which initiates the following steps.
+
+1. Fetch the database backup file. It knows where to find it from environment variables that are set when the [workflow][workflow-terraform] starts the virtual machine.
+2. Use `mongorestore` to import the backup into a running MongoDB database.
+3. Export the results of a query to csv.
+4. Upload the csv file to a bucket, and thence to BigQuery. This step could be refactored to upload the data directly to BigQuery. It was done this way for consistency with other, similar data pipelines that did so to make the data easily available in bulk, because it's very difficult to export large amounts of data from BigQuery. There is no longer a need for bulk data outside of BigQuery.
+5. Load the csv data to a table in BigQuery, using the "write disposition", which is equivalent to WRITE_TRUNCATE in SQL. It empties the table and wipes its schema, before inserting new rows. This is done within a transaction.
+
+## Build the image
+
+This folder only contains the `Dockerfile` and `entrypoint.sh`. A [GitHub action][github-action] rebuilds the image when these files are changed, and pushes it to the Artifact Registry.
+
+The rest of the code is in [`src/asset-manager`][src]. When the VM starts, the `entrypoint.sh` script fetches that code and runs it. This separation avoids having to rebuild the docker image when only changing the code that it runs.
+
+## Trigger the VM to start
+
+When the [govuk-s3-mirror][govuk-s3-mirror] finishes copying any file into its GCP bucket, it publishes a message to Pub/Sub channel. This project subscribes to that channel. A [workflow][workflow-terraform] reads the messages, and if they describe a file whose name fits the pattern for Asset Manager database backups, then it starts an instance of this virtual machine.
+
+### Manually start the VM
+
+Open a recent, successful [workflow-run][workflow-runs]. Its state will be `return_started_asset_manager Succeeded`. Click "Execute again" and then "Execute". This will run the workflow with the last input, which was a message that carried the information that the VM needs to find the Asset Manager database backup file.
+
+If the most recent successful workflow run was a few days ago, then the Asset Manager database backup file that it responded to might have been deleted. In this case, make a new copy of any of the Asset Manager database backup files that do exist in the [bucket][bucket] (typically named in the format `<timestamp>-govuk_assets_production.gz`). Doing so will create a new message in Pub/Sub, which will soon trigger the workflow to start the VM.
+
+[govuk-s3-mirror]: https://github.com/alphagov/govuk-s3-mirror
+[bucket]: https://console.cloud.google.com/storage/browser/govuk-s3-mirror_govuk-database-backups/shared-documentdb
+[workflow-terraform]: ../../terraform/workflows/govuk-database-backups.yaml
+[workflow-runs]: https://console.cloud.google.com/workflows/workflow/europe-west2/govuk-database-backups/executions?project=govuk-knowledge-graph&pli=1
+[src]: ../../src/asset-manager
+[github-action]: ../../.github/workflows/docker-asset-manager.yml
+[run.sh]: ../../src/asset-manager/run.sh

--- a/docker/asset-manager/entrypoint.sh
+++ b/docker/asset-manager/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Run a script from a copy of the HEAD of the repository.
+# This sometimes fails with
+#
+# > ERROR: (gcloud.storage.cat) You do not currently have an active account selected.
+#
+# So retry for a few minutes. Newly-built containers don't seem to work immediately.
+
+MAX_RETRIES=10
+RETRY_INTERVAL_SECONDS=60
+COUNTER=0
+CMD="gcloud storage cat gs://${PROJECT_ID}-repository/src/asset-manager/run.sh"
+
+while [ $COUNTER -lt $MAX_RETRIES ]; do
+  $CMD
+  if [ $? -eq 0 ]; then
+    break
+  else
+    echo "Command failed, retrying in ${RETRY_INTERVAL_SECONDS} seconds..."
+    sleep $RETRY_INTERVAL_SECONDS
+    let COUNTER=COUNTER+1
+  fi
+done
+
+if [ $COUNTER -eq $MAX_RETRIES ]; then
+  echo "Command failed after $MAX_RETRIES attempts, exiting..."
+  exit 1
+fi
+
+$CMD | bash

--- a/src/asset-manager/README.md
+++ b/src/asset-manager/README.md
@@ -1,0 +1,58 @@
+# Import Asset Manager data into BigQuery
+
+The Asset Manager service is used to store files and metadata for the publishing apps. Its database is backed up daily to files in AWS S3, which are copied into a GCP bucket by the [govuk-s3-mirror][govuk-s3-mirror].
+
+A virtual machine fetches the scripts in this directory from the copy of the HEAD of this repository that is synced to a [bucket][bucket], and runs [`run.sh`][run.sh], which initiates the following steps.
+
+1. Fetch the database backup file. It knows where to find it from environment variables that are set when the [workflow][workflow-terraform] starts the virtual machine ([more details][docker]).
+2. Use `mongorestore` to import the backup into a running MongoDB database.
+3. Export the results of a query to csv.
+4. Load the csv data to a table in BigQuery, using the "write disposition", which is equivalent to WRITE_TRUNCATE in SQL. It empties the table and wipes its schema, before inserting new rows. This is done within a transaction.
+
+## Dockerfile
+
+The [Docker configuration][docker] is separate, so that changes to the code here don't cause the image to be rebuilt unnecessarily.  When the virtual machine starts, it fetches [`run.sh`][run.sh] from the copy of the HEAD of this repository that is synced to a [bucket][bucket].
+
+## Testing locally
+
+To test locally:
+
+1. Add a line to [`run.sh`][run.sh] `tail -f /dev/null` before the command that deletes the virtual machine.
+2. Upload your modified copy of [run.sh]
+3. [Manually start the VM][docker-readme].
+4. SSH into the VM.
+
+### SSH into a VM
+
+Once a VM instance is running, you can SSH into it from your local device, in the
+terminal.
+
+```sh
+# SSH into the instance
+gcloud compute ssh \
+  --zone "europe-west2-b" \
+  "asset-manager" \
+  --project "govuk-knowledge-graph" \
+  --tunnel-through-iap
+
+# Wait a while for the docker image to start (about 30 seconds to a minute)
+
+# Get the ID of the docker container. For example, `klt--gdxf`.
+docker ps
+
+# Tail the logs of the mongodb docker image
+docker logs -tf klt--gdxf
+
+# Tail the logs of the postgres docker image
+docker logs -tf klt--gdxf
+
+# Otherwise, SSH directly from your device into the docker container
+gcloud compute ssh --zone "europe-west2-b" "asset-manager" --project "govuk-knowledge-graph" -- container "klt--gdxf"
+```
+
+[govuk-s3-mirror]: https://github.com/alphagov/govuk-s3-mirror
+[bucket]: https://console.cloud.google.com/storage/browser/govuk-knowledge-graph-repository
+[docker]: ../../docker/asset-manager
+[docker-readme]: ../../docker/asset-manager/README.md
+[run.sh]: ./run.sh
+[workflow-terraform]: ../../terraform/workflows/govuk-database-backups.yaml

--- a/src/asset-manager/query.js
+++ b/src/asset-manager/query.js
@@ -1,9 +1,31 @@
 db.assets.aggregate([
   {
     $project: {
-      md5_hexdigest: false,
-      etag: false,
-      auth_bypass_ids: false,
+      _id: { $toString: "$_id" },
+      created_at: { $toString: "$created_at" },
+      updated_at: { $toString: "$updated_at" },
+      replacement_id: { $toString: "$replacement_id" },
+      state: true,
+      filename_history: true,
+      uuid: true,
+      draft: true,
+      redirect_url: true,
+      last_modified: { $toString: "$last_modified" },
+      size: true,
+      content_type: true,
+      access_limited: {
+        $cond: {
+          if: { $eq: ["$access_limited", false] },
+          then: [],
+          else: "$access_limited"
+        }
+      },
+      access_limited_organisation_ids: true,
+      parent_document_url: true,
+      deleted_at: { $toString: "$deleted_at" },
+      file: true,
+      _type: true,
+      legacy_url_path: true
     }
   },
   {

--- a/src/asset-manager/query.js
+++ b/src/asset-manager/query.js
@@ -1,0 +1,12 @@
+db.assets.aggregate([
+  {
+    $project: {
+      md5_hexdigest: false,
+      etag: false,
+      auth_bypass_ids: false,
+    }
+  },
+  {
+    $out: "output"
+  },
+])

--- a/src/asset-manager/run.sh
+++ b/src/asset-manager/run.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Run both mongod and scripts that interact with the database
+# https://docs.docker.com/config/containers/multi-service_container/
+
+# turn on bash's job control
+set -mex
+
+# Start mongo and put it in the background
+mongod --fork --syslog
+
+# Wait for mongo to start
+sleep 5
+
+# Restore the Asset Manager app database from its backup .bson file in GCP Storage
+
+# Construct the file's URL
+OBJECT=$(
+gcloud compute instances describe asset-manager \
+  --project $PROJECT_ID \
+  --zone $ZONE \
+  --format="value[separator=\"/\"](metadata.items.object_bucket, metadata.items.object_name)"
+)
+OBJECT_URL="gs://$OBJECT"
+
+gcloud storage cat "${OBJECT_URL}" \
+  | gunzip -c \
+  | mongorestore --archive --nsInclude=govuk_assets_production.assets
+
+# Obtain the latest state of the repository
+gcloud storage cp -r gs://$PROJECT_ID-repository/\* .
+
+# Prepare to export some data to BigQuery
+cd src/asset-manager
+
+DATABASE=govuk_assets_production
+QUERY=query.js
+OUTPUT_COLLECTION=output
+FILE=assets
+OBJECT="gs://${PROJECT_ID}-data-processed/asset-manager/${FILE}.csv.gz"
+DATASET=asset_manager
+TABLE="${DATASET}.${FILE}"
+SCHEMA_NAME="schema_${FILE}"
+
+# Create a collection in mongodb of relevant assets.
+mongosh ${DATABASE} ${QUERY}
+
+# 1. Export that dataset
+# 2. Upload it to a cloud bucket
+mongoexport \
+  --quiet \
+  --db=govuk_assets_production \
+  --type=csv \
+  --collection="${OUTPUT_COLLECTION}" \
+  --fields=_id,created_at,updated_at,replacement_id,state,uuid,draft,redirect_url,last_modified,size,content_type,parent_document_url,deleted_at,file,_type,legacy_url_path \
+  | gcloud storage cp - "${OBJECT}" --quiet --gzip-in-flight-all
+
+bq show \
+  --schema=true \
+  --format=json \
+  "${DATASET}.${FILE}" \
+  > "${SCHEMA_NAME}"
+
+# Upload the dataset from the cloud bucket to a BigQuery table
+bq load \
+  --quiet=true \
+  --replace \
+  --source_format="CSV" \
+  --allow_quoted_newlines \
+  --skip_leading_rows=1 \
+  --schema="${SCHEMA_NAME}" \
+  "${TABLE}" \
+  "${OBJECT}"
+
+# Stop this instance
+# https://stackoverflow.com/a/41232669
+ gcloud compute instances delete asset-manager --quiet --zone=$ZONE

--- a/src/asset-manager/run.sh
+++ b/src/asset-manager/run.sh
@@ -36,7 +36,7 @@ DATABASE=govuk_assets_production
 QUERY=query.js
 OUTPUT_COLLECTION=output
 FILE=assets
-OBJECT="gs://${PROJECT_ID}-data-processed/asset-manager/${FILE}.csv.gz"
+OBJECT="gs://${PROJECT_ID}-data-processed/asset-manager/${FILE}.json.gz"
 DATASET=asset_manager
 TABLE="${DATASET}.${FILE}"
 SCHEMA_NAME="schema_${FILE}"
@@ -49,9 +49,9 @@ mongosh ${DATABASE} ${QUERY}
 mongoexport \
   --quiet \
   --db=govuk_assets_production \
-  --type=csv \
+  --type=json \
   --collection="${OUTPUT_COLLECTION}" \
-  --fields=_id,created_at,updated_at,replacement_id,state,uuid,draft,redirect_url,last_modified,size,content_type,parent_document_url,deleted_at,file,_type,legacy_url_path \
+  --fields=created_at,updated_at,replacement_id,state,filename_history,uuid,draft,redirect_url,last_modified,size,content_type,access_limited,access_limited_organisation_ids,parent_document_url,deleted_at,file,_type,legacy_url_path \
   | gcloud storage cp - "${OBJECT}" --quiet --gzip-in-flight-all
 
 bq show \
@@ -64,9 +64,7 @@ bq show \
 bq load \
   --quiet=true \
   --replace \
-  --source_format="CSV" \
-  --allow_quoted_newlines \
-  --skip_leading_rows=1 \
+  --source_format="NEWLINE_DELIMITED_JSON" \
   --schema="${SCHEMA_NAME}" \
   "${TABLE}" \
   "${OBJECT}"

--- a/terraform-dev/artifact-registry.tf
+++ b/terraform-dev/artifact-registry.tf
@@ -61,6 +61,8 @@ data "google_iam_policy" "artifact_registry_docker" {
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
+
     ]
   }
 

--- a/terraform-dev/bigquery-asset-manager.tf
+++ b/terraform-dev/bigquery-asset-manager.tf
@@ -1,0 +1,54 @@
+# A dataset of tables from the Asset Manager mongo database
+
+resource "google_bigquery_dataset" "asset_manager" {
+  dataset_id            = "asset_manager"
+  friendly_name         = "Asset Manager"
+  description           = "Data from the GOV.UK Asset Manager database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_asset_manager" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_asset_manager.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_asset_manager_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "asset_manager" {
+  dataset_id  = google_bigquery_dataset.asset_manager.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_asset_manager.policy_data
+}
+
+resource "google_bigquery_table" "asset_manager_assets" {
+  dataset_id    = google_bigquery_dataset.asset_manager.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets"
+  description   = "Assets table from the GOV.UK Asset Manager mongo database"
+  schema        = file("schemas/asset-manager/assets.json")
+  clustering    = ["content_type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}

--- a/terraform-dev/environment.auto.tfvars
+++ b/terraform-dev/environment.auto.tfvars
@@ -82,3 +82,7 @@ bigquery_test_data_viewer_members = [
 # BigQuery dataset: whitehall
 bigquery_whitehall_data_viewer_members = [
 ]
+
+# BigQuery dataset: asset-manager
+bigquery_asset_manager_data_viewer_members = [
+]

--- a/terraform-dev/main-gcp.tf
+++ b/terraform-dev/main-gcp.tf
@@ -176,6 +176,10 @@ variable "bigquery_whitehall_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_asset_manager_data_viewer_members" {
+  type = list(string)
+}
+
 terraform {
   required_providers {
     google = {
@@ -300,6 +304,7 @@ data "google_iam_policy" "project" {
         google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
         google_service_account.gce_whitehall.member,
+        google_service_account.gce_asset_manager.member,
         google_service_account.govgraphsearch.member,
       ],
       var.bigquery_job_user_members
@@ -370,6 +375,7 @@ data "google_iam_policy" "project" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]
@@ -422,7 +428,8 @@ data "google_iam_policy" "project" {
     members = [
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member,
-      google_service_account.gce_whitehall.member
+      google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member
     ]
   }
 

--- a/terraform-dev/schemas/asset-manager/assets.json
+++ b/terraform-dev/schemas/asset-manager/assets.json
@@ -30,6 +30,12 @@
     "type": "STRING"
   },
   {
+    "description": "An array comprising the asset's history of filenames",
+    "mode": "REPEATED",
+    "name": "filename_history",
+    "type": "STRING"
+  },
+  {
     "description": "The asset UUID",
     "mode": "NULLABLE",
     "name": "uuid",
@@ -42,7 +48,7 @@
     "type": "BOOLEAN"
   },
   {
-    "description": "The URL the asset should redirect to, typically when the parent edition is unpublished",
+    "description": "The URL the asset should redirect to",
     "mode": "NULLABLE",
     "name": "redirect_url",
     "type": "STRING"
@@ -63,6 +69,18 @@
     "description": "The MIME type of the asset",
     "mode": "NULLABLE",
     "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "An array comprising access limited user content IDs (deprecated)",
+    "mode": "REPEATED",
+    "name": "access_limited",
+    "type": "STRING"
+  },
+  {
+    "description": "An array comprising access limited organisation content IDs",
+    "mode": "REPEATED",
+    "name": "access_limited_organisation_ids",
     "type": "STRING"
   },
   {

--- a/terraform-dev/schemas/asset-manager/assets.json
+++ b/terraform-dev/schemas/asset-manager/assets.json
@@ -1,0 +1,98 @@
+[
+  {
+    "description": "The Asset Manager MongoDB ID for the asset",
+    "mode": "NULLABLE",
+    "name": "_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the asset was created",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the asset was last updated",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the replacement asset (this asset will redirect to it)",
+    "mode": "NULLABLE",
+    "name": "replacement_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The state of the asset, relating to upload and virus scanning status",
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "description": "The asset UUID",
+    "mode": "NULLABLE",
+    "name": "uuid",
+    "type": "STRING"
+  },
+  {
+    "description": "A flag indicating whether the asset is available on the draft or live stack",
+    "mode": "NULLABLE",
+    "name": "draft",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The URL the asset should redirect to, typically when the parent edition is unpublished",
+    "mode": "NULLABLE",
+    "name": "redirect_url",
+    "type": "STRING"
+  },
+  {
+    "description": "The last time the asset was modified",
+    "mode": "NULLABLE",
+    "name": "last_modified",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The size of the asset",
+    "mode": "NULLABLE",
+    "name": "size",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The MIME type of the asset",
+    "mode": "NULLABLE",
+    "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The URL of the parent document, either a draft or live url",
+    "mode": "NULLABLE",
+    "name": "parent_document_url",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the asset was deleted from Asset Manager",
+    "mode": "NULLABLE",
+    "name": "deleted_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The name of the asset file",
+    "mode": "NULLABLE",
+    "name": "file",
+    "type": "STRING"
+  },
+  {
+    "description": "Legacy field, either 'WhitehallAsset' or 'Asset', used to capture whether an asset came from Whitehall; Whitehall assets had a legacy_url_path",
+    "mode": "NULLABLE",
+    "name": "_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The legacy path at which a WhitehallAsset can be found",
+    "mode": "NULLABLE",
+    "name": "legacy_url_path",
+    "type": "STRING"
+  }
+]

--- a/terraform-dev/storage.tf
+++ b/terraform-dev/storage.tf
@@ -51,6 +51,7 @@ data "google_iam_policy" "bucket_repository" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
     ]
   }
 
@@ -107,6 +108,7 @@ data "google_iam_policy" "bucket_data_processed" {
     role = "roles/storage.objectAdmin"
     members = [
       google_service_account.gce_publisher.member,
+      google_service_account.gce_asset_manager.member,
     ]
   }
 

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -25,6 +25,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
       whitehall_metadata_value      = jsonencode(module.whitehall-container.metadata_value)
+      asset_manager_metadata_value  = jsonencode(module.asset-manager-container.metadata_value)
     }
   )
 }

--- a/terraform-dev/workflows/govuk-database-backups.yaml
+++ b/terraform-dev/workflows/govuk-database-backups.yaml
@@ -149,6 +149,35 @@ main:
                           value: ${whitehall_metadata_value}
             - return_started_whitehall:
                 return: $${"Started whitehall instance"}
+        - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_assets_production\\.gz$")}
+          steps:
+            - log_starting_asset_manager_instance:
+                call: sys.log
+                args:
+                  text: "Starting asset-manager instance"
+                  severity: INFO
+            - start_asset_manager:
+                call: googleapis.compute.v1.instances.insert
+                args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/asset-manager
+                  body:
+                    name: asset-manager
+                    metadata:
+                      items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${asset_manager_metadata_value}
+            - return_started_asset_manager:
+                return: $${"Started asset-manager instance"}
   - log_not_starting_instance:
       call: sys.log
       args:

--- a/terraform-staging/artifact-registry.tf
+++ b/terraform-staging/artifact-registry.tf
@@ -61,6 +61,8 @@ data "google_iam_policy" "artifact_registry_docker" {
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
+
     ]
   }
 

--- a/terraform-staging/bigquery-asset-manager.tf
+++ b/terraform-staging/bigquery-asset-manager.tf
@@ -1,0 +1,54 @@
+# A dataset of tables from the Asset Manager mongo database
+
+resource "google_bigquery_dataset" "asset_manager" {
+  dataset_id            = "asset_manager"
+  friendly_name         = "Asset Manager"
+  description           = "Data from the GOV.UK Asset Manager database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_asset_manager" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_asset_manager.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_asset_manager_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "asset_manager" {
+  dataset_id  = google_bigquery_dataset.asset_manager.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_asset_manager.policy_data
+}
+
+resource "google_bigquery_table" "asset_manager_assets" {
+  dataset_id    = google_bigquery_dataset.asset_manager.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets"
+  description   = "Assets table from the GOV.UK Asset Manager mongo database"
+  schema        = file("schemas/asset-manager/assets.json")
+  clustering    = ["content_type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}

--- a/terraform-staging/environment.auto.tfvars
+++ b/terraform-staging/environment.auto.tfvars
@@ -84,3 +84,7 @@ bigquery_test_data_viewer_members = [
 # BigQuery dataset: whitehall
 bigquery_whitehall_data_viewer_members = [
 ]
+
+# BigQuery dataset: asset-manager
+bigquery_asset_manager_data_viewer_members = [
+]

--- a/terraform-staging/main-gcp.tf
+++ b/terraform-staging/main-gcp.tf
@@ -176,6 +176,10 @@ variable "bigquery_whitehall_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_asset_manager_data_viewer_members" {
+  type = list(string)
+}
+
 terraform {
   required_providers {
     google = {
@@ -300,6 +304,7 @@ data "google_iam_policy" "project" {
         google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
         google_service_account.gce_whitehall.member,
+        google_service_account.gce_asset_manager.member,
         google_service_account.govgraphsearch.member,
       ],
       var.bigquery_job_user_members
@@ -370,6 +375,7 @@ data "google_iam_policy" "project" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]
@@ -422,7 +428,8 @@ data "google_iam_policy" "project" {
     members = [
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member,
-      google_service_account.gce_whitehall.member
+      google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member
     ]
   }
 

--- a/terraform-staging/schemas/asset-manager/assets.json
+++ b/terraform-staging/schemas/asset-manager/assets.json
@@ -30,6 +30,12 @@
     "type": "STRING"
   },
   {
+    "description": "An array comprising the asset's history of filenames",
+    "mode": "REPEATED",
+    "name": "filename_history",
+    "type": "STRING"
+  },
+  {
     "description": "The asset UUID",
     "mode": "NULLABLE",
     "name": "uuid",
@@ -42,7 +48,7 @@
     "type": "BOOLEAN"
   },
   {
-    "description": "The URL the asset should redirect to, typically when the parent edition is unpublished",
+    "description": "The URL the asset should redirect to",
     "mode": "NULLABLE",
     "name": "redirect_url",
     "type": "STRING"
@@ -63,6 +69,18 @@
     "description": "The MIME type of the asset",
     "mode": "NULLABLE",
     "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "An array comprising access limited user content IDs (deprecated)",
+    "mode": "REPEATED",
+    "name": "access_limited",
+    "type": "STRING"
+  },
+  {
+    "description": "An array comprising access limited organisation content IDs",
+    "mode": "REPEATED",
+    "name": "access_limited_organisation_ids",
     "type": "STRING"
   },
   {

--- a/terraform-staging/schemas/asset-manager/assets.json
+++ b/terraform-staging/schemas/asset-manager/assets.json
@@ -1,0 +1,98 @@
+[
+  {
+    "description": "The Asset Manager MongoDB ID for the asset",
+    "mode": "NULLABLE",
+    "name": "_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the asset was created",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the asset was last updated",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the replacement asset (this asset will redirect to it)",
+    "mode": "NULLABLE",
+    "name": "replacement_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The state of the asset, relating to upload and virus scanning status",
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "description": "The asset UUID",
+    "mode": "NULLABLE",
+    "name": "uuid",
+    "type": "STRING"
+  },
+  {
+    "description": "A flag indicating whether the asset is available on the draft or live stack",
+    "mode": "NULLABLE",
+    "name": "draft",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The URL the asset should redirect to, typically when the parent edition is unpublished",
+    "mode": "NULLABLE",
+    "name": "redirect_url",
+    "type": "STRING"
+  },
+  {
+    "description": "The last time the asset was modified",
+    "mode": "NULLABLE",
+    "name": "last_modified",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The size of the asset",
+    "mode": "NULLABLE",
+    "name": "size",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The MIME type of the asset",
+    "mode": "NULLABLE",
+    "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The URL of the parent document, either a draft or live url",
+    "mode": "NULLABLE",
+    "name": "parent_document_url",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the asset was deleted from Asset Manager",
+    "mode": "NULLABLE",
+    "name": "deleted_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The name of the asset file",
+    "mode": "NULLABLE",
+    "name": "file",
+    "type": "STRING"
+  },
+  {
+    "description": "Legacy field, either 'WhitehallAsset' or 'Asset', used to capture whether an asset came from Whitehall; Whitehall assets had a legacy_url_path",
+    "mode": "NULLABLE",
+    "name": "_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The legacy path at which a WhitehallAsset can be found",
+    "mode": "NULLABLE",
+    "name": "legacy_url_path",
+    "type": "STRING"
+  }
+]

--- a/terraform-staging/storage.tf
+++ b/terraform-staging/storage.tf
@@ -51,6 +51,7 @@ data "google_iam_policy" "bucket_repository" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
     ]
   }
 
@@ -107,6 +108,7 @@ data "google_iam_policy" "bucket_data_processed" {
     role = "roles/storage.objectAdmin"
     members = [
       google_service_account.gce_publisher.member,
+      google_service_account.gce_asset_manager.member,
     ]
   }
 

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -25,6 +25,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
       whitehall_metadata_value      = jsonencode(module.whitehall-container.metadata_value)
+      asset_manager_metadata_value  = jsonencode(module.asset-manager-container.metadata_value)
     }
   )
 }

--- a/terraform-staging/workflows/govuk-database-backups.yaml
+++ b/terraform-staging/workflows/govuk-database-backups.yaml
@@ -149,6 +149,35 @@ main:
                           value: ${whitehall_metadata_value}
             - return_started_whitehall:
                 return: $${"Started whitehall instance"}
+        - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_assets_production\\.gz$")}
+          steps:
+            - log_starting_asset_manager_instance:
+                call: sys.log
+                args:
+                  text: "Starting asset-manager instance"
+                  severity: INFO
+            - start_asset_manager:
+                call: googleapis.compute.v1.instances.insert
+                args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/asset-manager
+                  body:
+                    name: asset-manager
+                    metadata:
+                      items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${asset_manager_metadata_value}
+            - return_started_asset_manager:
+                return: $${"Started asset-manager instance"}
   - log_not_starting_instance:
       call: sys.log
       args:

--- a/terraform/artifact-registry.tf
+++ b/terraform/artifact-registry.tf
@@ -61,6 +61,8 @@ data "google_iam_policy" "artifact_registry_docker" {
       google_service_account.gce_publisher.member,
       google_service_account.gce_redis_cli.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
+
     ]
   }
 

--- a/terraform/bigquery-asset-manager.tf
+++ b/terraform/bigquery-asset-manager.tf
@@ -1,0 +1,54 @@
+# A dataset of tables from the Asset Manager mongo database
+
+resource "google_bigquery_dataset" "asset_manager" {
+  dataset_id            = "asset_manager"
+  friendly_name         = "Asset Manager"
+  description           = "Data from the GOV.UK Asset Manager database"
+  location              = "europe-west2"
+  max_time_travel_hours = "48"
+}
+
+data "google_iam_policy" "bigquery_dataset_asset_manager" {
+  binding {
+    role = "roles/bigquery.dataEditor"
+    members = [
+      "projectWriters",
+      google_service_account.bigquery_scheduled_queries.member,
+      google_service_account.gce_asset_manager.member,
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataOwner"
+    members = [
+      "projectOwners",
+    ]
+  }
+  binding {
+    role = "roles/bigquery.dataViewer"
+    members = concat(
+      [
+        "projectReaders",
+        google_service_account.bigquery_scheduled_queries_search.member,
+      ],
+      var.bigquery_asset_manager_data_viewer_members,
+    )
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "asset_manager" {
+  dataset_id  = google_bigquery_dataset.asset_manager.dataset_id
+  policy_data = data.google_iam_policy.bigquery_dataset_asset_manager.policy_data
+}
+
+resource "google_bigquery_table" "asset_manager_assets" {
+  dataset_id    = google_bigquery_dataset.asset_manager.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets"
+  description   = "Assets table from the GOV.UK Asset Manager mongo database"
+  schema        = file("schemas/asset-manager/assets.json")
+  clustering    = ["content_type"]
+  time_partitioning {
+    type  = "MONTH"
+    field = "updated_at"
+  }
+}

--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -110,3 +110,7 @@ bigquery_test_data_viewer_members = [
 # BigQuery dataset: whitehall
 bigquery_whitehall_data_viewer_members = [
 ]
+
+# BigQuery dataset: asset-manager
+bigquery_asset_manager_data_viewer_members = [
+]

--- a/terraform/main-gcp.tf
+++ b/terraform/main-gcp.tf
@@ -176,6 +176,10 @@ variable "bigquery_whitehall_data_viewer_members" {
   type = list(string)
 }
 
+variable "bigquery_asset_manager_data_viewer_members" {
+  type = list(string)
+}
+
 terraform {
   required_providers {
     google = {
@@ -300,6 +304,7 @@ data "google_iam_policy" "project" {
         google_service_account.gce_support_api.member,
         google_service_account.gce_publisher.member,
         google_service_account.gce_whitehall.member,
+        google_service_account.gce_asset_manager.member,
         google_service_account.govgraphsearch.member,
       ],
       var.bigquery_job_user_members
@@ -370,6 +375,7 @@ data "google_iam_policy" "project" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member
     ]
@@ -422,7 +428,8 @@ data "google_iam_policy" "project" {
     members = [
       google_service_account.workflow_govuk_database_backups.member,
       google_service_account.workflow_redis_cli.member,
-      google_service_account.gce_whitehall.member
+      google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member
     ]
   }
 

--- a/terraform/schemas/asset-manager/assets.json
+++ b/terraform/schemas/asset-manager/assets.json
@@ -30,6 +30,12 @@
     "type": "STRING"
   },
   {
+    "description": "An array comprising the asset's history of filenames",
+    "mode": "REPEATED",
+    "name": "filename_history",
+    "type": "STRING"
+  },
+  {
     "description": "The asset UUID",
     "mode": "NULLABLE",
     "name": "uuid",
@@ -42,7 +48,7 @@
     "type": "BOOLEAN"
   },
   {
-    "description": "The URL the asset should redirect to, typically when the parent edition is unpublished",
+    "description": "The URL the asset should redirect to",
     "mode": "NULLABLE",
     "name": "redirect_url",
     "type": "STRING"
@@ -63,6 +69,18 @@
     "description": "The MIME type of the asset",
     "mode": "NULLABLE",
     "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "An array comprising access limited user content IDs (deprecated)",
+    "mode": "REPEATED",
+    "name": "access_limited",
+    "type": "STRING"
+  },
+  {
+    "description": "An array comprising access limited organisation content IDs",
+    "mode": "REPEATED",
+    "name": "access_limited_organisation_ids",
     "type": "STRING"
   },
   {

--- a/terraform/schemas/asset-manager/assets.json
+++ b/terraform/schemas/asset-manager/assets.json
@@ -1,0 +1,98 @@
+[
+  {
+    "description": "The Asset Manager MongoDB ID for the asset",
+    "mode": "NULLABLE",
+    "name": "_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the asset was created",
+    "mode": "NULLABLE",
+    "name": "created_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The time at which the asset was last updated",
+    "mode": "NULLABLE",
+    "name": "updated_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The ID of the replacement asset (this asset will redirect to it)",
+    "mode": "NULLABLE",
+    "name": "replacement_id",
+    "type": "STRING"
+  },
+  {
+    "description": "The state of the asset, relating to upload and virus scanning status",
+    "mode": "NULLABLE",
+    "name": "state",
+    "type": "STRING"
+  },
+  {
+    "description": "The asset UUID",
+    "mode": "NULLABLE",
+    "name": "uuid",
+    "type": "STRING"
+  },
+  {
+    "description": "A flag indicating whether the asset is available on the draft or live stack",
+    "mode": "NULLABLE",
+    "name": "draft",
+    "type": "BOOLEAN"
+  },
+  {
+    "description": "The URL the asset should redirect to, typically when the parent edition is unpublished",
+    "mode": "NULLABLE",
+    "name": "redirect_url",
+    "type": "STRING"
+  },
+  {
+    "description": "The last time the asset was modified",
+    "mode": "NULLABLE",
+    "name": "last_modified",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The size of the asset",
+    "mode": "NULLABLE",
+    "name": "size",
+    "type": "INTEGER"
+  },
+  {
+    "description": "The MIME type of the asset",
+    "mode": "NULLABLE",
+    "name": "content_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The URL of the parent document, either a draft or live url",
+    "mode": "NULLABLE",
+    "name": "parent_document_url",
+    "type": "STRING"
+  },
+  {
+    "description": "The time at which the asset was deleted from Asset Manager",
+    "mode": "NULLABLE",
+    "name": "deleted_at",
+    "type": "TIMESTAMP"
+  },
+  {
+    "description": "The name of the asset file",
+    "mode": "NULLABLE",
+    "name": "file",
+    "type": "STRING"
+  },
+  {
+    "description": "Legacy field, either 'WhitehallAsset' or 'Asset', used to capture whether an asset came from Whitehall; Whitehall assets had a legacy_url_path",
+    "mode": "NULLABLE",
+    "name": "_type",
+    "type": "STRING"
+  },
+  {
+    "description": "The legacy path at which a WhitehallAsset can be found",
+    "mode": "NULLABLE",
+    "name": "legacy_url_path",
+    "type": "STRING"
+  }
+]

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -51,6 +51,7 @@ data "google_iam_policy" "bucket_repository" {
       google_service_account.gce_support_api.member,
       google_service_account.gce_publisher.member,
       google_service_account.gce_whitehall.member,
+      google_service_account.gce_asset_manager.member,
     ]
   }
 
@@ -107,6 +108,7 @@ data "google_iam_policy" "bucket_data_processed" {
     role = "roles/storage.objectAdmin"
     members = [
       google_service_account.gce_publisher.member,
+      google_service_account.gce_asset_manager.member,
     ]
   }
 

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -25,6 +25,7 @@ resource "google_workflows_workflow" "govuk_database_backups" {
       support_api_metadata_value    = jsonencode(module.support-api-container.metadata_value)
       publisher_metadata_value      = jsonencode(module.publisher-container.metadata_value)
       whitehall_metadata_value      = jsonencode(module.whitehall-container.metadata_value)
+      asset_manager_metadata_value  = jsonencode(module.asset-manager-container.metadata_value)
     }
   )
 }

--- a/terraform/workflows/govuk-database-backups.yaml
+++ b/terraform/workflows/govuk-database-backups.yaml
@@ -149,6 +149,35 @@ main:
                           value: ${whitehall_metadata_value}
             - return_started_whitehall:
                 return: $${"Started whitehall instance"}
+        - condition: $${text.match_regex(object_name, "^shared-documentdb/\\d{4}-\\d{2}-\\d{2}T\\d{6}Z-govuk_assets_production\\.gz$")}
+          steps:
+            - log_starting_asset_manager_instance:
+                call: sys.log
+                args:
+                  text: "Starting asset-manager instance"
+                  severity: INFO
+            - start_asset_manager:
+                call: googleapis.compute.v1.instances.insert
+                args:
+                  project: ${project_id}
+                  zone: ${zone}
+                  sourceInstanceTemplate: https://www.googleapis.com/compute/v1/projects/${project_id}/global/instanceTemplates/asset-manager
+                  body:
+                    name: asset-manager
+                    metadata:
+                      items:
+                        - key: object_bucket
+                          value: $${object_bucket}
+                        - key: object_name
+                          value: $${object_name}
+                        - key: google-logging-enabled
+                          value: true
+                        - key: serial-port-logging-enable
+                          value: true
+                        - key: gce-container-declaration
+                          value: ${asset_manager_metadata_value}
+            - return_started_asset_manager:
+                return: $${"Started asset-manager instance"}
   - log_not_starting_instance:
       call: sys.log
       args:


### PR DESCRIPTION
This adds a pipeline to push Asset Manager assets data into Google BigQuery. Alongside the work done in https://github.com/alphagov/govuk-knowledge-graph-gcp/pull/771, it will allow us to query the `asset_manager` and `whitehall` datasets to capture any data inconsistencies.

[Trello](https://trello.com/c/MCQYx02N/3598-replicate-the-asset-manager-database-in-google-cloudsql)