### PR TITLE
feat: derive an 'actions' table from Publisher

### DIFF
--- a/docker/publisher/Dockerfile
+++ b/docker/publisher/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get install -y \
   apt-transport-https \
   ca-certificates \
   gnupg \
+  make \
   curl
 RUN \
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \

--- a/src/publisher/Makefile
+++ b/src/publisher/Makefile
@@ -1,0 +1,24 @@
+SHELL := /bin/bash
+
+# Parallelise with all cores, if possible
+NPROCS = $(shell grep -c 'processor' /proc/cpuinfo)
+MAKEFLAGS += -j$(NPROCS)
+
+MONGO_DATABASE=govuk_content_production
+BQ_DATASET=publisher
+
+# Names of tables in the Mongo database to export to Cloud Storage
+# and BigQuery
+EXPORT = editions actions
+
+# A step to create all the targets described in the CSV.GZ and BIGQUERY
+# variables, which means that all the .sh and .sql scripts in the SH and
+# BIGQUERY variables will be executed.
+.PHONY: all
+all: $(EXPORT)
+
+editions:
+	source functions.sh; export_query_to_bigquery "${MONGO_DATABASE}" "${PROJECT_ID}" "${BQ_DATASET}" "editions" "url,updated_at,version_number,state,major_change"
+
+actions:
+	source functions.sh; export_query_to_bigquery "${MONGO_DATABASE}" "${PROJECT_ID}" "${BQ_DATASET}" "actions" "url,version_number,action_created_at,action_request_type"

--- a/src/publisher/actions.js
+++ b/src/publisher/actions.js
@@ -1,0 +1,23 @@
+// The steps that each new edition has gone through up to publication.
+// Can by joined to the editions table by the url and version_number.
+
+db.editions.aggregate([
+  // 'archived' editions were once 'published', and have since been superseded by
+  // a later edition.
+  { $match: { "state": { $in: [ "published", "archived" ] } } },
+  { $match: { "slug": { $ne: null } } },
+  { $unwind: "$actions" },
+  { $addFields: {
+    "action_created_at": "$actions.created_at",
+    "action_request_type": "$actions.request_type"
+  } },
+  { $unset: "actions" },
+  { $project: {
+    _id: false,
+    "url": { "$concat": [ "https://www.gov.uk/", "$slug" ] },
+    version_number: true, // sequence, sometimes in a different order from updated_at e.g. /1619-bursary-fund
+    action_created_at: true,
+    action_request_type: true,
+  } },
+  { $out: "actions_output"},
+])

--- a/src/publisher/editions.js
+++ b/src/publisher/editions.js
@@ -28,5 +28,5 @@ db.editions.aggregate([
     state: true, // 'published', or 'archived' if superseded
     major_change: true, // not often true
   } },
-  { $out: "output"},
+  { $out: "editions_output"},
 ])

--- a/src/publisher/functions.sh
+++ b/src/publisher/functions.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+set -e
+
+# Export a table from an SQL dump file, upload to storage and import into BigQuery
+export_query_to_bigquery () {
+  local mongo_database="$1"
+  local gcp_project_id="$2"
+  local bq_dataset="$3"
+  local bq_table="$4"
+  local fields="$5"
+
+  local query="${bq_table}.js"
+  local collection="${bq_table}_output"
+  local object="gs://${gcp_project_id}-data-processed/publisher/${bq_table}.csv.gz"
+  local table="${bq_dataset}.${bq_table}"
+
+  # Create a dataset in mongodb of relevant metadata about relevant editions of
+  # documents.
+  mongosh "${mongo_database}" "${query}"
+
+  # Export that dataset
+  # Upload it to a cloud bucket
+  mongoexport \
+    --quiet \
+    --db="${mongo_database}" \
+    --type=csv \
+    --collection="${collection}" \
+    --fields="${fields}" \
+    | gcloud storage cp - "${object}" --quiet --gzip-in-flight-all
+
+  # Upload the dataset from the cloud bucket to a BigQuery table
+  bq --project_id "${gcp_project_id}" load \
+    --quiet=true \
+    --replace \
+    --source_format="CSV" \
+    --allow_quoted_newlines \
+    --skip_leading_rows=1 \
+    "${table}" \
+    "${object}"
+}

--- a/src/publisher/run.sh
+++ b/src/publisher/run.sh
@@ -32,37 +32,7 @@ gcloud storage cp -r gs://$PROJECT_ID-repository/\* .
 # Prepare to export some data to BigQuery
 cd src/publisher
 
