### PR TITLE
feat: remove link_set_id from publisher.links

### DIFF
--- a/terraform-dev/bigquery-publishing-api.tf
+++ b/terraform-dev/bigquery-publishing-api.tf
@@ -131,14 +131,6 @@ resource "google_bigquery_table" "publishing_api_links" {
   friendly_name = "Links"
   description   = "Links table from the GOV.UK Publishing API PostgreSQL database"
   schema        = file("schemas/publishing-api/links.json")
-  range_partitioning {
-    field = "link_set_id"
-    range {
-      start    = 0
-      end      = 10000000 # 10 times the maximum at the end of 2023, which was about 1000000
-      interval = 2500     # 4k partitions, which is the limit
-    }
-  }
 }
 
 resource "google_bigquery_table" "publishing_api_path_reservations" {

--- a/terraform-dev/schemas/publishing-api/links.json
+++ b/terraform-dev/schemas/publishing-api/links.json
@@ -6,11 +6,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "link_set_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "target_content_id",
     "type": "STRING"
   },

--- a/terraform-staging/bigquery-publishing-api.tf
+++ b/terraform-staging/bigquery-publishing-api.tf
@@ -131,14 +131,6 @@ resource "google_bigquery_table" "publishing_api_links" {
   friendly_name = "Links"
   description   = "Links table from the GOV.UK Publishing API PostgreSQL database"
   schema        = file("schemas/publishing-api/links.json")
-  range_partitioning {
-    field = "link_set_id"
-    range {
-      start    = 0
-      end      = 10000000 # 10 times the maximum at the end of 2023, which was about 1000000
-      interval = 2500     # 4k partitions, which is the limit
-    }
-  }
 }
 
 resource "google_bigquery_table" "publishing_api_path_reservations" {

--- a/terraform-staging/schemas/publishing-api/links.json
+++ b/terraform-staging/schemas/publishing-api/links.json
@@ -6,11 +6,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "link_set_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "target_content_id",
     "type": "STRING"
   },

--- a/terraform/bigquery-publishing-api.tf
+++ b/terraform/bigquery-publishing-api.tf
@@ -131,14 +131,6 @@ resource "google_bigquery_table" "publishing_api_links" {
   friendly_name = "Links"
   description   = "Links table from the GOV.UK Publishing API PostgreSQL database"
   schema        = file("schemas/publishing-api/links.json")
-  range_partitioning {
-    field = "link_set_id"
-    range {
-      start    = 0
-      end      = 10000000 # 10 times the maximum at the end of 2023, which was about 1000000
-      interval = 2500     # 4k partitions, which is the limit
-    }
-  }
 }
 
 resource "google_bigquery_table" "publishing_api_path_reservations" {

--- a/terraform/schemas/publishing-api/links.json
+++ b/terraform/schemas/publishing-api/links.json
@@ -6,11 +6,6 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "link_set_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
     "name": "target_content_id",
     "type": "STRING"
   },


### PR DESCRIPTION
Following https://github.com/alphagov/publishing-api/pull/3330.

The range-partition can't be transferred to the replacement column, which is link_set_content_id, because that is a string column. So we must do without partitions.
