### PR TITLE
feat: derive assets table from Publishing API

### DIFF
--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -157,6 +157,17 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
   )
 }
 
+resource "google_bigquery_routine" "assets" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "assets"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/assets.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 # Must only be executed after
 # google_bigquery_routine.extract_content_from_editions, which refreshes a table
 # that this depends on.

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -41,6 +41,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "public_attachments" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets of attachments of editions"
+  description   = "Asset metadata extracted from the `details` column of editions. An edition can have many attachments, which can each have many assets (usually two: a document and its thumbnail)."
+  schema        = file("schemas/public/assets.json")
+}
+
 resource "google_bigquery_table" "base_path_lookup" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "base_path_lookup"

--- a/terraform-dev/bigquery/assets.sql
+++ b/terraform-dev/bigquery/assets.sql
@@ -1,0 +1,25 @@
+-- Refresh a table of assets, derived from the Publishing API editions table.
+TRUNCATE TABLE public.assets;
+INSERT INTO public.assets
+SELECT
+  id AS edition_id,
+  attachment_index,
+  BOOL(JSON_QUERY(attachment, "$.accessible")) AS accessible,
+  JSON_VALUE(attachment, "$.alternative_format_contact_email") AS alternative_format_contact_email,
+  JSON_VALUE(attachment, "$.attachment_type") AS attachment_type,
+  JSON_VALUE(attachment, "$.content_type") AS content_type,
+  CAST(JSON_VALUE(attachment, "$.file_size") AS INT64) AS file_size,
+  JSON_VALUE(attachment, "$.locale") AS locale,
+  JSON_VALUE(attachment, "$.title") AS title,
+  JSON_VALUE(attachment, "$.url") AS url,
+  JSON_VALUE(attachment, "$.filename") AS attachment_filename,
+  asset_index,
+  JSON_VALUE(asset, "$.filename") AS asset_filename,
+  JSON_VALUE(asset, "$.asset_manager_id") AS asset_manager_id
+FROM   public.publishing_api_editions_current
+CROSS JOIN
+  UNNEST (JSON_QUERY_ARRAY(details, "$.attachments")) AS attachment WITH OFFSET AS attachment_index
+CROSS JOIN UNNEST (JSON_QUERY_ARRAY(attachment, "$.assets")) AS asset WITH OFFSET AS asset_index
+WHERE JSON_QUERY_ARRAY(details, "$.attachments") IS NOT NULL
+ORDER BY id, attachment_index
+;

--- a/terraform-dev/bigquery/publishing-api-batch.sql
+++ b/terraform-dev/bigquery/publishing-api-batch.sql
@@ -18,6 +18,9 @@ CALL functions.extract_content_from_editions();
 -- Google Analytics ID.
 CALL functions.department_analytics_profile();
 
+-- Update the public table of assets
+CALL functions.assets();
+
 -- Depends on results of functions.extract_content_from_editions();
 CALL functions.base_path_lookup();
 

--- a/terraform-dev/schemas/public/assets.json
+++ b/terraform-dev/schemas/public/assets.json
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Joins to the `id` column of the `publishing_api.editions` table, and its derivatives"
+  },
+  {
+    "name": "attachment_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Ordinal position of the attachment in the `details` column of its parent edition"
+  },
+  {
+    "name": "accessible",
+    "type": "BOOLEAN",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "alternative_format_contact_email",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "attachment_type",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "content_type",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "file_size",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "locale",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "title",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "attachment_filename",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "asset_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Ordinal position of the asset in its parent attachment. Often there are two assets: a document, and its thumbnail with a filename that is prefixed with 'thumbnail_'."
+  },
+  {
+    "name": "asset_filename",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "asset_manager_id",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Joins to the `_id` column of the asset_manager.assets table"
+  }
+]

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -157,6 +157,17 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
   )
 }
 
+resource "google_bigquery_routine" "assets" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "assets"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/assets.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 # Must only be executed after
 # google_bigquery_routine.extract_content_from_editions, which refreshes a table
 # that this depends on.

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -41,6 +41,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "public_attachments" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets of attachments of editions"
+  description   = "Asset metadata extracted from the `details` column of editions. An edition can have many attachments, which can each have many assets (usually two: a document and its thumbnail)."
+  schema        = file("schemas/public/assets.json")
+}
+
 resource "google_bigquery_table" "base_path_lookup" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "base_path_lookup"

