### PR TITLE
feat: add the document type to publisher editions

### DIFF
--- a/src/publisher/Makefile
+++ b/src/publisher/Makefile
@@ -18,7 +18,7 @@ EXPORT = editions actions
 all: $(EXPORT)
 
 editions:
-	source functions.sh; export_query_to_bigquery "${MONGO_DATABASE}" "${PROJECT_ID}" "${BQ_DATASET}" "editions" "url,updated_at,version_number,state,major_change"
+	source functions.sh; export_query_to_bigquery "${MONGO_DATABASE}" "${PROJECT_ID}" "${BQ_DATASET}" "editions" "url,updated_at,version_number,state,major_change,type"
 
 actions:
 	source functions.sh; export_query_to_bigquery "${MONGO_DATABASE}" "${PROJECT_ID}" "${BQ_DATASET}" "actions" "url,version_number,action_created_at,action_request_type"

--- a/src/publisher/editions.js
+++ b/src/publisher/editions.js
@@ -27,6 +27,7 @@ db.editions.aggregate([
     version_number: true, // sequence, sometimes in a different order from updated_at e.g. /1619-bursary-fund
     state: true, // 'published', or 'archived' if superseded
     major_change: true, // not often true
+    type: "$_type", // 'GuideEdition', 'SmartAnswerEdition', etc.
   } },
   { $out: "editions_output"},
 ])

--- a/terraform-dev/schemas/publisher/editions.json
+++ b/terraform-dev/schemas/publisher/editions.json
@@ -28,5 +28,11 @@
     "type": "BOOLEAN",
     "mode": "REQUIRED",
     "description": "Whether the edition was a major change to the previous edition. Rarely 'true'"
+  },
+  {
+    "name": "type",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "The schema of a document, e.g. 'GuideEdition'"
   }
 ]

--- a/terraform-staging/schemas/publisher/editions.json
+++ b/terraform-staging/schemas/publisher/editions.json
@@ -28,5 +28,11 @@
     "type": "BOOLEAN",
     "mode": "REQUIRED",
     "description": "Whether the edition was a major change to the previous edition. Rarely 'true'"
+  },
+  {
+    "name": "type",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "The schema of a document, e.g. 'GuideEdition'"
   }
 ]

--- a/terraform/schemas/publisher/editions.json
+++ b/terraform/schemas/publisher/editions.json
@@ -28,5 +28,11 @@
     "type": "BOOLEAN",
     "mode": "REQUIRED",
     "description": "Whether the edition was a major change to the previous edition. Rarely 'true'"
+  },
+  {
+    "name": "type",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "The schema of a document, e.g. 'GuideEdition'"
   }
 ]


### PR DESCRIPTION
Mainstream Publisher editions have a type, similar to how Publishing API editions have a schema.

```text
 AnswerEdition  
 CampaignEdition  
 CompletedTransactionEdition  
 GuideEdition  
 HelpPageEdition  
 LicenceEdition  
 LocalTransactionEdition  
 PlaceEdition  
 ProgrammeEdition  
 SimpleSmartAnswerEdition  
 TransactionEdition  
 VideoEdition
```