### PR TITLE
Make http-to-bucket cloud function clean hashes before sending to big query

### DIFF
--- a/docker/http-to-bucket/spec/app_spec.rb
+++ b/docker/http-to-bucket/spec/app_spec.rb
@@ -316,4 +316,90 @@ RSpec.describe "Google Cloud Function: http_to_bucket" do
     end # context "and an unexpected error occurs"
 
   end # context "when all required parameters are provided"
+
+  describe "#remove_empty_hashes" do
+    context "when it's given a single layer hash" do
+      it "correctly removes empty hash elements" do
+        object = {foo: {}, bar: "baz"}
+        expectation = {bar: "baz"}
+
+        expect(remove_empty_hashes(object)).to eq(expectation)
+      end
+    end
+
+    context "when it's given an array of hashes" do
+      it "correctly removes empty hash elements" do
+        object = [{foo: {}, bar: "baz"}, {foo: "bar", baz: {}}]
+        expectation = [{bar: "baz"}, {foo: "bar"}]
+
+        expect(remove_empty_hashes(object)).to eq(expectation)
+      end
+    end
+
+    context "when it's given a multi layered hash" do
+      it "correctly removes empty hash elements" do
+        object = {
+          a: {foo: {}, bar: "baz"},
+          b: {foo: "bar", baz: {}},
+          c: {foo: {bar: "baz", foo: {}}}
+        }
+        expectation = {
+          a: {bar: "baz"},
+          b: {foo: "bar"},
+          c: {foo: {bar: "baz"}}
+        }
+
+        expect(remove_empty_hashes(object)).to eq(expectation)
+      end
+    end
+
+    context "when it's given an array of many multi layered hash" do
+      it "correctly removes empty hash elements" do
+        object = [
+          {
+            a: {foo: {}, bar: "baz"},
+            b: {foo: "bar", baz: {}},
+            c: {foo: {bar: "baz", foo: {}}}
+          },
+          {
+            a: {foo: {}, bar: "baz"},
+            b: {foo: "bar", baz: {}},
+            c: {foo: {bar: "baz", foo: {}}}
+          },
+        ]
+        expectation = [
+          {
+          a: {bar: "baz"},
+          b: {foo: "bar"},
+          c: {foo: {bar: "baz"}}
+          },
+          {
+          a: {bar: "baz"},
+          b: {foo: "bar"},
+          c: {foo: {bar: "baz"}}
+          },
+        ]
+
+        expect(remove_empty_hashes(object)).to eq(expectation)
+      end
+    end
+
+    context "when it's given empty, non hash objects" do
+      it "doesn't remove them" do
+        object = {foo: "", bar: []}
+        expectation = {foo: "", bar: []}
+
+        expect(remove_empty_hashes(object)).to eq(expectation)
+      end
+    end
+
+    context "when it's given many layers of nothing" do
+      it "removes them all the way up the tree" do
+        object = {foo: {bar: {}}}
+        expectation = {}
+
+        expect(remove_empty_hashes(object)).to eq(expectation)
+      end
+    end
+  end
 end # RSpec.describe


### PR DESCRIPTION
Uses recursion to remove empty hashes from all layers of a given array or hash. This is because BigQuery can't handle the empty hashes.

This is further outlined in this issue - https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/837