--- a/terraform-staging/bigquery/assets.sql
+++ b/terraform-staging/bigquery/assets.sql
@@ -1,0 +1,25 @@
+-- Refresh a table of assets, derived from the Publishing API editions table.
+TRUNCATE TABLE public.assets;
+INSERT INTO public.assets
+SELECT
+  id AS edition_id,
+  attachment_index,
+  BOOL(JSON_QUERY(attachment, "$.accessible")) AS accessible,
+  JSON_VALUE(attachment, "$.alternative_format_contact_email") AS alternative_format_contact_email,
+  JSON_VALUE(attachment, "$.attachment_type") AS attachment_type,
+  JSON_VALUE(attachment, "$.content_type") AS content_type,
+  CAST(JSON_VALUE(attachment, "$.file_size") AS INT64) AS file_size,
+  JSON_VALUE(attachment, "$.locale") AS locale,
+  JSON_VALUE(attachment, "$.title") AS title,
+  JSON_VALUE(attachment, "$.url") AS url,
+  JSON_VALUE(attachment, "$.filename") AS attachment_filename,
+  asset_index,
+  JSON_VALUE(asset, "$.filename") AS asset_filename,
+  JSON_VALUE(asset, "$.asset_manager_id") AS asset_manager_id
+FROM   public.publishing_api_editions_current
+CROSS JOIN
+  UNNEST (JSON_QUERY_ARRAY(details, "$.attachments")) AS attachment WITH OFFSET AS attachment_index
+CROSS JOIN UNNEST (JSON_QUERY_ARRAY(attachment, "$.assets")) AS asset WITH OFFSET AS asset_index
+WHERE JSON_QUERY_ARRAY(details, "$.attachments") IS NOT NULL
+ORDER BY id, attachment_index
+;

--- a/terraform-staging/bigquery/publishing-api-batch.sql
+++ b/terraform-staging/bigquery/publishing-api-batch.sql
@@ -18,6 +18,9 @@ CALL functions.extract_content_from_editions();
 -- Google Analytics ID.
 CALL functions.department_analytics_profile();
 
+-- Update the public table of assets
+CALL functions.assets();
+
 -- Depends on results of functions.extract_content_from_editions();
 CALL functions.base_path_lookup();
 

--- a/terraform-staging/schemas/public/assets.json
+++ b/terraform-staging/schemas/public/assets.json
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Joins to the `id` column of the `publishing_api.editions` table, and its derivatives"
+  },
+  {
+    "name": "attachment_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Ordinal position of the attachment in the `details` column of its parent edition"
+  },
+  {
+    "name": "accessible",
+    "type": "BOOLEAN",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "alternative_format_contact_email",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "attachment_type",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "content_type",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "file_size",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "locale",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "title",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "attachment_filename",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "asset_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Ordinal position of the asset in its parent attachment. Often there are two assets: a document, and its thumbnail with a filename that is prefixed with 'thumbnail_'."
+  },
+  {
+    "name": "asset_filename",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "asset_manager_id",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Joins to the `_id` column of the asset_manager.assets table"
+  }
+]

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -157,6 +157,17 @@ resource "google_bigquery_routine" "extract_content_from_editions" {
   )
 }
 
+resource "google_bigquery_routine" "assets" {
+  dataset_id   = google_bigquery_dataset.functions.dataset_id
+  routine_id   = "assets"
+  routine_type = "PROCEDURE"
+  language     = "SQL"
+  definition_body = templatefile(
+    "bigquery/assets.sql",
+    { project_id = var.project_id, }
+  )
+}
+
 # Must only be executed after
 # google_bigquery_routine.extract_content_from_editions, which refreshes a table
 # that this depends on.

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -41,6 +41,14 @@ resource "google_bigquery_dataset_iam_policy" "public" {
   policy_data = data.google_iam_policy.bigquery_dataset_public.policy_data
 }
 
