### PR TITLE
chore(terraform): use region variable everywhere

### DIFF
--- a/terraform-dev/bigquery-asset-manager.tf
+++ b/terraform-dev/bigquery-asset-manager.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "asset_manager" {
   dataset_id            = "asset_manager"
   friendly_name         = "Asset Manager"
   description           = "Data from the GOV.UK Asset Manager database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-content.tf
+++ b/terraform-dev/bigquery-content.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "content" {
   dataset_id            = "content"
   friendly_name         = "content"
   description           = "Deprecated: GOV.UK content data. Please use the 'private' and 'public' datsets instead. Tables in this dataset are now derived from those."
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-functions.tf
+++ b/terraform-dev/bigquery-functions.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "functions" {
   dataset_id            = "functions"
   friendly_name         = "functions"
   description           = "User-defined functions and remote functions"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-graph.tf
+++ b/terraform-dev/bigquery-graph.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "graph" {
   dataset_id            = "graph"
   friendly_name         = "graph"
   description           = "Deprecated: GOV.UK content data as a graph. Please use the 'private' and 'public' datsets instead."
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-private.tf
+++ b/terraform-dev/bigquery-private.tf
@@ -5,7 +5,7 @@ resource "google_bigquery_dataset" "private" {
   dataset_id            = "private"
   friendly_name         = "Private"
   description           = "Data that must not be accessible from outside of GOV.UK"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48" # The minimum is 48
 }
 

--- a/terraform-dev/bigquery-public.tf
+++ b/terraform-dev/bigquery-public.tf
@@ -5,7 +5,7 @@ resource "google_bigquery_dataset" "public" {
   dataset_id            = "public"
   friendly_name         = "Public"
   description           = "Data that must not be accessible from outside of GOV.UK"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48" # The minimum is 48
 }
 

--- a/terraform-dev/bigquery-publisher.tf
+++ b/terraform-dev/bigquery-publisher.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "publisher" {
   dataset_id            = "publisher"
   friendly_name         = "publisher"
   description           = "Data from the GOV.UK Publisher app database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-publishing-api.tf
+++ b/terraform-dev/bigquery-publishing-api.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "publishing_api" {
   dataset_id            = "publishing_api"
   friendly_name         = "Publishing API"
   description           = "Data from the GOV.UK Publishing API database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-search.tf
+++ b/terraform-dev/bigquery-search.tf
@@ -10,7 +10,7 @@ resource "google_bigquery_dataset" "search" {
   dataset_id            = "search"
   friendly_name         = "search"
   description           = "GOV.UK content data"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-smart-survey.tf
+++ b/terraform-dev/bigquery-smart-survey.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "smart_survey" {
   dataset_id            = "smart_survey"
   friendly_name         = "Smart Survey"
   description           = "Data from the Smart Survey API"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-support-api.tf
+++ b/terraform-dev/bigquery-support-api.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "support_api" {
   dataset_id            = "support_api"
   friendly_name         = "Support API"
   description           = "Data from the GOV.UK Support API database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-whitehall.tf
+++ b/terraform-dev/bigquery-whitehall.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "whitehall" {
   dataset_id            = "whitehall"
   friendly_name         = "Whitehall"
   description           = "Data from the GOV.UK Whitehall database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery-zendesk.tf
+++ b/terraform-dev/bigquery-zendesk.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "zendesk" {
   dataset_id            = "zendesk"
   friendly_name         = "Zendesk"
   description           = "Data from the Zendesk API"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/bigquery.tf
+++ b/terraform-dev/bigquery.tf
@@ -9,7 +9,7 @@ resource "google_bigquery_dataset" "test" {
   dataset_id            = "test"
   friendly_name         = "test"
   description           = "Test queries"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-dev/data-loss-prevention.tf
+++ b/terraform-dev/data-loss-prevention.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_service" "data_loss_prevention" {
   template {
     service_account = google_service_account.data_loss_prevention.email
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-dev/gce.tf
+++ b/terraform-dev/gce.tf
@@ -170,7 +170,7 @@ resource "google_compute_subnetwork" "cloudrun" {
   private_ipv6_google_access = "DISABLE_GOOGLE_ACCESS"
   project                    = var.project_id
   purpose                    = "PRIVATE"
-  region                     = "europe-west2"
+  region                     = var.region
   stack_type                 = "IPV4_ONLY"
 }
 
@@ -180,7 +180,7 @@ module "publishing-api-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/publishing-api:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/publishing-api:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -211,7 +211,7 @@ module "support-api-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/support-api:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/support-api:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -270,7 +270,7 @@ module "publisher-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/publisher:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/publisher:latest"
     tty : true
     stdin : true
     volumeMounts = [
@@ -327,7 +327,7 @@ module "redis-cli-container" {
   count = var.enable_redis_session_store_instance ? 1 : 0
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
     tty : true
     stdin : true
     env = [
@@ -363,7 +363,7 @@ module "whitehall-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/whitehall:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/whitehall:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -389,7 +389,7 @@ module "asset-manager-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/asset-manager:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/asset-manager:latest"
     tty : true
     stdin : true
     securityContext = {

--- a/terraform-dev/govgraphsearch.tf
+++ b/terraform-dev/govgraphsearch.tf
@@ -268,7 +268,7 @@ resource "google_cloud_run_service" "govgraphsearch" {
     spec {
       service_account_name = google_service_account.govgraphsearch.email
       containers {
-        image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {
           name  = "GTM_ID"
           value = var.gtm_id

--- a/terraform-dev/govspeak-to-html.tf
+++ b/terraform-dev/govspeak-to-html.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "govpeak_to_html" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/govspeak-to-html:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/govspeak-to-html:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-dev/html-to-text.tf
+++ b/terraform-dev/html-to-text.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "html_to_text" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/html-to-text:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/html-to-text:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-dev/http-to-bucket.tf
+++ b/terraform-dev/http-to-bucket.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_service" "http_to_bucket" {
     service_account = google_service_account.http_to_bucket.email
     containers {
       name  = "http-to-bucket"
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/http-to-bucket:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/http-to-bucket:latest"
       resources {
         limits = {
           cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-dev/logs.tf
+++ b/terraform-dev/logs.tf
@@ -21,7 +21,7 @@ resource "google_service_account_iam_policy" "log_writer" {
 
 resource "google_logging_project_sink" "log_sink" {
   name        = "log-sink"
-  destination = "logging.googleapis.com/projects/gds-bq-reporting/locations/europe-west2/buckets/multi_project"
+  destination = "logging.googleapis.com/projects/gds-bq-reporting/locations/${var.region}/buckets/multi_project"
   exclusions {
     name        = "standard-exclusions"
     description = "Standard exclusions https://docs.data-community.publishing.service.gov.uk/data-sources/gcp-logs/#set-up"

--- a/terraform-dev/parse-html.tf
+++ b/terraform-dev/parse-html.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "parse_html" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-staging/bigquery-asset-manager.tf
+++ b/terraform-staging/bigquery-asset-manager.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "asset_manager" {
   dataset_id            = "asset_manager"
   friendly_name         = "Asset Manager"
   description           = "Data from the GOV.UK Asset Manager database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-content.tf
+++ b/terraform-staging/bigquery-content.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "content" {
   dataset_id            = "content"
   friendly_name         = "content"
   description           = "Deprecated: GOV.UK content data. Please use the 'private' and 'public' datsets instead. Tables in this dataset are now derived from those."
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-functions.tf
+++ b/terraform-staging/bigquery-functions.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "functions" {
   dataset_id            = "functions"
   friendly_name         = "functions"
   description           = "User-defined functions and remote functions"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-graph.tf
+++ b/terraform-staging/bigquery-graph.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "graph" {
   dataset_id            = "graph"
   friendly_name         = "graph"
   description           = "Deprecated: GOV.UK content data as a graph. Please use the 'private' and 'public' datsets instead."
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-private.tf
+++ b/terraform-staging/bigquery-private.tf
@@ -5,7 +5,7 @@ resource "google_bigquery_dataset" "private" {
   dataset_id            = "private"
   friendly_name         = "Private"
   description           = "Data that must not be accessible from outside of GOV.UK"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48" # The minimum is 48
 }
 

--- a/terraform-staging/bigquery-public.tf
+++ b/terraform-staging/bigquery-public.tf
@@ -5,7 +5,7 @@ resource "google_bigquery_dataset" "public" {
   dataset_id            = "public"
   friendly_name         = "Public"
   description           = "Data that must not be accessible from outside of GOV.UK"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48" # The minimum is 48
 }
 

--- a/terraform-staging/bigquery-publisher.tf
+++ b/terraform-staging/bigquery-publisher.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "publisher" {
   dataset_id            = "publisher"
   friendly_name         = "publisher"
   description           = "Data from the GOV.UK Publisher app database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-publishing-api.tf
+++ b/terraform-staging/bigquery-publishing-api.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "publishing_api" {
   dataset_id            = "publishing_api"
   friendly_name         = "Publishing API"
   description           = "Data from the GOV.UK Publishing API database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-search.tf
+++ b/terraform-staging/bigquery-search.tf
@@ -10,7 +10,7 @@ resource "google_bigquery_dataset" "search" {
   dataset_id            = "search"
   friendly_name         = "search"
   description           = "GOV.UK content data"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-smart-survey.tf
+++ b/terraform-staging/bigquery-smart-survey.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "smart_survey" {
   dataset_id            = "smart_survey"
   friendly_name         = "Smart Survey"
   description           = "Data from the Smart Survey API"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-support-api.tf
+++ b/terraform-staging/bigquery-support-api.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "support_api" {
   dataset_id            = "support_api"
   friendly_name         = "Support API"
   description           = "Data from the GOV.UK Support API database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-whitehall.tf
+++ b/terraform-staging/bigquery-whitehall.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "whitehall" {
   dataset_id            = "whitehall"
   friendly_name         = "Whitehall"
   description           = "Data from the GOV.UK Whitehall database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery-zendesk.tf
+++ b/terraform-staging/bigquery-zendesk.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "zendesk" {
   dataset_id            = "zendesk"
   friendly_name         = "Zendesk"
   description           = "Data from the Zendesk API"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/bigquery.tf
+++ b/terraform-staging/bigquery.tf
@@ -9,7 +9,7 @@ resource "google_bigquery_dataset" "test" {
   dataset_id            = "test"
   friendly_name         = "test"
   description           = "Test queries"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform-staging/data-loss-prevention.tf
+++ b/terraform-staging/data-loss-prevention.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_service" "data_loss_prevention" {
   template {
     service_account = google_service_account.data_loss_prevention.email
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-staging/gce.tf
+++ b/terraform-staging/gce.tf
@@ -170,7 +170,7 @@ resource "google_compute_subnetwork" "cloudrun" {
   private_ipv6_google_access = "DISABLE_GOOGLE_ACCESS"
   project                    = var.project_id
   purpose                    = "PRIVATE"
-  region                     = "europe-west2"
+  region                     = var.region
   stack_type                 = "IPV4_ONLY"
 }
 
@@ -180,7 +180,7 @@ module "publishing-api-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/publishing-api:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/publishing-api:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -211,7 +211,7 @@ module "support-api-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/support-api:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/support-api:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -270,7 +270,7 @@ module "publisher-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/publisher:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/publisher:latest"
     tty : true
     stdin : true
     volumeMounts = [
@@ -327,7 +327,7 @@ module "redis-cli-container" {
   count = var.enable_redis_session_store_instance ? 1 : 0
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
     tty : true
     stdin : true
     env = [
@@ -363,7 +363,7 @@ module "whitehall-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/whitehall:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/whitehall:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -389,7 +389,7 @@ module "asset-manager-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/asset-manager:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/asset-manager:latest"
     tty : true
     stdin : true
     securityContext = {

--- a/terraform-staging/govgraphsearch.tf
+++ b/terraform-staging/govgraphsearch.tf
@@ -268,7 +268,7 @@ resource "google_cloud_run_service" "govgraphsearch" {
     spec {
       service_account_name = google_service_account.govgraphsearch.email
       containers {
-        image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {
           name  = "GTM_ID"
           value = var.gtm_id

--- a/terraform-staging/govspeak-to-html.tf
+++ b/terraform-staging/govspeak-to-html.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "govpeak_to_html" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/govspeak-to-html:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/govspeak-to-html:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-staging/html-to-text.tf
+++ b/terraform-staging/html-to-text.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "html_to_text" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/html-to-text:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/html-to-text:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-staging/http-to-bucket.tf
+++ b/terraform-staging/http-to-bucket.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_service" "http_to_bucket" {
     service_account = google_service_account.http_to_bucket.email
     containers {
       name  = "http-to-bucket"
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/http-to-bucket:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/http-to-bucket:latest"
       resources {
         limits = {
           cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-staging/logs.tf
+++ b/terraform-staging/logs.tf
@@ -21,7 +21,7 @@ resource "google_service_account_iam_policy" "log_writer" {
 
 resource "google_logging_project_sink" "log_sink" {
   name        = "log-sink"
-  destination = "logging.googleapis.com/projects/gds-bq-reporting/locations/europe-west2/buckets/multi_project"
+  destination = "logging.googleapis.com/projects/gds-bq-reporting/locations/${var.region}/buckets/multi_project"
   exclusions {
     name        = "standard-exclusions"
     description = "Standard exclusions https://docs.data-community.publishing.service.gov.uk/data-sources/gcp-logs/#set-up"

--- a/terraform-staging/parse-html.tf
+++ b/terraform-staging/parse-html.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "parse_html" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform/bigquery-asset-manager.tf
+++ b/terraform/bigquery-asset-manager.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "asset_manager" {
   dataset_id            = "asset_manager"
   friendly_name         = "Asset Manager"
   description           = "Data from the GOV.UK Asset Manager database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-content.tf
+++ b/terraform/bigquery-content.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "content" {
   dataset_id            = "content"
   friendly_name         = "content"
   description           = "Deprecated: GOV.UK content data. Please use the 'private' and 'public' datsets instead. Tables in this dataset are now derived from those."
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-functions.tf
+++ b/terraform/bigquery-functions.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "functions" {
   dataset_id            = "functions"
   friendly_name         = "functions"
   description           = "User-defined functions and remote functions"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-graph.tf
+++ b/terraform/bigquery-graph.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "graph" {
   dataset_id            = "graph"
   friendly_name         = "graph"
   description           = "Deprecated: GOV.UK content data as a graph. Please use the 'private' and 'public' datsets instead."
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-private.tf
+++ b/terraform/bigquery-private.tf
@@ -5,7 +5,7 @@ resource "google_bigquery_dataset" "private" {
   dataset_id            = "private"
   friendly_name         = "Private"
   description           = "Data that must not be accessible from outside of GOV.UK"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48" # The minimum is 48
 }
 

--- a/terraform/bigquery-public.tf
+++ b/terraform/bigquery-public.tf
@@ -5,7 +5,7 @@ resource "google_bigquery_dataset" "public" {
   dataset_id            = "public"
   friendly_name         = "Public"
   description           = "Data that must not be accessible from outside of GOV.UK"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48" # The minimum is 48
 }
 

--- a/terraform/bigquery-publisher.tf
+++ b/terraform/bigquery-publisher.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "publisher" {
   dataset_id            = "publisher"
   friendly_name         = "publisher"
   description           = "Data from the GOV.UK Publisher app database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-publishing-api.tf
+++ b/terraform/bigquery-publishing-api.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "publishing_api" {
   dataset_id            = "publishing_api"
   friendly_name         = "Publishing API"
   description           = "Data from the GOV.UK Publishing API database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-search.tf
+++ b/terraform/bigquery-search.tf
@@ -10,7 +10,7 @@ resource "google_bigquery_dataset" "search" {
   dataset_id            = "search"
   friendly_name         = "search"
   description           = "GOV.UK content data"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-smart-survey.tf
+++ b/terraform/bigquery-smart-survey.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "smart_survey" {
   dataset_id            = "smart_survey"
   friendly_name         = "Smart Survey"
   description           = "Data from the Smart Survey API"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-support-api.tf
+++ b/terraform/bigquery-support-api.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "support_api" {
   dataset_id            = "support_api"
   friendly_name         = "Support API"
   description           = "Data from the GOV.UK Support API database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-whitehall.tf
+++ b/terraform/bigquery-whitehall.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "whitehall" {
   dataset_id            = "whitehall"
   friendly_name         = "Whitehall"
   description           = "Data from the GOV.UK Whitehall database"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery-zendesk.tf
+++ b/terraform/bigquery-zendesk.tf
@@ -4,7 +4,7 @@ resource "google_bigquery_dataset" "zendesk" {
   dataset_id            = "zendesk"
   friendly_name         = "Zendesk"
   description           = "Data from the Zendesk API"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -9,7 +9,7 @@ resource "google_bigquery_dataset" "test" {
   dataset_id            = "test"
   friendly_name         = "test"
   description           = "Test queries"
-  location              = "europe-west2"
+  location              = var.region
   max_time_travel_hours = "48"
 }
 

--- a/terraform/data-loss-prevention.tf
+++ b/terraform/data-loss-prevention.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_service" "data_loss_prevention" {
   template {
     service_account = google_service_account.data_loss_prevention.email
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform/gce.tf
+++ b/terraform/gce.tf
@@ -170,7 +170,7 @@ resource "google_compute_subnetwork" "cloudrun" {
   private_ipv6_google_access = "DISABLE_GOOGLE_ACCESS"
   project                    = var.project_id
   purpose                    = "PRIVATE"
-  region                     = "europe-west2"
+  region                     = var.region
   stack_type                 = "IPV4_ONLY"
 }
 
@@ -180,7 +180,7 @@ module "publishing-api-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/publishing-api:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/publishing-api:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -211,7 +211,7 @@ module "support-api-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/support-api:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/support-api:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -270,7 +270,7 @@ module "publisher-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/publisher:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/publisher:latest"
     tty : true
     stdin : true
     volumeMounts = [
@@ -327,7 +327,7 @@ module "redis-cli-container" {
   count = var.enable_redis_session_store_instance ? 1 : 0
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/redis-cli:latest"
     tty : true
     stdin : true
     env = [
@@ -363,7 +363,7 @@ module "whitehall-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/whitehall:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/whitehall:latest"
     tty : true
     stdin : true
     securityContext = {
@@ -389,7 +389,7 @@ module "asset-manager-container" {
   version = "~> 2.0"
 
   container = {
-    image = "europe-west2-docker.pkg.dev/${var.project_id}/docker/asset-manager:latest"
+    image = "${var.region}-docker.pkg.dev/${var.project_id}/docker/asset-manager:latest"
     tty : true
     stdin : true
     securityContext = {

--- a/terraform/govgraphsearch.tf
+++ b/terraform/govgraphsearch.tf
@@ -268,7 +268,7 @@ resource "google_cloud_run_service" "govgraphsearch" {
     spec {
       service_account_name = google_service_account.govgraphsearch.email
       containers {
-        image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.cloud_run_source_deploy.repository_id}/govuk-knowledge-graph-search:latest"
         env {
           name  = "GTM_ID"
           value = var.gtm_id

--- a/terraform/govspeak-to-html.tf
+++ b/terraform/govspeak-to-html.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "govpeak_to_html" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/govspeak-to-html:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/govspeak-to-html:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform/html-to-text.tf
+++ b/terraform/html-to-text.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "html_to_text" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/html-to-text:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/html-to-text:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform/http-to-bucket.tf
+++ b/terraform/http-to-bucket.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_service" "http_to_bucket" {
     service_account = google_service_account.http_to_bucket.email
     containers {
       name  = "http-to-bucket"
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/http-to-bucket:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/http-to-bucket:latest"
       resources {
         limits = {
           cpu    = "1000m" # If we put "1" or nothing, terraform reapplies it.

--- a/terraform/logs.tf
+++ b/terraform/logs.tf
@@ -21,7 +21,7 @@ resource "google_service_account_iam_policy" "log_writer" {
 
 resource "google_logging_project_sink" "log_sink" {
   name        = "log-sink"
-  destination = "logging.googleapis.com/projects/gds-bq-reporting/locations/europe-west2/buckets/multi_project"
+  destination = "logging.googleapis.com/projects/gds-bq-reporting/locations/${var.region}/buckets/multi_project"
   exclusions {
     name        = "standard-exclusions"
     description = "Standard exclusions https://docs.data-community.publishing.service.gov.uk/data-sources/gcp-logs/#set-up"

--- a/terraform/parse-html.tf
+++ b/terraform/parse-html.tf
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "parse_html" {
 
   template {
     containers {
-      image = "europe-west2-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/parse-html:latest"
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/560

The region `europe-west2` is hardcoded in many places, but a variable already exists and ought to be used.

`terraform plan` oughtn't and doesn't propose any changes.