### PR TITLE
fix: cloud run deploy github action permissions

### DIFF
--- a/terraform-dev/data-loss-prevention.tf
+++ b/terraform-dev/data-loss-prevention.tf
@@ -85,3 +85,18 @@ resource "google_bigquery_job" "deploy_data_loss_prevention" {
     write_disposition  = "" # must be set to "" for scripts
   }
 }
+
+data "google_iam_policy" "service_account_data_loss_prevention" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+
+    members = [
+      google_service_account.artifact_registry_docker.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "service_account_data_loss_prevention" {
+  service_account_id = google_service_account.data_loss_prevention.name
+  policy_data        = data.google_iam_policy.service_account_data_loss_prevention.policy_data
+}

--- a/terraform-staging/data-loss-prevention.tf
+++ b/terraform-staging/data-loss-prevention.tf
@@ -85,3 +85,18 @@ resource "google_bigquery_job" "deploy_data_loss_prevention" {
     write_disposition  = "" # must be set to "" for scripts
   }
 }
+
+data "google_iam_policy" "service_account_data_loss_prevention" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+
+    members = [
+      google_service_account.artifact_registry_docker.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "service_account_data_loss_prevention" {
+  service_account_id = google_service_account.data_loss_prevention.name
+  policy_data        = data.google_iam_policy.service_account_data_loss_prevention.policy_data
+}

--- a/terraform/data-loss-prevention.tf
+++ b/terraform/data-loss-prevention.tf
@@ -85,3 +85,18 @@ resource "google_bigquery_job" "deploy_data_loss_prevention" {
     write_disposition  = "" # must be set to "" for scripts
   }
 }
+
+data "google_iam_policy" "service_account_data_loss_prevention" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+
+    members = [
+      google_service_account.artifact_registry_docker.member,
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "service_account_data_loss_prevention" {
+  service_account_id = google_service_account.data_loss_prevention.name
+  policy_data        = data.google_iam_policy.service_account_data_loss_prevention.policy_data
+}


### PR DESCRIPTION
Similar to #794

The docker-data-loss-prevention GitHub Action failed in the staging project (having succeeded in the others).

```text
google-github-actions/deploy-cloudrun failed with: failed to execute gcloud command `gcloud run deploy data-loss-prevention --image europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker/data-loss-prevention:latest --update-labels ^,^managed-by=github-actions,commit-sha=9f2daea24bc8bd3ed3c6d801052f4e947b810a05 --format json --region europe-west2`: Deploying container to Cloud Run service [data-loss-prevention] in project [govuk-knowledge-graph-staging] region [europe-west2]
Deploying...
failed
Deployment failed
ERROR: (gcloud.run.deploy) PERMISSION_DENIED: Permission 'iam.serviceaccounts.actAs' denied on service account data-loss-prevention@govuk-knowledge-graph-staging.iam.gserviceaccount.com (or it may not exist). This command is authenticated as artifact-registry-docker@govuk-knowledge-graph-staging.iam.gserviceaccount.com using the credentials in /home/runner/work/govuk-knowledge-graph-gcp/govuk-knowledge-graph-gcp/gha-creds-fb205a1ac5b31fd7.json, specified by the [auth/credential_file_override] property.
```