+resource "google_bigquery_table" "public_attachments" {
+  dataset_id    = google_bigquery_dataset.public.dataset_id
+  table_id      = "assets"
+  friendly_name = "Assets of attachments of editions"
+  description   = "Asset metadata extracted from the `details` column of editions. An edition can have many attachments, which can each have many assets (usually two: a document and its thumbnail)."
+  schema        = file("schemas/public/assets.json")
+}
+
 resource "google_bigquery_table" "base_path_lookup" {
   dataset_id    = google_bigquery_dataset.public.dataset_id
   table_id      = "base_path_lookup"

--- a/terraform/bigquery/assets.sql
+++ b/terraform/bigquery/assets.sql
@@ -1,0 +1,25 @@
+-- Refresh a table of assets, derived from the Publishing API editions table.
+TRUNCATE TABLE public.assets;
+INSERT INTO public.assets
+SELECT
+  id AS edition_id,
+  attachment_index,
+  BOOL(JSON_QUERY(attachment, "$.accessible")) AS accessible,
+  JSON_VALUE(attachment, "$.alternative_format_contact_email") AS alternative_format_contact_email,
+  JSON_VALUE(attachment, "$.attachment_type") AS attachment_type,
+  JSON_VALUE(attachment, "$.content_type") AS content_type,
+  CAST(JSON_VALUE(attachment, "$.file_size") AS INT64) AS file_size,
+  JSON_VALUE(attachment, "$.locale") AS locale,
+  JSON_VALUE(attachment, "$.title") AS title,
+  JSON_VALUE(attachment, "$.url") AS url,
+  JSON_VALUE(attachment, "$.filename") AS attachment_filename,
+  asset_index,
+  JSON_VALUE(asset, "$.filename") AS asset_filename,
+  JSON_VALUE(asset, "$.asset_manager_id") AS asset_manager_id
+FROM   public.publishing_api_editions_current
+CROSS JOIN
+  UNNEST (JSON_QUERY_ARRAY(details, "$.attachments")) AS attachment WITH OFFSET AS attachment_index
+CROSS JOIN UNNEST (JSON_QUERY_ARRAY(attachment, "$.assets")) AS asset WITH OFFSET AS asset_index
+WHERE JSON_QUERY_ARRAY(details, "$.attachments") IS NOT NULL
+ORDER BY id, attachment_index
+;

--- a/terraform/bigquery/publishing-api-batch.sql
+++ b/terraform/bigquery/publishing-api-batch.sql
@@ -18,6 +18,9 @@ CALL functions.extract_content_from_editions();
 -- Google Analytics ID.
 CALL functions.department_analytics_profile();
 
+-- Update the public table of assets
+CALL functions.assets();
+
 -- Depends on results of functions.extract_content_from_editions();
 CALL functions.base_path_lookup();
 

--- a/terraform/schemas/public/assets.json
+++ b/terraform/schemas/public/assets.json
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "edition_id",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Joins to the `id` column of the `publishing_api.editions` table, and its derivatives"
+  },
+  {
+    "name": "attachment_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Ordinal position of the attachment in the `details` column of its parent edition"
+  },
+  {
+    "name": "accessible",
+    "type": "BOOLEAN",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "alternative_format_contact_email",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "attachment_type",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "content_type",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "file_size",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "locale",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "title",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "url",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "attachment_filename",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "asset_index",
+    "type": "INTEGER",
+    "mode": "REQUIRED",
+    "description": "Ordinal position of the asset in its parent attachment. Often there are two assets: a document, and its thumbnail with a filename that is prefixed with 'thumbnail_'."
+  },
+  {
+    "name": "asset_filename",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "asset_manager_id",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Joins to the `_id` column of the asset_manager.assets table"
+  }
+]


### PR DESCRIPTION
Derive a table `public.assets` from the `details` JSON column of the `public.publishing_api_editions_current` table.

* An edition may have many attachments.
* An attachment may have many assets (often two: a document, and its thumbnail).
* Details about each asset can be looked up by joining `public.attachments.asset_manager_id` to `asset_manager.assets._id`.

Closes #796
