### PR TITLE
fix: http-to-bucket handle nested parameters

### DIFF
--- a/docker/http-to-bucket/app.rb
+++ b/docker/http-to-bucket/app.rb
@@ -12,6 +12,7 @@ FunctionsFramework.on_startup do
   require "google/cloud/storage"
   require 'json'
   require 'jmespath'
+  require 'rack'
 end
 
 # Validates the presence of required parameters.
@@ -25,7 +26,7 @@ end
 # Forwards the incoming HTTP request to the target URL.
 def forward_request(request, endpoint_url, headers)
   uri = URI(endpoint_url)
-  uri.query = URI.encode_www_form(request.params)
+  uri.query = Rack::Utils.build_nested_query(request.params)
 
   new_request = Net::HTTP::Get.new(uri.request_uri)
 

--- a/docker/http-to-bucket/spec/app_spec.rb
+++ b/docker/http-to-bucket/spec/app_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "Google Cloud Function: http_to_bucket" do
         response = call_http "http_to_bucket", request
 
         expect(response.status).to eq(200)
-        expect(response.headers["Content-Type"]).to eq("application/text")
+        expect(response.headers["Content-Type"]).to eq("text/plain; charset=utf-8")
         expect(response.body.join).to eq("Success")
       end
 


### PR DESCRIPTION
The Zendesk API uses nested URL parameters, such as `page[size]=5`. When the `http-to-bucket` Cloud Run service receives a request with parameters, it uses `Rack::Utils::parse_nested_query()` to convert the parameters into a hash such as `{"page" => {"size" => "5"}}`. This was then being converted back into a URL with `URI.encode_www_form(request.params)`, which created a url-encoded version of `page={size+=>+"2"}`, and was rejected by the Zendesk API. `Rack::Utils::build_nested_query()` correctly produces a url-encoded version of `page[size]=5`.

The `expect(response.headers["Content-Type"]).to eq("text/plain; charset=utf-8")` change is unrelated. I just noticed that the test was failing, for some reason.
