### PR TITLE
Guarantee position of organisations in the search page table

### DIFF
--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -41,10 +41,11 @@ WITH
   organisations AS (
     SELECT
       links.source_edition_id AS edition_id,
-      ARRAY_AGG(DISTINCT editions.title) AS titles
+      ARRAY_AGG(editions.title ORDER BY editions.position) AS titles
     FROM links
     INNER JOIN editions ON editions.id = links.target_edition_id
     WHERE links.type = 'organisations'
+    AND editions.locale = "en"
     GROUP BY links.source_edition_id
   ),
   organisations_ancestry AS (

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -41,10 +41,11 @@ WITH
   organisations AS (
     SELECT
       links.source_edition_id AS edition_id,
-      ARRAY_AGG(DISTINCT editions.title) AS titles
+      ARRAY_AGG(editions.title ORDER BY editions.position) AS titles
     FROM links
     INNER JOIN editions ON editions.id = links.target_edition_id
     WHERE links.type = 'organisations'
+    AND editions.locale = "en"
     GROUP BY links.source_edition_id
   ),
   organisations_ancestry AS (

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -41,10 +41,11 @@ WITH
   organisations AS (
     SELECT
       links.source_edition_id AS edition_id,
-      ARRAY_AGG(DISTINCT editions.title) AS titles
+      ARRAY_AGG(editions.title ORDER BY editions.position) AS titles
     FROM links
     INNER JOIN editions ON editions.id = links.target_edition_id
     WHERE links.type = 'organisations'
+    AND editions.locale = "en"
     GROUP BY links.source_edition_id
   ),
   organisations_ancestry AS (


### PR DESCRIPTION
This will align the order of organisations within the search page table with what was put in Whitehall when documents were published. We haven't yet confirmed how Mainstream deals with ordering, so while this will retain ordering for things published in Mainstream there's a chance that organisations aren't orderable by publishers at publish time.

Co-authored-by: Duncan <duncan.garmonsway@digital.cabinet-office.gov.uk>