### PR TITLE
refactor: configure DLP env vars in terraform

### DIFF
--- a/.github/workflows/docker-data-loss-prevention-dev.yml
+++ b/.github/workflows/docker-data-loss-prevention-dev.yml
@@ -81,5 +81,3 @@ jobs:
         service: 'data-loss-prevention'
         region: 'europe-west2'
         image: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-dev/docker/data-loss-prevention:latest'
-        env_vars: |-
-          PROJECT_ID=govuk-knowledge-graph-dev

--- a/.github/workflows/docker-data-loss-prevention-staging.yml
+++ b/.github/workflows/docker-data-loss-prevention-staging.yml
@@ -81,5 +81,3 @@ jobs:
         service: 'data-loss-prevention'
         region: 'europe-west2'
         image: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph-staging/docker/data-loss-prevention:latest'
-        env_vars: |-
-          PROJECT_ID=govuk-knowledge-graph-staging

--- a/.github/workflows/docker-data-loss-prevention.yml
+++ b/.github/workflows/docker-data-loss-prevention.yml
@@ -81,5 +81,3 @@ jobs:
         service: 'data-loss-prevention'
         region: 'europe-west2'
         image: 'europe-west2-docker.pkg.dev/govuk-knowledge-graph/docker/data-loss-prevention:latest'
-        env_vars: |-
-          PROJECT_ID=govuk-knowledge-graph

--- a/terraform-dev/data-loss-prevention.tf
+++ b/terraform-dev/data-loss-prevention.tf
@@ -9,6 +9,10 @@ resource "google_cloud_run_v2_service" "data_loss_prevention" {
     service_account = google_service_account.data_loss_prevention.email
     containers {
       image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform-staging/data-loss-prevention.tf
+++ b/terraform-staging/data-loss-prevention.tf
@@ -9,6 +9,10 @@ resource "google_cloud_run_v2_service" "data_loss_prevention" {
     service_account = google_service_account.data_loss_prevention.email
     containers {
       image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.

--- a/terraform/data-loss-prevention.tf
+++ b/terraform/data-loss-prevention.tf
@@ -9,6 +9,10 @@ resource "google_cloud_run_v2_service" "data_loss_prevention" {
     service_account = google_service_account.data_loss_prevention.email
     containers {
       image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}/data-loss-prevention:latest"
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
       resources {
         limits = {
           cpu    = "1000m"  # If we put "1" or nothing, terraform reapplies it.


### PR DESCRIPTION
Instead of when deploying via GitHub actions.

Otherwise it's all-to-easy to wipe them when deploying from a local CLI.
