### PR TITLE
Fix URL field after publisher postgres move

### DIFF
--- a/terraform-dev/bigquery/search-page.sql
+++ b/terraform-dev/bigquery/search-page.sql
@@ -66,7 +66,7 @@ WITH
   -- editors don't tend to use 'public_updated_at', and 'updated_at' is polluted
   -- by creation of new editions for techy reasons rather than editing reasons.
   SELECT
-    url,
+    CONCAT("https://www.gov.uk", slug) AS url,
     MAX(updated_at) AS publisher_updated_at,
   FROM publisher.editions
   WHERE state='published'

--- a/terraform-staging/bigquery/search-page.sql
+++ b/terraform-staging/bigquery/search-page.sql
@@ -66,7 +66,7 @@ WITH
   -- editors don't tend to use 'public_updated_at', and 'updated_at' is polluted
   -- by creation of new editions for techy reasons rather than editing reasons.
   SELECT
-    url,
+    CONCAT("https://www.gov.uk", slug) AS url,
     MAX(updated_at) AS publisher_updated_at,
   FROM publisher.editions
   WHERE state='published'

--- a/terraform/bigquery/search-page.sql
+++ b/terraform/bigquery/search-page.sql
@@ -66,7 +66,7 @@ WITH
   -- editors don't tend to use 'public_updated_at', and 'updated_at' is polluted
   -- by creation of new editions for techy reasons rather than editing reasons.
   SELECT
-    url,
+    CONCAT("https://www.gov.uk", slug) AS url,
     MAX(updated_at) AS publisher_updated_at,
   FROM publisher.editions
   WHERE state='published'


### PR DESCRIPTION
We recently made some changes to allow the knowledge graph to support Mainstream Publisher changes following the apps move to postgres from Mongo. There was an oversight in the move that has caused data to not be recorded. This should fix that by creating a field that was present in Mongo that isn't in postgres