### PR TITLE
feat: widen access to Whitehall and Asset Manager

### DIFF
--- a/terraform/environment.auto.tfvars
+++ b/terraform/environment.auto.tfvars
@@ -116,8 +116,10 @@ bigquery_test_data_viewer_members = [
 
 # BigQuery dataset: whitehall
 bigquery_whitehall_data_viewer_members = [
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk",
 ]
 
 # BigQuery dataset: asset-manager
 bigquery_asset_manager_data_viewer_members = [
+  "group:govgraph-private-data-readers@digital.cabinet-office.gov.uk",
 ]


### PR DESCRIPTION
Currently only members of https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govgraph-developers have access. This PR would widen access to include https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govgraph-private-data-readers, which is everyone in GOV.UK.