### PR TITLE
IA-1624: Ingest smart survey v2 api

### DIFF
--- a/terraform-dev/bigquery/smart-survey-responses.sql
+++ b/terraform-dev/bigquery/smart-survey-responses.sql
@@ -5,7 +5,13 @@ BEGIN
 
 -- Delete any responses that have newer versions in the source table.
 MERGE smart_survey.responses AS T
-USING `smart_survey.SOURCE_TABLE_NAME` AS S
+USING (
+  SELECT
+    record.*
+  FROM
+    `smart_survey.SOURCE_TABLE_NAME`,
+    UNNEST(records) AS record
+) AS S
 ON T.id = S.id
 
 -- The table requires filtering by the partition, but we don't want to filter in
@@ -18,6 +24,12 @@ WHEN MATCHED THEN DELETE;
 
 -- Insert new responses.
 INSERT INTO smart_survey.responses
-SELECT * FROM `smart_survey.SOURCE_TABLE_NAME`;
+SELECT * FROM (
+  SELECT
+    record.*
+  FROM
+    `smart_survey.SOURCE_TABLE_NAME`,
+    UNNEST(records) AS record
+);
 
 END

--- a/terraform-dev/schemas/smart-survey/raw-responses.json
+++ b/terraform-dev/schemas/smart-survey/raw-responses.json
@@ -1,0 +1,354 @@
+[
+  {
+    "mode": "REPEATED",
+    "name": "records",
+    "type": "RECORD",
+    "fields": [
+      {
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "survey_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "tracking_link_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "translation_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "unique_id",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_started",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_ended",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_modified",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "status",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "contact_name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "contact_email",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "contact_invitation_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ip_address",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "user_agent",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "country",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "entry_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "referer_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "edit_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "saved",
+        "type": "BOOLEAN"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_email",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_continue_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "current_page_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "page_path",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "manual_entry",
+        "type": "BOOLEAN"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "total_score",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "href",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "label",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "variables",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "contact_data",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "title",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "position",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "total_score",
+            "type": "INTEGER"
+          },
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "title",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "type",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "sub_type",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "number",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "position",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "total_score",
+                "type": "INTEGER"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "REQUIRED",
+                    "name": "id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "type",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "row_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "row_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "value",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "answers",
+                "type": "RECORD"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "questions",
+            "type": "RECORD"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "pages",
+        "type": "RECORD"
+      }
+    ]
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "page_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "pages",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "page_size",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "total",
+    "type": "INTEGER"
+  }
+]

--- a/terraform-dev/schemas/smart-survey/responses.json
+++ b/terraform-dev/schemas/smart-survey/responses.json
@@ -1,265 +1,327 @@
 [
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "label",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
+    {
+        "mode": "REQUIRED",
         "name": "id",
         "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "variables",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "translation_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "tracking_link_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "total_score",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "status",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "edit_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_continue_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "referer_url",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "survey_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "tracking_link_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "translation_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "unique_id",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_started",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_ended",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_modified",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "status",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "contact_name",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "contact_email",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "contact_invitation_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ip_address",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "user_agent",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "country",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "entry_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "referer_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "edit_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "saved",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_name",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_email",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_continue_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "current_page_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "page_path",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "manual_entry",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "total_score",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "href",
+        "type": "STRING"
+    },
+    {
         "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "type",
-            "type": "STRING"
-          },
-          {
-            "fields": [
-              {
-                "mode": "NULLABLE",
-                "name": "row_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "row_title",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "column_title",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "column_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "choice_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "type",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
+            {
+                "mode": "REQUIRED",
                 "name": "id",
                 "type": "INTEGER"
-              },
-              {
+            },
+            {
                 "mode": "NULLABLE",
-                "name": "choice_title",
+                "name": "name",
                 "type": "STRING"
-              },
-              {
+            },
+            {
                 "mode": "NULLABLE",
                 "name": "value",
                 "type": "STRING"
-              }
-            ],
-            "mode": "REPEATED",
-            "name": "answers",
-            "type": "RECORD"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "sub_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "position",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "title",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "number",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "INTEGER"
-          }
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "label",
+                "type": "STRING"
+            }
         ],
         "mode": "REPEATED",
-        "name": "questions",
+        "name": "variables",
         "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "title",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "position",
