### PR TITLE
chore: bump postgres version

### DIFF
--- a/docker/publishing-api/Dockerfile
+++ b/docker/publishing-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.0-alpine3.18
+FROM postgres:17.6-alpine3.22
 
 # Install the gcloud CLI, a specific version from a long-term archive
 # Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile

--- a/docker/support-api/Dockerfile
+++ b/docker/support-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.0-alpine3.18
+FROM postgres:17.6-alpine3.22
 
 # Install the gcloud CLI, a specific version from a long-term archive
 # Adapted from https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile


### PR DESCRIPTION
The version of `pg_dump` that AWS RDS now uses exceeds the version of `pg_restore` that we use.

Symptoms:
* Docker logs report `pg_restore:pg_restore:  error: error: unsupported version (1.16) in file header`
* Zero rows are loaded into BigQuery, so that the tables in BigQuery now have no rows.

Logging/monitoring/alerting:
* Docker logs still aren't getting into the usual GCP logs https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/777
* Alert emails haven't been received for ages https://github.com/alphagov/govuk-knowledge-graph-gcp/issues/741
