### PR TITLE
fix: cloud run deploy github action permissions

### DIFF
--- a/terraform-dev/http-to-bucket.tf
+++ b/terraform-dev/http-to-bucket.tf
@@ -38,3 +38,18 @@ resource "google_cloud_run_v2_service_iam_policy" "http_to_bucket" {
   name        = google_cloud_run_v2_service.http_to_bucket.name
   policy_data = data.google_iam_policy.cloud_run_http_to_bucket.policy_data
 }
+
+data "google_iam_policy" "service_account_http_to_bucket" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+
+    members = [
+      google_service_account.artifact_registry_docker.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "service_account_http_to_bucket" {
+  service_account_id = google_service_account.http_to_bucket.name
+  policy_data        = data.google_iam_policy.service_account_http_to_bucket.policy_data
+}

--- a/terraform-staging/http-to-bucket.tf
+++ b/terraform-staging/http-to-bucket.tf
@@ -38,3 +38,18 @@ resource "google_cloud_run_v2_service_iam_policy" "http_to_bucket" {
   name        = google_cloud_run_v2_service.http_to_bucket.name
   policy_data = data.google_iam_policy.cloud_run_http_to_bucket.policy_data
 }
+
+data "google_iam_policy" "service_account_http_to_bucket" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+
+    members = [
+      google_service_account.artifact_registry_docker.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "service_account_http_to_bucket" {
+  service_account_id = google_service_account.http_to_bucket.name
+  policy_data        = data.google_iam_policy.service_account_http_to_bucket.policy_data
+}

--- a/terraform/http-to-bucket.tf
+++ b/terraform/http-to-bucket.tf
@@ -38,3 +38,18 @@ resource "google_cloud_run_v2_service_iam_policy" "http_to_bucket" {
   name        = google_cloud_run_v2_service.http_to_bucket.name
   policy_data = data.google_iam_policy.cloud_run_http_to_bucket.policy_data
 }
+
+data "google_iam_policy" "service_account_http_to_bucket" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+
+    members = [
+      google_service_account.artifact_registry_docker.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "service_account_http_to_bucket" {
+  service_account_id = google_service_account.http_to_bucket.name
+  policy_data        = data.google_iam_policy.service_account_http_to_bucket.policy_data
+}


### PR DESCRIPTION
This used to work, but now more permission is required.