-        "type": "INTEGER"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "id",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "pages",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ip_address",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "href",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "manual_entry",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "entry_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_started",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_modified",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_email",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_invitation_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_ended",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_email",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "current_page_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "user_agent",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "country",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "survey_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "id",
-    "type": "INTEGER"
-  }
+    },
+    {
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "name",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "contact_data",
+        "type": "RECORD"
+    },
+    {
+        "fields": [
+            {
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "title",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "position",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "total_score",
+                "type": "INTEGER"
+            },
+            {
+                "fields": [
+                    {
+                        "mode": "REQUIRED",
+                        "name": "id",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "title",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "type",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "sub_type",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "number",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "position",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "total_score",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "fields": [
+                            {
+                                "mode": "REQUIRED",
+                                "name": "id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "type",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "row_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "row_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ],
+                        "mode": "REPEATED",
+                        "name": "answers",
+                        "type": "RECORD"
+                    }
+                ],
+                "mode": "REPEATED",
+                "name": "questions",
+                "type": "RECORD"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "pages",
+        "type": "RECORD"
+    }
 ]

--- a/terraform-dev/workflow.tf
+++ b/terraform-dev/workflow.tf
@@ -82,7 +82,7 @@ resource "google_service_account" "workflow_smart_survey" {
   display_name = "Service account for the smart-survey workflow"
 }
 
-# A workflow to start a virtual machine to access the Memorystore Redis instance
+# Workflow for the smart-survey data
 resource "google_workflows_workflow" "smart_survey" {
   name                    = "smart-survey"
   region                  = var.region
@@ -96,8 +96,8 @@ resource "google_workflows_workflow" "smart_survey" {
       http_to_bucket_uri = google_cloud_run_v2_service.http_to_bucket.uri,
       bucket_name        = google_storage_bucket.smart_survey.name,
       schema = indent(32,
-      yamlencode(jsondecode(file("schemas/smart-survey/responses.json")))),
-      query = jsonencode(file("bigquery/smart-answers-results.sql"))
+      yamlencode(jsondecode(file("schemas/smart-survey/raw-responses.json")))),
+      query = jsonencode(file("bigquery/smart-survey-responses.sql"))
     }
   )
 }

--- a/terraform-dev/workflows/smart-survey.yaml
+++ b/terraform-dev/workflows/smart-survey.yaml
@@ -7,7 +7,7 @@ main:
           # the arguments provided in the call to this workflow (UNIX epoch integers)
           - yesterday: $${text.substring(time.format(sys.now() - 60 * 60 * 24), 0, 10)}
           - since: $${int(default(map.get(args, "since"), time.parse(yesterday + "T00:00:00.000000Z")))}
-          - until: $${int(default(map.get(args, "since"), time.parse(yesterday + "T23:59:59.999999Z")))}
+          - until: $${int(default(map.get(args, "until"), time.parse(yesterday + "T23:59:59.999999Z")))}
 
           # Default page size
           # The API itself defaults to 10, with a maximum of 100. The number of
@@ -52,14 +52,15 @@ main:
 
     - build_endpoint_url:
         assign:
-          - endpoint_url: $${"https://api.smartsurvey.io/v1/surveys/" + str_survey_id + "/responses"}
+          - endpoint_url: $${"https://api.smartsurvey.io/v2/surveys/" + str_survey_id + "/responses"}
 
     - build_headers:
         assign:
           - auth_str: $${str_token + ":" + str_secret}
           - auth_str_base64: $${"Basic " + base64.encode(text.encode(auth_str, "UTF-8"))}
 
-    # Call the API solely for the header that says how many results there will be.
+
+    # Retrieve the value of the total field. This says how many results there will be in this time-window for pagination.
     - first_api_call:
         try:
           call: http.get
@@ -71,7 +72,7 @@ main:
               filter_id: $${filter_id}
               completed: $${completed}
               page: 1
-              page_size: 0
+              page_size: 1
               sort_by: $${sort_by}
               include_labels: $${include_labels}
             headers:
@@ -88,10 +89,10 @@ main:
     # Calculate how many pages of page_size would fetch all the results.
     - calculate_page_range:
         assign:
-        - pagination_total: $${int(first_api_response.headers["X-Ss-Pagination-Total"])}
+        - pagination_total: $${int(first_api_response.body.total)}
         - max_page: $${pagination_total // page_size + math.min(1, pagination_total % page_size)}
 
-    # Iteratively fetch each page of results and send to BigQuery
+    # Iteratively fetch each page of results
     - iterative_api_calls:
         for:
             value: page_number

--- a/terraform-staging/bigquery/smart-survey-responses.sql
+++ b/terraform-staging/bigquery/smart-survey-responses.sql
@@ -5,7 +5,13 @@ BEGIN
 
 -- Delete any responses that have newer versions in the source table.
 MERGE smart_survey.responses AS T
-USING `smart_survey.SOURCE_TABLE_NAME` AS S
+USING (
+  SELECT
+    record.*
+  FROM
+    `smart_survey.SOURCE_TABLE_NAME`,
+    UNNEST(records) AS record
+) AS S
 ON T.id = S.id
 
 -- The table requires filtering by the partition, but we don't want to filter in
@@ -18,6 +24,12 @@ WHEN MATCHED THEN DELETE;
 
 -- Insert new responses.
 INSERT INTO smart_survey.responses
-SELECT * FROM `smart_survey.SOURCE_TABLE_NAME`;
+SELECT * FROM (
+  SELECT
+    record.*
+  FROM
+    `smart_survey.SOURCE_TABLE_NAME`,
+    UNNEST(records) AS record
+);
 
 END

--- a/terraform-staging/schemas/smart-survey/raw-responses.json
+++ b/terraform-staging/schemas/smart-survey/raw-responses.json
@@ -1,0 +1,354 @@
+[
+  {
+    "mode": "REPEATED",
+    "name": "records",
+    "type": "RECORD",
+    "fields": [
+      {
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "survey_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "tracking_link_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "translation_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "unique_id",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_started",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_ended",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_modified",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "status",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "contact_name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "contact_email",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "contact_invitation_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ip_address",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "user_agent",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "country",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "entry_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "referer_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "edit_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "saved",
+        "type": "BOOLEAN"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_email",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_continue_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "current_page_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "page_path",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "manual_entry",
+        "type": "BOOLEAN"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "total_score",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "href",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "label",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "variables",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "contact_data",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "title",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "position",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "total_score",
+            "type": "INTEGER"
+          },
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "title",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "type",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "sub_type",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "number",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "position",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "total_score",
+                "type": "INTEGER"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "REQUIRED",
+                    "name": "id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "type",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "row_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "row_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "value",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "answers",
+                "type": "RECORD"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "questions",
+            "type": "RECORD"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "pages",
+        "type": "RECORD"
+      }
+    ]
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "page_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "pages",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "page_size",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "total",
+    "type": "INTEGER"
+  }
+]

--- a/terraform-staging/schemas/smart-survey/responses.json
+++ b/terraform-staging/schemas/smart-survey/responses.json
@@ -1,265 +1,327 @@
 [
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "label",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
+    {
+        "mode": "REQUIRED",
         "name": "id",
         "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "variables",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "translation_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "tracking_link_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "total_score",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "status",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "edit_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_continue_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "referer_url",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "survey_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "tracking_link_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "translation_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "unique_id",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_started",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_ended",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_modified",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "status",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "contact_name",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "contact_email",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "contact_invitation_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ip_address",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "user_agent",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "country",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "entry_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "referer_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "edit_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "saved",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_name",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_email",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_continue_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "current_page_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "page_path",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "manual_entry",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "total_score",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "href",
+        "type": "STRING"
+    },
+    {
         "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "type",
-            "type": "STRING"
-          },
-          {
-            "fields": [
-              {
-                "mode": "NULLABLE",
-                "name": "row_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "row_title",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "column_title",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "column_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "choice_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "type",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
+            {
+                "mode": "REQUIRED",
                 "name": "id",
                 "type": "INTEGER"
-              },
-              {
+            },
+            {
                 "mode": "NULLABLE",
-                "name": "choice_title",
+                "name": "name",
                 "type": "STRING"
-              },
-              {
+            },
+            {
                 "mode": "NULLABLE",
                 "name": "value",
                 "type": "STRING"
-              }
-            ],
-            "mode": "REPEATED",
-            "name": "answers",
-            "type": "RECORD"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "sub_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "position",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "title",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "number",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "INTEGER"
-          }
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "label",
+                "type": "STRING"
+            }
         ],
         "mode": "REPEATED",
-        "name": "questions",
+        "name": "variables",
         "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "title",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "position",
-        "type": "INTEGER"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "id",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "pages",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ip_address",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "href",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "manual_entry",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "entry_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_started",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_modified",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_email",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_invitation_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_ended",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_email",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "current_page_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "user_agent",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "country",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "survey_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "id",
-    "type": "INTEGER"
-  }
+    },
+    {
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "name",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "contact_data",
+        "type": "RECORD"
+    },
+    {
+        "fields": [
+            {
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "title",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "position",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "total_score",
+                "type": "INTEGER"
+            },
+            {
+                "fields": [
+                    {
+                        "mode": "REQUIRED",
+                        "name": "id",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "title",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "type",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "sub_type",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "number",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "position",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "total_score",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "fields": [
+                            {
+                                "mode": "REQUIRED",
+                                "name": "id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "type",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "row_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "row_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ],
+                        "mode": "REPEATED",
+                        "name": "answers",
+                        "type": "RECORD"
+                    }
+                ],
+                "mode": "REPEATED",
+                "name": "questions",
+                "type": "RECORD"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "pages",
+        "type": "RECORD"
+    }
 ]

--- a/terraform-staging/workflow.tf
+++ b/terraform-staging/workflow.tf
@@ -82,7 +82,7 @@ resource "google_service_account" "workflow_smart_survey" {
   display_name = "Service account for the smart-survey workflow"
 }
 
-# A workflow to start a virtual machine to access the Memorystore Redis instance
+# Workflow for the smart-survey data
 resource "google_workflows_workflow" "smart_survey" {
   name                    = "smart-survey"
   region                  = var.region
@@ -96,8 +96,8 @@ resource "google_workflows_workflow" "smart_survey" {
       http_to_bucket_uri = google_cloud_run_v2_service.http_to_bucket.uri,
       bucket_name        = google_storage_bucket.smart_survey.name,
       schema = indent(32,
-      yamlencode(jsondecode(file("schemas/smart-survey/responses.json")))),
-      query = jsonencode(file("bigquery/smart-answers-results.sql"))
+      yamlencode(jsondecode(file("schemas/smart-survey/raw-responses.json")))),
+      query = jsonencode(file("bigquery/smart-survey-responses.sql"))
     }
   )
 }

--- a/terraform-staging/workflows/smart-survey.yaml
+++ b/terraform-staging/workflows/smart-survey.yaml
@@ -7,7 +7,7 @@ main:
           # the arguments provided in the call to this workflow (UNIX epoch integers)
           - yesterday: $${text.substring(time.format(sys.now() - 60 * 60 * 24), 0, 10)}
           - since: $${int(default(map.get(args, "since"), time.parse(yesterday + "T00:00:00.000000Z")))}
-          - until: $${int(default(map.get(args, "since"), time.parse(yesterday + "T23:59:59.999999Z")))}
+          - until: $${int(default(map.get(args, "until"), time.parse(yesterday + "T23:59:59.999999Z")))}
 
           # Default page size
           # The API itself defaults to 10, with a maximum of 100. The number of
@@ -52,14 +52,15 @@ main:
 
     - build_endpoint_url:
         assign:
-          - endpoint_url: $${"https://api.smartsurvey.io/v1/surveys/" + str_survey_id + "/responses"}
+          - endpoint_url: $${"https://api.smartsurvey.io/v2/surveys/" + str_survey_id + "/responses"}
 
     - build_headers:
         assign:
           - auth_str: $${str_token + ":" + str_secret}
           - auth_str_base64: $${"Basic " + base64.encode(text.encode(auth_str, "UTF-8"))}
 
-    # Call the API solely for the header that says how many results there will be.
+
+    # Retrieve the value of the total field. This says how many results there will be in this time-window for pagination.
     - first_api_call:
         try:
           call: http.get
@@ -71,7 +72,7 @@ main:
               filter_id: $${filter_id}
               completed: $${completed}
               page: 1
-              page_size: 0
+              page_size: 1
               sort_by: $${sort_by}
               include_labels: $${include_labels}
             headers:
@@ -88,10 +89,10 @@ main:
     # Calculate how many pages of page_size would fetch all the results.
     - calculate_page_range:
         assign:
-        - pagination_total: $${int(first_api_response.headers["X-Ss-Pagination-Total"])}
+        - pagination_total: $${int(first_api_response.body.total)}
         - max_page: $${pagination_total // page_size + math.min(1, pagination_total % page_size)}
 
-    # Iteratively fetch each page of results and send to BigQuery
+    # Iteratively fetch each page of results
     - iterative_api_calls:
         for:
             value: page_number

--- a/terraform/bigquery/smart-survey-responses.sql
+++ b/terraform/bigquery/smart-survey-responses.sql
@@ -5,7 +5,13 @@ BEGIN
 
 -- Delete any responses that have newer versions in the source table.
 MERGE smart_survey.responses AS T
-USING `smart_survey.SOURCE_TABLE_NAME` AS S
+USING (
+  SELECT
+    record.*
+  FROM
+    `smart_survey.SOURCE_TABLE_NAME`,
+    UNNEST(records) AS record
+) AS S
 ON T.id = S.id
 
 -- The table requires filtering by the partition, but we don't want to filter in
@@ -18,6 +24,12 @@ WHEN MATCHED THEN DELETE;
 
 -- Insert new responses.
 INSERT INTO smart_survey.responses
-SELECT * FROM `smart_survey.SOURCE_TABLE_NAME`;
+SELECT * FROM (
+  SELECT
+    record.*
+  FROM
+    `smart_survey.SOURCE_TABLE_NAME`,
+    UNNEST(records) AS record
+);
 
 END

--- a/terraform/schemas/smart-survey/raw-responses.json
+++ b/terraform/schemas/smart-survey/raw-responses.json
@@ -1,0 +1,354 @@
+[
+  {
+    "mode": "REPEATED",
+    "name": "records",
+    "type": "RECORD",
+    "fields": [
+      {
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "survey_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "tracking_link_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "translation_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "unique_id",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_started",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_ended",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "date_modified",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "status",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "contact_name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "contact_email",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "contact_invitation_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ip_address",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "user_agent",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "country",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "entry_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "referer_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "edit_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "saved",
+        "type": "BOOLEAN"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_email",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "saved_continue_url",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "current_page_id",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "page_path",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "manual_entry",
+        "type": "BOOLEAN"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "total_score",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "href",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "label",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "variables",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "value",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "contact_data",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REQUIRED",
+            "name": "id",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "title",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "position",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "total_score",
+            "type": "INTEGER"
+          },
+          {
+            "fields": [
+              {
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "title",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "type",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "sub_type",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "number",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "position",
+                "type": "INTEGER"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "total_score",
+                "type": "INTEGER"
+              },
+              {
+                "fields": [
+                  {
+                    "mode": "REQUIRED",
+                    "name": "id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "type",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "choice_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "row_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "row_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "column_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_title",
+                    "type": "STRING"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_id",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "dropdown_score_value",
+                    "type": "INTEGER"
+                  },
+                  {
+                    "mode": "NULLABLE",
+                    "name": "value",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "REPEATED",
+                "name": "answers",
+                "type": "RECORD"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "questions",
+            "type": "RECORD"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "pages",
+        "type": "RECORD"
+      }
+    ]
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "page_index",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "pages",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "page_size",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "total",
+    "type": "INTEGER"
+  }
+]

--- a/terraform/schemas/smart-survey/responses.json
+++ b/terraform/schemas/smart-survey/responses.json
@@ -1,265 +1,327 @@
 [
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "label",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
+    {
+        "mode": "REQUIRED",
         "name": "id",
         "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "variables",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "translation_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "tracking_link_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "total_score",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "status",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "edit_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_continue_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "referer_url",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "survey_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "tracking_link_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "translation_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "unique_id",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_started",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_ended",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "date_modified",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "status",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "contact_name",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "contact_email",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "contact_invitation_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "ip_address",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "user_agent",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "country",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "entry_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "referer_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "edit_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "saved",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_name",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_email",
+        "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "saved_continue_url",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "current_page_id",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "page_path",
+        "type": "STRING"
+    },
+    {
+        "mode": "REQUIRED",
+        "name": "manual_entry",
+        "type": "BOOLEAN"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "total_score",
+        "type": "INTEGER"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "href",
+        "type": "STRING"
+    },
+    {
         "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "type",
-            "type": "STRING"
-          },
-          {
-            "fields": [
-              {
-                "mode": "NULLABLE",
-                "name": "row_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "row_title",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "column_title",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "column_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "choice_id",
-                "type": "INTEGER"
-              },
-              {
-                "mode": "NULLABLE",
-                "name": "type",
-                "type": "STRING"
-              },
-              {
-                "mode": "NULLABLE",
+            {
+                "mode": "REQUIRED",
                 "name": "id",
                 "type": "INTEGER"
-              },
-              {
+            },
+            {
                 "mode": "NULLABLE",
-                "name": "choice_title",
+                "name": "name",
                 "type": "STRING"
-              },
-              {
+            },
+            {
                 "mode": "NULLABLE",
                 "name": "value",
                 "type": "STRING"
-              }
-            ],
-            "mode": "REPEATED",
-            "name": "answers",
-            "type": "RECORD"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "sub_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "position",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "title",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "number",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "INTEGER"
-          }
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "label",
+                "type": "STRING"
+            }
         ],
         "mode": "REPEATED",
-        "name": "questions",
+        "name": "variables",
         "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "title",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "position",
-        "type": "INTEGER"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "id",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "pages",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_name",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "ip_address",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "href",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "manual_entry",
-    "type": "BOOLEAN"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "entry_url",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_started",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_modified",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "saved_email",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_invitation_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "date_ended",
-    "type": "TIMESTAMP"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "contact_email",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "current_page_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "user_agent",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "country",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "survey_id",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "id",
-    "type": "INTEGER"
-  }
+    },
+    {
+        "fields": [
+            {
+                "mode": "NULLABLE",
+                "name": "name",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "value",
+                "type": "STRING"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "contact_data",
+        "type": "RECORD"
+    },
+    {
+        "fields": [
+            {
+                "mode": "REQUIRED",
+                "name": "id",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "title",
+                "type": "STRING"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "position",
+                "type": "INTEGER"
+            },
+            {
+                "mode": "NULLABLE",
+                "name": "total_score",
+                "type": "INTEGER"
+            },
+            {
+                "fields": [
+                    {
+                        "mode": "REQUIRED",
+                        "name": "id",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "title",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "type",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "sub_type",
+                        "type": "STRING"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "number",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "position",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "mode": "NULLABLE",
+                        "name": "total_score",
+                        "type": "INTEGER"
+                    },
+                    {
+                        "fields": [
+                            {
+                                "mode": "REQUIRED",
+                                "name": "id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "type",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "choice_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "row_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "row_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "column_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_title",
+                                "type": "STRING"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_id",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "dropdown_score_value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "mode": "NULLABLE",
+                                "name": "value",
+                                "type": "STRING"
+                            }
+                        ],
+                        "mode": "REPEATED",
+                        "name": "answers",
+                        "type": "RECORD"
+                    }
+                ],
+                "mode": "REPEATED",
+                "name": "questions",
+                "type": "RECORD"
+            }
+        ],
+        "mode": "REPEATED",
+        "name": "pages",
+        "type": "RECORD"
+    }
 ]

--- a/terraform/workflow.tf
+++ b/terraform/workflow.tf
@@ -82,7 +82,7 @@ resource "google_service_account" "workflow_smart_survey" {
   display_name = "Service account for the smart-survey workflow"
 }
 
-# A workflow to start a virtual machine to access the Memorystore Redis instance
+# Workflow for the smart-survey data
 resource "google_workflows_workflow" "smart_survey" {
   name                    = "smart-survey"
   region                  = var.region
@@ -96,8 +96,8 @@ resource "google_workflows_workflow" "smart_survey" {
       http_to_bucket_uri = google_cloud_run_v2_service.http_to_bucket.uri,
       bucket_name        = google_storage_bucket.smart_survey.name,
       schema = indent(32,
-      yamlencode(jsondecode(file("schemas/smart-survey/responses.json")))),
-      query = jsonencode(file("bigquery/smart-answers-results.sql"))
+      yamlencode(jsondecode(file("schemas/smart-survey/raw-responses.json")))),
+      query = jsonencode(file("bigquery/smart-survey-responses.sql"))
     }
   )
 }

--- a/terraform/workflows/smart-survey.yaml
+++ b/terraform/workflows/smart-survey.yaml
@@ -7,7 +7,7 @@ main:
           # the arguments provided in the call to this workflow (UNIX epoch integers)
           - yesterday: $${text.substring(time.format(sys.now() - 60 * 60 * 24), 0, 10)}
           - since: $${int(default(map.get(args, "since"), time.parse(yesterday + "T00:00:00.000000Z")))}
-          - until: $${int(default(map.get(args, "since"), time.parse(yesterday + "T23:59:59.999999Z")))}
+          - until: $${int(default(map.get(args, "until"), time.parse(yesterday + "T23:59:59.999999Z")))}
 
           # Default page size
           # The API itself defaults to 10, with a maximum of 100. The number of
@@ -52,14 +52,15 @@ main:
 
     - build_endpoint_url:
         assign:
-          - endpoint_url: $${"https://api.smartsurvey.io/v1/surveys/" + str_survey_id + "/responses"}
+          - endpoint_url: $${"https://api.smartsurvey.io/v2/surveys/" + str_survey_id + "/responses"}
 
     - build_headers:
         assign:
           - auth_str: $${str_token + ":" + str_secret}
           - auth_str_base64: $${"Basic " + base64.encode(text.encode(auth_str, "UTF-8"))}
 
-    # Call the API solely for the header that says how many results there will be.
+
+    # Retrieve the value of the total field. This says how many results there will be in this time-window for pagination.
     - first_api_call:
         try:
           call: http.get
@@ -71,7 +72,7 @@ main:
               filter_id: $${filter_id}
               completed: $${completed}
               page: 1
-              page_size: 0
+              page_size: 1
               sort_by: $${sort_by}
               include_labels: $${include_labels}
             headers:
@@ -88,10 +89,10 @@ main:
     # Calculate how many pages of page_size would fetch all the results.
     - calculate_page_range:
         assign:
-        - pagination_total: $${int(first_api_response.headers["X-Ss-Pagination-Total"])}
+        - pagination_total: $${int(first_api_response.body.total)}
         - max_page: $${pagination_total // page_size + math.min(1, pagination_total % page_size)}
 
-    # Iteratively fetch each page of results and send to BigQuery
+    # Iteratively fetch each page of results
     - iterative_api_calls:
         for:
             value: page_number


### PR DESCRIPTION
This is now running in dev. I have copied the old v1 table to `v1_responses_deprecated`. I'm using these queries to make comparisons which all look good for September...

```sql
--- do responses match by date?
SELECT COALESCE(DATE(v1.date_started), DATE(v2.date_started)),
  COUNT(v1.id) AS num_v1_id,
  COUNT(v2.id) AS num_v2_id
FROM (SELECT * FROM `smart_survey.v1_responses_deprecated` WHERE date_started >= "2020-01-01") v1
FULL OUTER JOIN (SELECT * FROM `smart_survey.responses` WHERE date_started >= "2020-01-01") v2
USING (date_started)
GROUP BY 1
ORDER BY 1 DESC
;

-- does distribution of questions hold?
WITH v1_questions AS (
  SELECT DATE(response.date_started) AS date_started, response.id AS response_id, question.*
  FROM `smart_survey.v1_responses_deprecated` response, UNNEST(pages) as page, UNNEST(questions) as question
  WHERE date_started BETWEEN "2025-09-01" AND "2025-09-07"
)
, v2_questions AS (
  SELECT DATE(response.date_started) AS date_started, response.id AS response_id, question.*
  FROM `smart_survey.responses` response, UNNEST(pages) as page, UNNEST(questions) as question
  WHERE date_started BETWEEN "2025-09-01" AND "2025-09-07"
)
, joined AS (
  SELECT
  v1_questions.id AS v1_questions_id,
  v2_questions.id AS v2_questions_id,
  v1_questions.date_started AS v1_questions_date_started,
  v2_questions.date_started AS v2_questions_date_started,
  v1_questions.response_id AS v1_questions_response_id,
  v2_questions.response_id AS v2_questions_response_id,
  v1_questions.title AS v1_questions_title,
  v2_questions.title AS v2_questions_title,
FROM v1_questions
FULL OUTER JOIN v2_questions
USING (response_id, id)
)
SELECT
  COALESCE(v1_questions_date_started, v2_questions_date_started),
  COALESCE(v1_questions_title, v2_questions_title),
  COUNT(v1_questions_id) AS num_v1_id,
  COUNT(v2_questions_id) AS num_v2_id
FROM joined
GROUP BY 1, 2
ORDER BY 1 DESC, 2
;
```