### PR TITLE
fix: handle the re-use of edition IDs

### DIFF
--- a/terraform-dev/bigquery/extract-content-from-editions.sql
+++ b/terraform-dev/bigquery/extract-content-from-editions.sql
@@ -334,6 +334,10 @@ MERGE INTO
 public.content AS target
 USING private.publishing_api_editions_new_current AS source
 ON source.document_id = target.document_id
+-- Sometimes an edition_id is reused, e.g. if it has been used initially by a
+-- test in a non-production environment (which is where GovGraph gets its data,
+-- as of 2025-05), and then used again for real in production.
+OR source.id = target.edition_id
 WHEN matched THEN DELETE
 ;
 

--- a/terraform-dev/bigquery/publishing-api-editions-current.sql
+++ b/terraform-dev/bigquery/publishing-api-editions-current.sql
@@ -105,6 +105,10 @@ MERGE INTO
 public.publishing_api_editions_current AS target
 USING private.publishing_api_editions_new_current AS source
 ON source.document_id = target.document_id
+-- Sometimes an edition id is reused, e.g. if it has been used initially by a
+-- test in a non-production environment (which is where GovGraph gets its data,
+-- as of 2025-05), and then used again for real in production.
+OR source.id = target.id
 WHEN matched THEN DELETE
 ;
 

--- a/terraform-staging/bigquery/extract-content-from-editions.sql
+++ b/terraform-staging/bigquery/extract-content-from-editions.sql
@@ -334,6 +334,10 @@ MERGE INTO
 public.content AS target
 USING private.publishing_api_editions_new_current AS source
 ON source.document_id = target.document_id
+-- Sometimes an edition_id is reused, e.g. if it has been used initially by a
+-- test in a non-production environment (which is where GovGraph gets its data,
+-- as of 2025-05), and then used again for real in production.
+OR source.id = target.edition_id
 WHEN matched THEN DELETE
 ;
 

--- a/terraform-staging/bigquery/publishing-api-editions-current.sql
+++ b/terraform-staging/bigquery/publishing-api-editions-current.sql
@@ -105,6 +105,10 @@ MERGE INTO
 public.publishing_api_editions_current AS target
 USING private.publishing_api_editions_new_current AS source
 ON source.document_id = target.document_id
+-- Sometimes an edition id is reused, e.g. if it has been used initially by a
+-- test in a non-production environment (which is where GovGraph gets its data,
+-- as of 2025-05), and then used again for real in production.
+OR source.id = target.id
 WHEN matched THEN DELETE
 ;
 

--- a/terraform/bigquery/extract-content-from-editions.sql
+++ b/terraform/bigquery/extract-content-from-editions.sql
@@ -334,6 +334,10 @@ MERGE INTO
 public.content AS target
 USING private.publishing_api_editions_new_current AS source
 ON source.document_id = target.document_id
+-- Sometimes an edition_id is reused, e.g. if it has been used initially by a
+-- test in a non-production environment (which is where GovGraph gets its data,
+-- as of 2025-05), and then used again for real in production.
+OR source.id = target.edition_id
 WHEN matched THEN DELETE
 ;
 

--- a/terraform/bigquery/publishing-api-editions-current.sql
+++ b/terraform/bigquery/publishing-api-editions-current.sql
@@ -105,6 +105,10 @@ MERGE INTO
 public.publishing_api_editions_current AS target
 USING private.publishing_api_editions_new_current AS source
 ON source.document_id = target.document_id
+-- Sometimes an edition id is reused, e.g. if it has been used initially by a
+-- test in a non-production environment (which is where GovGraph gets its data,
+-- as of 2025-05), and then used again for real in production.
+OR source.id = target.id
 WHEN matched THEN DELETE
 ;
 


### PR DESCRIPTION
The Publishing API never re-uses an `edition_id`. But it is possible for GovGraph to see an `edition_id` appear alongside one `document_id` in one Publishing API database dump file, and a alongside a different `document_id` in a subsequent dump file. This causes the same `edition_id` to appear in multiple rows of certain tables, which causes subsequent queries to fail.

1. The production Publishing API is replicated into the Staging environment.
2. A test creates a new edition in the staging environment, with `edition_id=123` and `document_id=456`.
3. A backup of the database is created from the staging environment.
4. GovGraph ingests the new backup and sees a record with `edition_id=123` and `document_id=456`.
5. A new edition is created in the production environment that uses the same `edition_id=123` but `document_id=789`.
6. The production Publishing API is replicated into the Staging environment again.
7. Another backup of the database is created from the staging environment.
8. GovGraph ingests the new backup and sees a record with `edition_id=123` and `document_id=789`.

This affects two `MERGE` statements. They are intended to work as
follows.

1. A row with `edition_id=123` and `document_id=456` is inserted into a table.
2. On another day, a row with `edition_id=234` and `document_id=456` is received.
3. The original row with `edition_id=123` and `document_id=456` is deleted.
4. The new row with `edition_id=234` and `document_id=456` is inserted.

When an `edition_id` is reused with a different `document_id`, the
`MERGE` statements fail as follows.

1. A row with `edition_id=123` and `document_id=456` is inserted into a table.
2. On another day, a row with `edition_id=123` and `document_id=789` is received.
3. The original row with `edition_id=123` and `document_id=456` _isn't_ deleted, because there is no newer edition with the same `document_id`.
4. The new row with `edition_id=123` and `document_id=789` is inserted.
5. There are now two rows, both with `edition_id=123`, but each with different a `document_id`.

First MERGE statement:

```sql
-- Delete rows from the public.publishing_api_editions_current table where a
-- newer edition of the same document is now available.  The newer edition might
-- be private, so use the private editions as the source of the merge.
MERGE INTO
public.publishing_api_editions_current AS target
USING private.publishing_api_editions_new_current AS source
ON source.document_id = target.document_id
WHEN matched THEN DELETE
;
```

Second MERGE statement:

```sql
-- Delete rows from the public.content table where a newer edition of the same
-- document is now available.  The newer edition might be private, so use the
-- private editions as the source of the merge.
MERGE INTO
public.content AS target
USING private.publishing_api_editions_new_current AS source
ON source.document_id = target.document_id
WHEN matched THEN DELETE
;
```

This commit adds another check to the `ON` clause of each `MERGE` statement, to ensure that any rows that have the same `edition_id` are also deleted.

```sql
-- Sometimes an edition_id is reused, e.g. if it has been used initially by a
-- test in a non-production environment (which is where GovGraph gets its data,
-- as of 2025-05), and then used again for real in production.
OR source.edition_id = target.edition_id
```

This works because the table `private.publishing_api_editions_new_current` includes the reused edition. The relevant part of the SQL statement that creates that table is below. It checks whether an incoming edition is newer than any existing edition of the same `document_id`. In this situation, the incoming edition has a different `document_id` from before, so it is seen to be the first edition of a new document, and and it is inserted into `private.publishing_api_editions_new_current`.

```sql
LEFT JOIN private.publishing_api_editions_current ON
  -- same document
  publishing_api_editions_current.document_id = editions.document_id
  -- equal/more recent edition
  AND publishing_api_editions_current.updated_at >= editions.updated_at
-- if there isn't an equal/more recent edition, then this is a new edition
LEFT JOIN publishing_api.unpublishings ON unpublishings.edition_id = editions.id
WHERE publishing_api_editions_current.document_id IS NULL
```
