### PR TITLE
feat: Use larger batches of PII

### DIFF
--- a/terraform-dev/bigquery/data-loss-prevention.sql
+++ b/terraform-dev/bigquery/data-loss-prevention.sql
@@ -3,5 +3,5 @@ RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.data-loss-prevention`
 OPTIONS (
   endpoint = "${uri}",
-  max_batching_rows=1
+  max_batching_rows=50000
 )

--- a/terraform-staging/bigquery/data-loss-prevention.sql
+++ b/terraform-staging/bigquery/data-loss-prevention.sql
@@ -3,5 +3,5 @@ RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.data-loss-prevention`
 OPTIONS (
   endpoint = "${uri}",
-  max_batching_rows=1
+  max_batching_rows=50000
 )

--- a/terraform/bigquery/data-loss-prevention.sql
+++ b/terraform/bigquery/data-loss-prevention.sql
@@ -3,5 +3,5 @@ RETURNS JSON
 REMOTE WITH CONNECTION `${project_id}.${region}.data-loss-prevention`
 OPTIONS (
   endpoint = "${uri}",
-  max_batching_rows=1
+  max_batching_rows=50000
 )


### PR DESCRIPTION
For much greater speed and efficiency, use the largest batch permitted
by the DLP API.
