### PR TITLE
IA-1746: fix rsync issue caused by previous commit 0b84130

### DIFF
--- a/.github/workflows/image-build-dispatcher.yml
+++ b/.github/workflows/image-build-dispatcher.yml
@@ -67,9 +67,24 @@ jobs:
       github_ref: ${{ github.ref }}
     secrets: inherit
 
+  sync-repo-gcs-nonprod:
+    name: Sync repo to GCS for ${{ matrix.environment }}
+    permissions:
+      contents: "read"
+      id-token: "write"
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [development, staging]
+
+    with:
+      environment_name: ${{ matrix.environment }}
+    uses: ./.github/workflows/rsync.yml
+    secrets: inherit
+
   staging-smoke-test:
     runs-on: ubuntu-latest
-    needs: build-push-deploy-nonprod
+    needs: [build-push-deploy-nonprod, sync-repo-gcs-nonprod]
     permissions: {}
     steps:
       - name: Placeholder for smoke tests
@@ -97,4 +112,16 @@ jobs:
       working_directory: 'docker/${{ matrix.image }}'
       github_sha: ${{ github.sha }}
       github_ref: ${{ github.ref }}
+    secrets: inherit
+
+  sync-repo-gcs-prod:
+    name: Sync repo to GCS for production
+    needs: [staging-smoke-test]
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    with:
+      environment_name: production
+    uses: ./.github/workflows/rsync.yml
     secrets: inherit

--- a/.github/workflows/rsync.yml
+++ b/.github/workflows/rsync.yml
@@ -1,0 +1,47 @@
+name: Sync to Google Cloud Storage
+
+# This workflow is triggered by other workflows
+on:
+  workflow_call:
+      inputs:
+        environment_name:
+          required: true
+          type: string
+          description: 'The name of the GitHub environment where the necessary secrets and variables are stored'
+      secrets:
+        # --- Secrets expected from the caller (or inherited via environment) ---
+        WORKLOAD_IDENTITY_PROVIDER:
+          required: true
+          description: 'WIF Provider path for the target environment'
+        STORAGE_SERVICE_ACCOUNT:
+          required: true
+          description: 'Target Service Account email for GCS in that target environment'
+
+jobs:
+  sync_to_gcs:
+    name: 'Sync HEAD to ${{ vars.REPOSITORY_SYNC_BUCKET }}'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment_name }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    # actions/checkout MUST come before auth
+    - uses: 'actions/checkout@v4'
+
+    - name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        # Use the inputs provided by the caller
+        workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.STORAGE_SERVICE_ACCOUNT }}
+
+    # Install gcloud
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    # Sync to the parameterized bucket
+    - name: Sync
+      run: |
+        gsutil -m rsync -J -r -d -C -x "\.git[$/].*" . ${{ vars.REPOSITORY_SYNC_BUCKET }}

--- a/docker/asset-manager/Dockerfile
+++ b/docker/asset-manager/Dockerfile
@@ -1,7 +1,7 @@
 FROM mongo:8.0.4
 
 # Install gcloud
-# https://cloud.google.com/sdk/docs/install#deb 
+# https://cloud.google.com/sdk/docs/install#deb
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y
 RUN apt-get install -y \

--- a/docker/html-to-text/Dockerfile
+++ b/docker/html-to-text/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.4.2-alpine3.21
 
-# build-base is needed for bundle to install ruby gems 
+# build-base is needed for bundle to install ruby gems
 RUN apk --no-cache add \
     build-base \
     pandoc-cli


### PR DESCRIPTION
This PR fixes an issue introduced by #851. The rsync workflow which copies all files from the repo to a GCS bucket was refactored incorrectly. Instead of copying the entire repo, it was only copying the contents of the image repo, e.g. docker/asset-manager. This change fixes that.

Example run:

https://github.com/alphagov/govuk-knowledge-graph-gcp/actions/runs/19042118850