-DATABASE=govuk_content_production
-QUERY=query.js
-OUTPUT_COLLECTION=output
-FILE=editions
-OBJECT="gs://${PROJECT_ID}-data-processed/publisher/${FILE}.csv.gz"
-DATASET=publisher
-TABLE="${DATASET}.${FILE}"
-
-# Create a dataset in mongodb of relevant metadata about relevant editions of
-# documents.
-mongosh ${DATABASE} ${QUERY}
-
-# 1. Export that dataset
-# 2. Upload it to a cloud bucket
-mongoexport \
-  --quiet \
-  --db=govuk_content_production \
-  --type=csv \
-  --collection="${OUTPUT_COLLECTION}" \
-  --fields=url,updated_at,version_number,state,major_change \
-  | gcloud storage cp - "${OBJECT}" --quiet --gzip-in-flight-all
-
-# Upload the dataset from the cloud bucket to a BigQuery table
-bq load \
-  --quiet=true \
-  --replace \
-  --source_format="CSV" \
-  --allow_quoted_newlines \
-  --skip_leading_rows=1 \
-  "${TABLE}" \
-  "${OBJECT}"
+make
 
 # Stop this instance
 # https://stackoverflow.com/a/41232669

--- a/terraform-dev/bigquery-publisher.tf
+++ b/terraform-dev/bigquery-publisher.tf
@@ -46,3 +46,11 @@ resource "google_bigquery_table" "publisher_editions" {
   description   = "Editions table derived from the GOV.UK Publisher app Mongo database"
   schema        = file("schemas/publisher/editions.json")
 }
+
+resource "google_bigquery_table" "publisher_actions" {
+  dataset_id    = google_bigquery_dataset.publisher.dataset_id
+  table_id      = "actions"
+  friendly_name = "Actions"
+  description   = "Actions table derived from the GOV.UK Publisher app Mongo database. Many actions occur per edition, leading to publication."
+  schema        = file("schemas/publisher/actions.json")
+}

--- a/terraform-dev/schemas/publisher/actions.json
+++ b/terraform-dev/schemas/publisher/actions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+  },
+  {
+    "name": "version_number",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Sometimes in a different sequence from updated_at, e.g. /1619-bursary-fund"
+  },
+  {
+    "name": "action_created_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "description": "When the action occurred"
+  },
+  {
+    "name": "action_request_type",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "E.g. 'send_fact_check', 'request_amendments', 'note'."
+  }
+]

--- a/terraform-staging/bigquery-publisher.tf
+++ b/terraform-staging/bigquery-publisher.tf
@@ -46,3 +46,11 @@ resource "google_bigquery_table" "publisher_editions" {
   description   = "Editions table derived from the GOV.UK Publisher app Mongo database"
   schema        = file("schemas/publisher/editions.json")
 }
+
+resource "google_bigquery_table" "publisher_actions" {
+  dataset_id    = google_bigquery_dataset.publisher.dataset_id
+  table_id      = "actions"
+  friendly_name = "Actions"
+  description   = "Actions table derived from the GOV.UK Publisher app Mongo database. Many actions occur per edition, leading to publication."
+  schema        = file("schemas/publisher/actions.json")
+}

--- a/terraform-staging/schemas/publisher/actions.json
+++ b/terraform-staging/schemas/publisher/actions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+  },
+  {
+    "name": "version_number",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Sometimes in a different sequence from updated_at, e.g. /1619-bursary-fund"
+  },
+  {
+    "name": "action_created_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "description": "When the action occurred"
+  },
+  {
+    "name": "action_request_type",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "E.g. 'send_fact_check', 'request_amendments', 'note'."
+  }
+]

--- a/terraform/bigquery-publisher.tf
+++ b/terraform/bigquery-publisher.tf
@@ -46,3 +46,11 @@ resource "google_bigquery_table" "publisher_editions" {
   description   = "Editions table derived from the GOV.UK Publisher app Mongo database"
   schema        = file("schemas/publisher/editions.json")
 }
+
+resource "google_bigquery_table" "publisher_actions" {
+  dataset_id    = google_bigquery_dataset.publisher.dataset_id
+  table_id      = "actions"
+  friendly_name = "Actions"
+  description   = "Actions table derived from the GOV.UK Publisher app Mongo database. Many actions occur per edition, leading to publication."
+  schema        = file("schemas/publisher/actions.json")
+}

--- a/terraform/schemas/publisher/actions.json
+++ b/terraform/schemas/publisher/actions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "URL of a document. Not broken down into chapters of guide or travel_advice documents."
+  },
+  {
+    "name": "version_number",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Sometimes in a different sequence from updated_at, e.g. /1619-bursary-fund"
+  },
+  {
+    "name": "action_created_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "description": "When the action occurred"
+  },
+  {
+    "name": "action_request_type",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "E.g. 'send_fact_check', 'request_amendments', 'note'."
+  }
+]


### PR DESCRIPTION
Implements #792

Many actions are taken per new edition. For example, "request_amendments", "send_fact_check". Each of those is a row in this table. It can be joined to the "editions" table by the URL and version_number.
